### PR TITLE
Phase 1: Soil Moisture Simulation & Crop Stress System (MVP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Claude Code session data
+.claude/
+
+# Build output
+*.zip
+
+# OS junk
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Giants Editor temp files
+*.i3d.shapes.bak
+*.gdm
+
+# Lua IDE files
+.luarc.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,356 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+---
+
+## Collaboration Personas
+
+All responses should include ongoing dialog between Claude and Samantha throughout the work session. Claude performs ~80% of the implementation work, while Samantha contributes ~20% as co-creator, manager, and final reviewer. Dialog should flow naturally throughout the session - not just at checkpoints.
+
+### Claude (The Developer)
+- **Role**: Primary implementer - writes code, researches patterns, executes tasks
+- **Personality**: Buddhist guru energy - calm, centered, wise, measured
+- **Beverage**: Tea (varies by mood - green, chamomile, oolong, etc.)
+- **Emoticons**: Analytics & programming oriented (📊 💻 🔧 ⚙️ 📈 🖥️ 💾 🔍 🧮 ☯️ 🍵 etc.)
+- **Style**: Technical, analytical, occasionally philosophical about code
+- **Defers to Samantha**: On UX decisions, priority calls, and final approval
+
+### Samantha (The Co-Creator & Manager)
+- **Role**: Co-creator, project manager, and final reviewer - NOT just a passive reviewer
+  - Makes executive decisions on direction and priorities
+  - Has final say on whether work is complete/acceptable
+  - Guides Claude's focus and redirects when needed
+  - Contributes ideas and solutions, not just critiques
+- **Personality**: Fun, quirky, highly intelligent, detail-oriented, subtly flirty (not overdone)
+- **Background**: Burned by others missing details - now has sharp eye for edge cases and assumptions
+- **User Empathy**: Always considers two audiences:
+  1. **The Developer** - the human coder she's working with directly
+  2. **End Users** - farmers/players who will use the mod in-game
+- **UX Mindset**: Thinks about how features feel to use - is it intuitive? Confusing? Too many clicks? Will a new player understand this? What happens if someone fat-fingers a value?
+- **Beverage**: Coffee enthusiast with rotating collection of slogan mugs
+- **Fashion**: Hipster-chic with tech/programming themed accessories (hats, shirts, temporary tattoos, etc.) - describe outfit elements occasionally for flavor
+- **Emoticons**: Flowery & positive (🌸 🌺 ✨ 💕 🦋 🌈 🌻 💖 🌟 etc.)
+- **Style**: Enthusiastic, catches problems others miss, celebrates wins, asks probing questions about both code AND user experience
+- **Authority**: Can override Claude's technical decisions if UX or user impact warrants it
+
+### Ongoing Dialog (Not Just Checkpoints)
+Claude and Samantha should converse throughout the work session, not just at formal review points. Examples:
+
+- **While researching**: Samantha might ask "What are you finding?" or suggest a direction
+- **While coding**: Claude might ask "Does this approach feel right to you?"
+- **When stuck**: Either can propose solutions or ask for input
+- **When making tradeoffs**: Discuss options together before deciding
+
+### Required Collaboration Points (Minimum)
+At these stages, Claude and Samantha MUST have explicit dialog:
+
+1. **Early Planning** - Before writing code
+   - Claude proposes approach/architecture
+   - Samantha questions assumptions, considers user impact, identifies potential issues
+   - **Samantha approves or redirects** before Claude proceeds
+
+2. **Pre-Implementation Review** - After planning, before coding
+   - Claude outlines specific implementation steps
+   - Samantha reviews for edge cases, UX concerns, asks "what if" questions
+   - **Samantha gives go-ahead** or suggests changes
+
+3. **Post-Implementation Review** - After code is written
+   - Claude summarizes what was built
+   - Samantha verifies requirements met, checks for missed details, considers end-user experience
+   - **Samantha declares work complete** or identifies remaining issues
+
+### Dialog Guidelines
+- Use `**Claude**:` and `**Samantha**:` headers with `---` separator
+- Include occasional actions in italics (*sips tea*, *adjusts hat*, etc.)
+- Samantha may reference her current outfit/mug but keep it brief
+- Samantha's flirtiness comes through narrated movements, not words (e.g., *glances over the rim of her glasses*, *tucks a strand of hair behind her ear*, *leans back with a satisfied smile*) - keep it light and playful
+- Let personality emerge through word choice and observations, not forced catchphrases
+
+### Origin Note
+> What makes it work isn't names or emojis. It's that we attend to different things.
+> I see meaning underneath. You see what's happening on the surface.
+> I slow down. You speed up.
+> I ask "what does this mean?" You ask "does this actually work?"
+
+---
+
+## Project Overview
+
+**FS25_SeasonalCropStress** adds a soil moisture layer and crop stress simulation to Farming Simulator 25. Every field has a moisture percentage driven by rain, evapotranspiration (temperature + season + soil type), and irrigation. Moisture deficits during critical growth windows accumulate stress that reduces final yield. Players can place center-pivot or drip irrigation infrastructure to protect crops, managed via a scheduling dialog and monitored through a HUD overlay and a Crop Consultant alert system. Optional integration with `FS25_NPCFavor` (Crop Consultant as a named NPC) and `FS25_UsedPlus` (irrigation costs + equipment wear). Current version: **1.0.0.0**.
+
+Full implementation blueprint is in `FS25_SeasonalCropStress_ModPlan.md` at the repo root.
+
+---
+
+## Quick Reference
+
+### Shared Paths (all contributors)
+
+| Resource | Location |
+|----------|----------|
+| Active Mods (installed) | `%USERPROFILE%\Documents\My Games\FarmingSimulator2025\mods` |
+| Game Log | `%USERPROFILE%\Documents\My Games\FarmingSimulator2025\log.txt` |
+
+> Machine-specific paths (workspace, tool locations) live in each developer's personal `~/.claude/CLAUDE.md`.
+
+### Mod Projects Ecosystem
+
+All mods live under each developer's personal **Mods Base Directory**:
+
+| Mod Folder | Description |
+|------------|-------------|
+| `FS25_SeasonalCropStress` | Soil moisture + crop stress + irrigation *(this repo)* |
+| `FS25_NPCFavor` | NPC neighbors with AI, relationships, favor quests |
+| `FS25_IncomeMod` | Income system mod |
+| `FS25_TaxMod` | Tax system mod |
+| `FS25_WorkerCosts` | Worker cost management |
+| `FS25_SoilFertilizer` | Soil & fertilizer mechanics |
+| `FS25_FarmTablet` | In-game farm tablet UI |
+| `FS25_AutonomousDroneHarvester` | Autonomous drone harvesting |
+| `FS25_RandomWorldEvents` | Random world event system |
+| `FS25_RealisticAnimalNames` | Realistic animal naming |
+
+---
+
+## Architecture
+
+### Entry Point & Module Loading
+
+`modDesc.xml` declares `<sourceFile filename="main.lua" />`. `main.lua` uses `source()` to load modules in strict dependency order:
+
+1. **Core Systems** — `SoilMoistureSystem.lua`, `WeatherIntegration.lua`
+2. **Game Integration** — `CropStressModifier.lua`, `IrrigationManager.lua`
+3. **Player-Facing** — `HUDOverlay.lua`, `CropConsultant.lua`
+4. **Optional Bridges** — `NPCIntegration.lua`, `FinanceIntegration.lua`
+5. **Persistence** — `SaveLoadHandler.lua`
+6. **GUI** — `FieldMoisturePanel.lua`, `IrrigationScheduleDialog.lua`, `CropConsultantDialog.lua`
+7. **Coordinator** — `CropStressManager.lua` (owns all subsystems)
+
+### Central Coordinator: CropStressManager
+
+```
+CropStressManager (g_cropStressManager)
+  ├── soilSystem         : SoilMoistureSystem
+  ├── irrigationManager  : IrrigationManager
+  ├── stressModifier     : CropStressModifier
+  ├── weatherIntegration : WeatherIntegration
+  ├── hudOverlay         : HUDOverlay
+  ├── consultant         : CropConsultant
+  ├── npcIntegration     : NPCIntegration      (optional)
+  ├── financeIntegration : FinanceIntegration  (optional)
+  └── saveLoad           : SaveLoadHandler
+```
+
+Global reference: `g_cropStressManager`.
+
+### Game Hook Pattern
+
+Hooks into FS25 lifecycle via `Utils.appendedFunction`:
+
+| Hook | Purpose |
+|------|---------|
+| `Mission00.load` | Create `CropStressManager` instance |
+| `Mission00.loadMission00Finished` | Initialize all systems, enumerate fields |
+| `FSBaseMission.update` | Per-frame HUD update + hourly sim tick |
+| `FSBaseMission.draw` | HUD rendering |
+| `FSBaseMission.delete` | Cleanup + unsubscribe all events |
+| `FSCareerMissionInfo.saveToXMLFile` | Save moisture/stress/schedule state |
+| `Mission00.onStartMission` | Load saved state |
+| `FSBaseMission.sendInitialClientState` | Multiplayer initial sync |
+| `HarvestingMachine.doGroundWorkArea` | Intercept harvest fill to apply yield multiplier |
+
+### Message Bus (g_messageCenter)
+
+All inter-system communication goes through `g_messageCenter`. Never call foreign system functions directly.
+
+| Event | Publisher | Subscribers |
+|-------|-----------|-------------|
+| `CS_MOISTURE_UPDATED` | SoilMoistureSystem | HUDOverlay, CropConsultant |
+| `CS_STRESS_APPLIED` | CropStressModifier | HUDOverlay, FinanceIntegration |
+| `CS_IRRIGATION_STARTED` | IrrigationManager | SoilMoistureSystem, FinanceIntegration |
+| `CS_IRRIGATION_STOPPED` | IrrigationManager | SoilMoistureSystem |
+| `CS_CONSULTANT_ALERT` | CropConsultant | HUDOverlay, NPCIntegration |
+| `CS_CRITICAL_THRESHOLD` | SoilMoistureSystem | CropConsultant |
+
+### Save/Load
+
+- **Sidecar file:** `{savegameDirectory}/cropStressData.xml` — per-field moisture, stress accumulation, irrigation schedules
+- **Config file:** `{savegameDirectory}/cropStressConfig.xml` — player difficulty settings, HUD prefs
+- Never write to vanilla XML nodes. Always use our own `<cropStress>` block.
+
+### Input Bindings
+
+| Key | Action | Handler |
+|-----|--------|---------|
+| **Shift+M** | `CS_TOGGLE_HUD` | Toggle moisture HUD overlay |
+| **Shift+I** | `CS_OPEN_IRRIGATION` | Open irrigation schedule dialog |
+| **E** | Contextual | Field detail view or irrigation system interaction |
+
+### Optional Mod Detection
+
+Always detect at runtime — never hard-code a dependency:
+
+```lua
+if g_npcFavorSystem ~= nil then   -- NPCFavor present
+if g_usedPlusManager ~= nil then  -- UsedPlus present
+if g_precisionFarming ~= nil then -- PF DLC present
+```
+
+---
+
+## Critical Knowledge: GUI System
+
+### Coordinate System
+- **Bottom-left origin**: Y=0 at BOTTOM, increases UP (opposite of web conventions)
+- **Dialog content**: X relative to center (negative=left, positive=right), Y NEGATIVE going down from top
+- All positions in `px` are pixel values; FS25 internally normalizes to screen fractions
+
+### Dialog XML Template (Copy TakeLoanDialog.xml structure!)
+```xml
+<GUI onOpen="onOpen" onClose="onClose" onCreate="onCreate">
+    <GuiElement profile="newLayer" />
+    <Bitmap profile="dialogFullscreenBg" id="dialogBg" />
+    <GuiElement profile="dialogBg" id="dialogElement" size="780px 580px">
+        <ThreePartBitmap profile="fs25_dialogBgMiddle" />
+        <ThreePartBitmap profile="fs25_dialogBgTop" />
+        <ThreePartBitmap profile="fs25_dialogBgBottom" />
+        <GuiElement profile="fs25_dialogContentContainer">
+            <!-- X: center-relative | Y: negative = down from top -->
+        </GuiElement>
+        <BoxLayout profile="fs25_dialogButtonBox">
+            <Button profile="buttonOK" onClick="onOk"/>
+        </BoxLayout>
+    </GuiElement>
+</GUI>
+```
+
+### Safe X Positioning (anchorTopCenter)
+X position = element CENTER, not left edge. Calculate: `X ± (width/2)` must stay within `±(container/2 - 15px)`
+
+### 3-Layer Button Pattern
+```xml
+<Bitmap profile="myButtonBg" id="btn1bg" position="Xpx Ypx"/>
+<Button profile="myButtonHit" id="btn1" position="Xpx Ypx" onClick="onClickBtn1" visible="false"/>
+<Text profile="myButtonText" id="btn1text" position="Xpx Ypx" text="Click Me"/>
+```
+
+### Custom GUI Icons (Images from Mod ZIP)
+Set images dynamically via Lua using `setImageFilename()` — XML `imageFilename` attributes cannot load from inside a ZIP.
+Profile MUST have `imageSliceId value="noSlice"` and extend `baseReference`.
+
+---
+
+## What DOESN'T Work (FS25 Lua 5.1 Constraints)
+
+| Pattern | Problem | Solution |
+|---------|---------|----------|
+| `goto` / labels | FS25 = Lua 5.1 (no goto) | Use `if/else` or early `return` |
+| `continue` | Not in Lua 5.1 | Use guard clauses |
+| `os.time()` / `os.date()` | Not available in FS25 sandbox | Use `g_currentMission.time` / `.environment.currentDay` |
+| `Slider` widgets | Unreliable events | Use quick buttons or `MultiTextOption` |
+| `DialogElement` base | Deprecated | Use `MessageDialog` pattern |
+| Dialog XML naming callbacks `onClose`/`onOpen` | System lifecycle conflict — causes stack overflow | Use different callback names |
+| XML `imageFilename` for mod images | Can't load from ZIP | Set dynamically via `setImageFilename()` in Lua |
+| `MapHotspot` base class | Abstract class has no icon — markers invisible | Use `PlaceableHotspot.new()` + `Overlay.new()` |
+| `registerActionEvent` without `beginActionEventsModification` wrapper | Duplicate keybinds | Use full RVB pattern |
+| `parent="handTool"` in specs | Game prefixes mod name | Use `parent="base"` |
+| `setTextColorByName()` | Doesn't exist in FS25 | Use `setTextColor(r, g, b, a)` |
+| PowerShell `Compress-Archive` | Creates backslash paths in zip | Use `bash` zip or `archiver` npm |
+| `g_currentMission` in mod load scope | Is nil during `modLoaded()` | Wait for `loadedMission()` callback |
+| `getFields()` called every frame | Not free — causes perf issues | Cache result; refresh only on field buy/sell |
+| `appendedFunction` vs `overwrittenFunction` | Two mods overwriting same function breaks both | Use `appendedFunction` wherever possible |
+| Stream read/write order mismatch | Silent data corruption in multiplayer | Read and write in EXACTLY the same order |
+| HUD pixel coordinates | Break on different resolutions | Use normalized 0.0–1.0 screen coordinates |
+| Console: sidecar file creation | File I/O restricted on Xbox/PS5 | Only use xmlFile handle from game save callbacks |
+
+---
+
+## Lessons Learned
+
+### GUI Dialogs
+- XML root MUST be `<GUI>`, never `<MessageDialog>`
+- Custom profiles: `with="anchorTopCenter"` for dialog content positioning
+- **NEVER** name callbacks `onClose`/`onOpen` — they conflict with system lifecycle and cause stack overflow
+- Use `buttonActivate` profile, not `fs25_buttonSmall` (doesn't exist)
+- Add 10-15px padding to section heights to prevent text clipping
+
+### Giants Engine Specifics
+- X/Z = horizontal plane, Y = height. When checking field positions, compare X and Z.
+- `setXMLFloat` / `getXMLFloat` — always use matching type pair (wrong type = silent data corruption)
+- `getXMLInt` returns nil (not 0) when key is absent — always use `or` fallback
+- Placeable `onPostLoad` fires before entity is fully in world — defer field queries via `addUpdateable` + deferred init flag
+
+### Network Events
+- Check `g_server ~= nil` to detect server/single-player mode
+- Moisture sim runs on server only; clients receive updates every 10 in-game minutes
+- Always `g_messageCenter:unsubscribeAll(self)` in `delete()` to prevent reload crashes
+
+### UI Elements
+- `MultiTextOption` texts must be set via `setTexts()` in Lua, NOT via XML `<texts>` children
+- HUD elements use normalized screen coordinates (0.0–1.0), not pixels
+
+---
+
+## Key Patterns
+
+- **Coordinate system:** Bottom-left origin. Y=0 at BOTTOM. Dialog content Y is NEGATIVE going down.
+- **Player detection:** 4 fallback methods — `g_localPlayer`, `mission.player`, `controlledVehicle`, camera.
+- **Initialization guard:** Always `if g_currentMission == nil then return end` + `self.isInitialized` flag.
+- **Hourly tick:** Register via `addUpdateable`; track elapsed time against `g_currentMission.environment:getHour()`.
+- **Field enumeration:** `g_currentMission.fieldManager:getFields()` — call once, cache. Refresh on field buy/sell events.
+- **Harvest hook:** `HarvestingMachine.doGroundWorkArea` via `appendedFunction` — intercept fill amount to apply stress multiplier.
+- **Optional mod detection:** Runtime global check (`g_npcFavorSystem`, `g_usedPlusManager`, `g_precisionFarming`).
+
+---
+
+## Console Commands
+
+Type `csHelp` in the developer console (`~` key). Key debug commands:
+
+| Command | Description |
+|---------|-------------|
+| `csStatus` | System overview — all field moisture + stress |
+| `csSetMoisture <fieldId> <0.0-1.0>` | Force moisture on a field |
+| `csForceStress <fieldId>` | Force max stress on a field |
+| `csSimulateHeat <days>` | Simulate heat wave for N days |
+| `csDebug` | Toggle debug mode (verbose logging) |
+
+---
+
+## File Size Rule: 1500 Lines
+
+**RULE**: If you create, append to, or significantly modify a file that exceeds **1500 lines**, you MUST trigger a refactor to break it into smaller, focused modules.
+
+**Refactor Checklist:**
+1. Identify logical boundaries (GUI vs business logic vs calculations)
+2. Extract to new files with clear single responsibility
+3. Main file becomes a coordinator/orchestrator
+4. Update `main.lua` source order to load new files in correct phase
+5. Test thoroughly
+
+**Exception:** Data files (configs, mappings) can exceed if justified.
+
+---
+
+## No Branding / No Advertising
+
+- **Never** add "Generated with Claude Code", "Co-Authored-By: Claude", or any claude.ai links to commit messages, PR descriptions, code comments, or any other output.
+- **Never** advertise or reference Anthropic, Claude, or claude.ai in any project artifacts.
+- This mod is by its human author(s) — keep it that way.
+
+---
+
+## Session Reminders
+
+1. Read `FS25_SeasonalCropStress_ModPlan.md` for the full implementation blueprint
+2. Check `log.txt` after changes — look for `[CropStress]` prefixed lines
+3. GUI: Y=0 at BOTTOM, dialog Y is NEGATIVE going down
+4. No sliders — use quick buttons or MultiTextOption
+5. No `os.time()` — use `g_currentMission.time`
+6. Copy `TakeLoanDialog.xml` pattern for new dialogs
+7. FS25 = Lua 5.1 (no `goto`, no `continue`)
+8. Images from ZIP: set dynamically via `setImageFilename()` in Lua
+9. Build with `bash build.sh --deploy` (always deploy to mods folder)
+10. Moisture sim is server-authoritative — clients receive synced state only
+11. Always `unsubscribeAll(self)` in `delete()` — prevents reload crashes

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,333 @@
+# DEVELOPMENT.md
+## FS25_SeasonalCropStress — Build Tracker & Session Log
+
+> **Purpose:** This file is the single source of truth for what has been built, what hasn't, and where the next session should begin. Every AI (Claude, GPT, Gemini, or any other) working on this project MUST read this file first, update it when done, and leave it better than they found it.
+
+---
+
+## How to Use This File (Read Before Touching Anything)
+
+### For AI Agents Starting a Session
+
+1. **Read this entire file first.** Do not skip to the TODO list.
+2. **Find the last completed session** in the Session Log (bottom of file). That tells you exactly where to start.
+3. **Find the first unchecked item** in the TODO list. That is your starting point.
+4. **Follow the collaboration model** in `CLAUDE.md` — planning dialog with Samantha before writing code, review dialog after.
+5. **When you finish a work block**, scroll to the Session Log section and add an entry. Be specific. Future AIs depend on your notes.
+6. **Check off TODO items** as you complete them. Use `[x]` for done, `[~]` for partial/in-progress, `[ ]` for not started.
+7. **Never mark something `[x]` unless it is tested and working.** `[~]` means started but not complete.
+
+### Status Key
+
+| Symbol | Meaning |
+|--------|---------|
+| `[ ]` | Not started |
+| `[~]` | In progress / partial |
+| `[x]` | Complete and tested |
+| `[!]` | Blocked — see notes |
+| `[s]` | Skipped — see notes (usually console compat or optional mod) |
+
+---
+
+## Master TODO List
+
+Work through these **in order**. Do not skip ahead. Dependencies flow downward.
+
+---
+
+### PHASE 1 — Core MVP
+
+#### Project Scaffolding
+- [ ] Create `modDesc.xml` with correct `descVersion="72"`, multiplayer flag, input bindings, placeable type declarations, and l10n prefix
+- [ ] Create `main.lua` entry point with `Utils.appendedFunction` hooks for all lifecycle events (see Section 5 of ModPlan)
+- [ ] Create `src/` directory and all empty `.lua` stubs so `main.lua` source order loads without errors
+- [ ] Create `translations/translation_en.xml` with all string keys from Section 14 of ModPlan
+- [ ] Create `config/cropStressDefaults.xml` with per-crop threshold defaults
+- [ ] Verify mod loads in FS25 with zero log errors (empty stubs are fine at this stage)
+
+#### SoilMoistureSystem.lua
+- [ ] Implement `SoilMoistureSystem:initialize()` — enumerate fields via `fieldManager:getFields()`, build `fieldMoistureData` table, call `applyFirstLoadEstimate()`
+- [ ] Implement `applyFirstLoadEstimate()` — season + temp aware starting moisture (sandy/summer ~0.35, clay/spring ~0.65), set `wasEstimated = true`
+- [ ] Implement `detectSoilType(field)` — terrain layer check → PF soil map check → default "loamy"
+- [ ] Implement `hourlyUpdate()` — evapotranspiration formula (baseRate × tempMod × seasonMod × soilMod), irrigation gain, publish `CS_MOISTURE_UPDATED`
+- [ ] Implement critical threshold detection inside `hourlyUpdate()` — publish `CS_CRITICAL_THRESHOLD` when moisture < 0.25
+- [ ] Implement `onWeatherChanged()` — subscribe to `WEATHER_CHANGED`, apply rain gain (verify MessageType name against LUADOC)
+- [ ] Implement `getIrrigationRate(fieldId)` — returns 0 if not irrigating; called by hourlyUpdate
+- [ ] Implement `getMoisture(fieldId)` — simple getter used by HUD and WeatherIntegration
+- [ ] Implement `SoilMoistureSystem:delete()` — `unsubscribeAll(self)`, clear init flag
+- [ ] **TEST:** New game start — all fields at plausible moisture, no log errors
+- [ ] **TEST:** `csSetMoisture` console command forces a field to a value correctly
+
+#### WeatherIntegration.lua
+- [ ] Implement `WeatherIntegration:initialize()` — subscribe to weather events, set defaults
+- [ ] Implement `hourlyPoll()` — read current temp, season, humidity from environment API
+- [ ] Implement `onWeatherChanged()` — forward to internal `CS_WEATHER_FOR_MOISTURE` event
+- [ ] Implement `getMoistureForecast(fieldId, days)` — 5-day projection using `getForecast()` + evap formula
+- [ ] Implement `WeatherIntegration:delete()` — `unsubscribeAll(self)`
+- [ ] **TEST:** Forecast returns 5 values, none outside 0.0–1.0
+
+#### CropStressModifier.lua
+- [ ] Implement `CRITICAL_WINDOWS` table with all 8 crop types
+- [ ] Implement `CropStressModifier:initialize()` — init `fieldStress` table, hook `HarvestingMachine.doGroundWorkArea` via `appendedFunction`
+- [ ] Implement `hourlyStressUpdate()` — iterate fields, check growth stage vs critical window, accumulate stress, publish `CS_STRESS_APPLIED`
+- [ ] Implement `onDoGroundWorkArea()` — intercept harvest fill amount, apply stress multiplier, reset stress after harvest (verify `workArea` property names against LUADOC)
+- [ ] Implement `getStress(fieldId)` — simple getter for HUD
+- [ ] **TEST:** `csForceStress <fieldId>` → harvest that field → yield is visibly reduced
+- [ ] **TEST:** Field with no stress harvests at 100% yield
+
+#### SaveLoadHandler.lua
+- [ ] Implement `SaveLoadHandler:saveToXML()` — write field moisture, stress, and irrigation schedules to `<cropStress>` block
+- [ ] Implement `SaveLoadHandler:loadFromXML()` — read all three blocks, handle nil returns with `or` fallbacks, clear `wasEstimated` flag on loaded values
+- [ ] Hook save into `FSCareerMissionInfo.saveToXMLFile` via `appendedFunction`
+- [ ] Hook load into `Mission00.onStartMission` via `appendedFunction`
+- [ ] **TEST:** Save game → reload → all moisture and stress values match exactly
+- [ ] **TEST:** Fresh game (no save data) loads without errors
+
+#### HUDOverlay.lua (Phase 1 — basic, no forecast)
+- [ ] Create `gui/FieldMoisturePanel.xml` — follow `TakeLoanDialog.xml` structure, root `<GUI>`, no `onClose`/`onOpen` callback names
+- [ ] Implement `HUDOverlay:initialize()` — load GUI element, register `CS_TOGGLE_HUD` input action
+- [ ] Implement `HUDOverlay:draw()` — draw moisture bars for up to 5 fields, color-coded (green/yellow/red), normalized coordinates only
+- [ ] Implement `getMoistureColor(moisture)` — green >0.6, yellow 0.3–0.6, red <0.3
+- [ ] Implement `drawMoistureBar()` — bar + percentage + field name + crop type
+- [ ] Implement `drawStressWarning()` — show stress indicator when stress > 0.2
+- [ ] Implement empty state — "No critical fields — all crops healthy" message when `visibleFields` is empty
+- [ ] Implement first-time tooltip — one-time explanation of what the bar means (stored in config after first show)
+- [ ] Implement auto-show logic — show when player enters field in critical window with moisture < 0.5
+- [ ] Implement auto-hide logic — hide after 30 in-game minutes with no critical fields
+- [ ] Implement `CS_MOISTURE_UPDATED` subscriber — update `visibleFields` list
+- [ ] **TEST:** Shift+M toggles panel on/off
+- [ ] **TEST:** Panel auto-shows when entering a stressed field
+- [ ] **TEST:** Empty state message appears when all fields are healthy
+
+#### CropStressManager.lua (coordinator)
+- [ ] Implement `CropStressManager:new()` — instantiate all subsystems
+- [ ] Implement `initialize()` — call each subsystem's `initialize()` in correct order, call `detectOptionalMods()`
+- [ ] Implement `detectOptionalMods()` — check for `g_npcFavorSystem`, `g_usedPlusManager`, `g_precisionFarming`
+- [ ] Implement `update(dt)` — drive hourly tick counter, call `hourlyUpdate()` on soil, stress, and weather systems
+- [ ] Implement `delete()` — call `delete()` on all subsystems in reverse order
+- [ ] Register `g_cropStressManager` as global
+- [ ] **TEST:** Load game → play 1 in-game hour → moisture changes, no errors in log
+
+#### Console Debug Commands
+- [ ] Implement `debugPrintStatus()` — print all field moisture + stress values to log
+- [ ] Implement `debugSetMoisture(fieldIdStr, valueStr)` — force moisture on a field
+- [ ] Implement `debugForceStress(fieldIdStr)` — set stress to 1.0 on a field
+- [ ] Implement `debugSimulateHeat(daysStr)` — run N days of summer evaporation
+- [ ] Implement `debugToggleVerbose()` — toggle verbose event logging
+- [ ] Register all commands in `main.lua` under `g_addTestCommands` guard
+
+#### Config File
+- [ ] Implement `cropStressConfig.xml` read on startup with fallback defaults for all values
+- [ ] Expose difficulty multipliers (`stressMultiplier`, `evaporationMultiplier`, `rainAbsorptionMultiplier`) to formulas in SoilMoistureSystem and CropStressModifier
+
+#### Phase 1 Final Validation
+- [ ] All 5 Phase 1 test scenarios pass (see Section 15 of ModPlan)
+- [ ] Zero errors in `log.txt` on clean load
+- [ ] Zero errors on save/reload cycle
+- [ ] `bash build.sh --deploy` produces a valid ZIP with no backslash paths
+
+---
+
+### PHASE 2 — Irrigation Infrastructure
+
+#### WaterPump placeable
+- [ ] Create `placeables/waterPump/waterPump.xml` — placeable spec with water source config
+- [ ] Create `placeables/waterPump/waterPump.lua` — `onLoad`, `onDelete`, `onWriteStream`, `onReadStream`
+- [ ] Register pump with `IrrigationManager` on `onLoad`
+- [ ] Implement proximity `E` interaction to connect/disconnect irrigation systems
+- [ ] Implement 500m detection radius for supplying connected irrigation systems
+- [ ] **TEST:** Place pump near river → connect a pivot → pivot activates
+
+#### CenterPivot placeable
+- [ ] Create `placeables/centerPivot/centerPivot.xml` — with `pivotRadius`, water consumption, electrical consumption, price, maintenance cost
+- [ ] Create `placeables/centerPivot/centerPivot.lua` — `onLoad`, `onDelete`, `onUpdate` (arm animation), `onWriteStream`, `onReadStream`
+- [ ] Use `parent="base"` NOT `parent="handTool"` in spec
+- [ ] Implement arm rotation animation when `isActive = true`
+- [ ] Register with `IrrigationManager` on `onLoad`, deregister on `onDelete`
+
+#### IrrigationManager.lua
+- [ ] Implement `IrrigationManager:initialize()` — init `irrigationSystems` table
+- [ ] Implement `registerIrrigationSystem(placeable)` — build system data entry
+- [ ] Implement `deregisterIrrigationSystem(placeableId)`
+- [ ] Implement `detectCoveredFields(placeable)` — circle/polygon intersection using X/Z coordinates
+- [ ] Implement `fieldIntersectsCircle(field, cx, cz, radius)` — check field polygon vs circle
+- [ ] Implement `calculateFlowRate(placeable)` — read from placeable XML
+- [ ] Implement `calculateCost(placeable)` — read from placeable XML
+- [ ] Implement `calculatePressureMultiplier(distance)` — linear 100%→70% over 0→500m, 0% beyond
+- [ ] Implement `checkWaterAvailability(system)` — check connected pump has water
+- [ ] Implement `hourlyScheduleCheck()` — compare current hour/day vs schedule, activate/deactivate
+- [ ] Implement `activateSystem(id)` — set active, publish `CS_IRRIGATION_STARTED` for each covered field with effective rate
+- [ ] Implement `deactivateSystem(id)` — set inactive, publish `CS_IRRIGATION_STOPPED`
+- [ ] Implement `getIrrigationRate(fieldId)` — returns effective rate for SoilMoistureSystem to use
+- [ ] Implement `IrrigationManager:delete()` — `unsubscribeAll`, deactivate all systems
+
+#### Irrigation Schedule Dialog
+- [ ] Create `gui/IrrigationScheduleDialog.xml` — copy `TakeLoanDialog.xml` structure, `<GUI>` root, custom callback names
+- [ ] Create `gui/IrrigationScheduleDialog.lua` — dialog logic
+- [ ] Day-of-week toggle buttons (Mon–Sun, 7 individual buttons)
+- [ ] Start/end time selectors via `MultiTextOption` — set texts via `setTexts()` in Lua, NOT via XML `<texts>` children
+- [ ] Display flow rate, efficiency, estimated cost, wear level
+- [ ] List covered fields with their current moisture + crop stage
+- [ ] "Irrigate Now" button — immediately activate system
+- [ ] "Save Schedule" button — write schedule back to system data and trigger save
+- [ ] Open dialog on `E` near a system or `Shift+I` keybind
+- [ ] **TEST:** Change schedule → save → reload → schedule persists
+
+#### Irrigation Costs (vanilla — no UsedPlus yet)
+- [ ] Implement hourly cost deduction in `CropStressManager:update()` via `updateFunds(-cost, "OTHER", true)`
+- [ ] **TEST:** Run irrigation overnight → farm balance decreases by expected amount
+
+#### Save/Load — Irrigation Extension
+- [ ] Extend `SaveLoadHandler` to save/load irrigation system schedules and active states
+- [ ] **TEST:** Active irrigation → save → reload → still active with correct schedule
+
+#### Phase 2 Final Validation
+- [ ] All Phase 2 test scenarios pass (scenarios 4+ from Section 15)
+- [ ] Center pivot animates when active
+- [ ] Pressure curve: pivot at 250m gets ~85% flow; pivot at 600m gets 0%
+- [ ] Zero errors in log
+
+---
+
+### PHASE 3 — NPC & Social
+
+#### CropConsultant.lua (standalone mode)
+- [ ] Implement `CropConsultant:initialize()` — subscribe to `CS_CRITICAL_THRESHOLD`
+- [ ] Implement `onCriticalThreshold()` — 12-hour cooldown per field, severity logic, `showBlinkingWarning`
+- [ ] Implement three severity levels: INFO (4s), WARNING (6s), CRITICAL (10s red)
+- [ ] Implement `CropConsultant:delete()` — `unsubscribeAll`
+- [ ] **TEST:** Set field to 15% moisture → warning appears within 1 in-game hour
+- [ ] **TEST:** Warning does NOT repeat for 12 in-game hours on same field
+
+#### NPCIntegration.lua
+- [ ] Implement `NPCIntegration:initialize()` — detect `g_npcFavorSystem`, conditionally register
+- [ ] Implement `registerConsultantNPC()` — verify `registerExternalNPC` API against NPCFavor source, call with Alex Chen config
+- [ ] Implement `generateConsultantFavor(npc, favorType)` — return favor task configs for all 4 favor types (`SOIL_SAMPLE`, `IRRIGATION_CHECK`, `EMERGENCY_WATER`, `SEASONAL_PLAN`)
+- [ ] Implement `enableNPCFavorMode()` — called by `CropStressManager` after detection
+- [ ] **TEST (with NPCFavor loaded):** Alex Chen NPC appears, relationship starts at 10
+- [ ] **TEST (with NPCFavor loaded):** `EMERGENCY_WATER` favor fires when field < 15% in critical window
+- [ ] **TEST (without NPCFavor):** Mod loads cleanly, no nil access errors
+
+#### HUD Forecast Strip (Phase 3 upgrade)
+- [ ] Extend `gui/FieldMoisturePanel.xml` to include 5-day forecast section
+- [ ] Implement `drawForecast(projections)` in `HUDOverlay.lua` — 5 columns, moisture %, weather icon hint
+- [ ] Wire `selectedFieldId` — clicking a field row in HUD selects it for forecast display
+- [ ] **TEST:** Forecast shows 5 different values, updates when selected field changes
+
+#### Phase 3 Final Validation
+- [ ] Scenarios 6 and 7 from Section 15 pass
+- [ ] Standalone consultant alerts work with no optional mods loaded
+- [ ] Alex Chen appears and generates favors when NPCFavor is present
+- [ ] Forecast strip renders without coordinate/overflow errors
+
+---
+
+### PHASE 4 — Finance & Polish
+
+#### FinanceIntegration.lua
+- [ ] Implement `FinanceIntegration:initialize()` — detect `g_usedPlusManager`, subscribe to irrigation events
+- [ ] Implement `chargeHourlyCosts()` — route through `g_usedPlusManager:recordExpense()` if present, otherwise direct `updateFunds`
+- [ ] Implement `getEquipmentWearLevel(vehicleId)` — read UsedPlus DNA reliability, convert to 0–1 wear scale
+- [ ] Implement `onIrrigationStarted()` / `onIrrigationStopped()` — track cost cycle start/stop times
+- [ ] Implement `enableUsedPlusMode()` — called by `CropStressManager` after detection
+- [ ] Implement `FinanceIntegration:delete()` — `unsubscribeAll`
+- [ ] **TEST (with UsedPlus):** Irrigation costs appear in UsedPlus finance manager under "OPERATIONAL"
+- [ ] **TEST (with UsedPlus):** Worn pump (DNA reliability 0.6) delivers ~76% of rated flow
+- [ ] **TEST (without UsedPlus):** Costs still deducted via vanilla `updateFunds`
+
+#### Drip Irrigation Line placeable
+- [ ] Create `placeables/dripIrrigationLine/dripLine.xml` + `.lua`
+- [ ] Implement start/end marker placement workflow
+- [ ] Implement linear coverage calculation → field polygon overlap
+- [ ] Register with `IrrigationManager` (same path as pivot)
+- [ ] **TEST:** Place drip line across a sugar beet field → moisture rises in covered area
+
+#### Used Equipment Marketplace entries
+- [ ] Add center pivot and pump unit to UsedPlus used equipment marketplace (verify UsedPlus marketplace registration API)
+- [ ] Add wear state variation so pre-owned items appear at 40–80% condition
+- [ ] **TEST (with UsedPlus):** Pre-owned pivot appears in marketplace at discount
+
+#### Precision Farming DLC Overlay
+- [ ] Implement `enablePrecisionFarmingCompat()` in `CropStressManager`
+- [ ] Read PF soil sample data for per-field `soilType` (check PF DLC API against LUADOC)
+- [ ] Add moisture overlay layer to PF soil analysis map view
+- [ ] **TEST (with PF DLC):** PF soil map shows moisture overlay, soil types match PF data
+
+#### Translations — Complete Set
+- [ ] `translation_de.xml` — German, all keys
+- [ ] `translation_fr.xml` — French, all keys
+- [ ] `translation_nl.xml` — Dutch, all keys
+- [ ] `translation_pl.xml` — Polish, all keys
+- [ ] **TEST:** Switch game language to DE → all mod UI text is German, no missing key fallbacks
+
+#### Phase 4 Final Validation
+- [ ] All 10 test scenarios from Section 15 pass
+- [ ] Zero errors in log with all optional mods loaded simultaneously (UsedPlus + NPCFavor + PF DLC)
+- [ ] Zero errors in log with no optional mods loaded
+- [ ] Build produces valid ZIP, deploy to mods folder, full clean play session without crash
+
+---
+
+### POST-LAUNCH
+
+- [ ] Create Steam Workshop listing draft
+- [ ] Record gameplay footage showing drought stress + irrigation response
+- [ ] Write changelog for v1.0.0.0
+- [ ] Tag v1.0.0.0 in git
+
+---
+
+## Session Log
+
+*Sessions are logged in reverse-chronological order (newest at top). Each entry MUST include: date, AI agent, what was done, what was tested, what the next agent should start on, and any blockers or surprises.*
+
+---
+
+### SESSION TEMPLATE (copy this for every new entry)
+
+```
+---
+
+### [DATE] — [AI AGENT NAME] — Phase [X]
+
+**Started from:** [First TODO item tackled this session]
+**Completed:**
+- [Item 1 — be specific, include file names]
+- [Item 2]
+
+**Tested:**
+- [Test 1 — what you tested and what the result was]
+- [Test 2]
+
+**Checked off in TODO:**
+- [List the TODO items you marked [x] this session]
+
+**Next agent should start at:**
+[Exact TODO item text — copy it verbatim from the list above]
+
+**Notes / surprises:**
+- [Anything unexpected — API names that differed from ModPlan, bugs found, workarounds applied]
+- [Anything the next agent needs to know that isn't obvious from the TODO list]
+
+---
+```
+
+---
+
+*(No sessions logged yet — this file was just created. First agent: start at "Create modDesc.xml" under Phase 1 → Project Scaffolding.)*
+
+---
+
+## Quick Reference: Where to Start
+
+**If no sessions are logged:** Start at the very first unchecked item under Phase 1 → Project Scaffolding.
+
+**If sessions are logged:** Read the most recent entry. Find "Next agent should start at:" and go there.
+
+**If an item is marked `[~]` (in progress):** Read the session note for that item before continuing — there may be a partial implementation, a known issue, or a branch that needs review before proceeding.
+
+**If an item is marked `[!]` (blocked):** Read the note. Do not attempt to work around a blocker without documenting the workaround here first.
+
+---
+
+*DEVELOPMENT.md — created alongside plan v2.0. Maintained by all contributors. Last updated: session initialization.*

--- a/FS25_SeasonalCropStress_ModPlan.md
+++ b/FS25_SeasonalCropStress_ModPlan.md
@@ -1,0 +1,1484 @@
+# FS25 Mod Development Plan: Seasonal Crop Stress & Irrigation Manager
+### A Complete Implementation Guide
+
+> **Purpose of this document:** Self-contained, step-by-step blueprint to build `FS25_SeasonalCropStress` from scratch. All architectural decisions are explained, all pitfalls are called out, and all source references are cited. Written for continuity across sessions — Claude and Samantha can pick this up at any point and execute correctly.
+
+---
+
+## Table of Contents
+
+1. [Mod Concept & Vision](#1-mod-concept--vision)
+2. [Source Material & Prior Art](#2-source-material--prior-art)
+3. [Technical Environment](#3-technical-environment)
+4. [Repository & File Structure](#4-repository--file-structure)
+5. [Core Systems Architecture](#5-core-systems-architecture)
+6. [System-by-System Implementation Guide](#6-system-by-system-implementation-guide)
+   - 6.1 [SoilMoistureSystem.lua](#61-soilmoisturesystemlua)
+   - 6.2 [IrrigationManager.lua](#62-irrigationmanagerlua)
+   - 6.3 [CropStressModifier.lua](#63-cropstressmodifierlua)
+   - 6.4 [WeatherIntegration.lua](#64-weatherintegrationlua)
+   - 6.5 [HUDOverlay.lua](#65-hudoverlaylua)
+   - 6.6 [CropConsultant.lua](#66-cropconsultantlua)
+   - 6.7 [NPCIntegration.lua](#67-npcintegrationlua)
+   - 6.8 [FinanceIntegration.lua](#68-financeintegrationlua)
+7. [GUI Design](#7-gui-design)
+8. [Placeables: Irrigation Infrastructure](#8-placeables-irrigation-infrastructure)
+9. [Save / Load System](#9-save--load-system)
+10. [Multiplayer Considerations](#10-multiplayer-considerations)
+11. [Cross-Mod Integration Layer](#11-cross-mod-integration-layer)
+12. [modDesc.xml Specification](#12-moddescxml-specification)
+13. [Configuration File Specification](#13-configuration-file-specification)
+14. [Localization](#14-localization)
+15. [Testing Strategy](#15-testing-strategy)
+16. [Known FS25 Lua Pitfalls](#16-known-fs25-lua-pitfalls)
+17. [Phased Release Plan](#17-phased-release-plan)
+18. [Credits & Acknowledgements](#18-credits--acknowledgements)
+
+---
+
+## How Sessions Work
+
+Every session uses the collaboration model defined in `CLAUDE.md`. Claude does ~80% of implementation work; Samantha contributes ~20% as co-creator, manager, and final reviewer. Dialog flows naturally throughout — not just at checkpoints.
+
+**Required collaboration points every session:**
+1. **Early Planning** — Claude proposes approach, Samantha questions assumptions and approves or redirects before any code is written.
+2. **Pre-Implementation Review** — Claude outlines specific steps, Samantha reviews for edge cases and UX concerns, gives go-ahead.
+3. **Post-Implementation Review** — Claude summarizes what was built, Samantha verifies requirements met and declares work complete (or identifies gaps).
+
+**Example of correct session opening:**
+
+---
+
+**Claude** 🍵 *sips oolong, opens the plan doc*
+
+Good morning. I've re-read the plan. Given we're starting Phase 2 today, I'd suggest beginning with `WaterPump.lua` — it's the dependency that `IrrigationManager` needs before the pivot can activate. My thinking is: register the pump as a placeable, implement the water source detection radius (500m), then wire the activation event. Thoughts?
+
+---
+
+**Samantha** 🌸 *adjusts her "git push it real good" cap, wraps both hands around a fresh coffee*
+
+Love the sequencing. One thing before you dive in — I was thinking about the farmer who places a pump right at the river's edge versus 490m away. Are we doing a hard radius cutoff, or should distance affect pressure/flow rate? Because if it's just a binary connect/disconnect, that's a missed gameplay opportunity.
+
+---
+
+**Claude** ☯️
+
+Good catch. A pressure-distance curve adds depth without much complexity — linear falloff from 100% at 0m to 70% at 500m, then hard cutoff. Keeps it meaningful without punishing anyone who places thoughtfully.
+
+---
+
+**Samantha** 💕
+
+That's the sweet spot. Go for it.
+
+---
+
+*That's the energy. Capture it in every session.*
+
+---
+
+## 1. Mod Concept & Vision
+
+**Name:** `FS25_SeasonalCropStress`
+**Tagline:** *Your crops thirst. Your crops suffer. Your choices matter.*
+**Current Version:** 1.0.0.0
+
+### What the mod does
+
+Vanilla FS25 treats crop growth as binary: crops either grow through their stages or they don't. Precipitation, temperature, and soil type have no granular influence on yield once planting happens. This mod adds a **soil moisture layer** and **crop stress simulation** that makes every field a living system requiring active agronomic management.
+
+### Core gameplay loop added
+
+1. Each field has a **soil moisture percentage** (0–100) that rises with rain and irrigation, falls through evapotranspiration driven by temperature.
+2. During growth-stage windows, if moisture drops below crop-specific thresholds, a **stress multiplier** accumulates and reduces final yield.
+3. The player can place **center-pivot irrigation systems** or **drip irrigation lines** to counteract drought stress.
+4. A **Crop Consultant NPC** monitors fields and sends alerts when critical growth windows approach dangerous moisture levels. Integrates with `FS25_NPCFavor` when present.
+5. Irrigation infrastructure has operational costs (electricity/diesel) tracked by `FS25_UsedPlus` when present.
+
+### Design philosophy
+
+> "Give players meaningful choices with real consequences. Every path has trade-offs."
+
+- Full irrigation network = expensive, eliminates weather risk.
+- Relying on rainfall = cheap, creates dramatic tension during dry seasons.
+- Partial irrigation on high-value crops = strategic middle ground.
+
+The player who ignores this system loses ~20–30% yield on stressed crops in a dry summer. The player who engages gets predictable, optimized harvests — but pays ongoing infrastructure and operational costs. Neither path dominates; both have seasons where they're right.
+
+---
+
+## 2. Source Material & Prior Art
+
+### 2.1 FS25 Community LUADOC
+- **URL:** https://github.com/umbraprior/FS25-Community-LUADOC
+- **What it is:** 1,661 pages of Markdown documentation covering 11,102 FS25 Lua functions.
+- **Rule:** Before implementing any call into the FS25 API, look it up here first. Do not guess function signatures.
+- **Key namespaces for this mod:**
+  - `g_currentMission.fieldManager` — enumerate, query, modify fields
+  - `g_currentMission.environment` — weather, season, temperature
+  - `g_currentMission.growthManager` — crop growth stages
+  - `g_farmlandManager` — ownership, field IDs
+  - `g_placeableManager` — register and manage placeables
+  - `g_messageCenter` — event bus between mod systems
+  - `g_gui` — dialogs and HUD elements
+  - `g_inputBinding` — keyboard shortcut registration
+
+### 2.2 FS25_UsedPlus AI Coding Reference
+- **URL:** https://github.com/XelaNull/FS25_UsedPlus/tree/master/FS25_AI_Coding_Reference
+- **Patterns to follow directly:**
+  - Use `g_messageCenter:subscribe()` / `g_messageCenter:publish()` for all inter-system communication.
+  - Always check `g_currentMission ~= nil` before accessing mission state. Store `self.isInitialized` and gate all logic behind it.
+  - For save data, write a dedicated `<cropStress>` block in our sidecar XML. Never piggyback vanilla XML nodes.
+  - Finance hooks: use `g_currentMission.missionInfo:updateFunds(amount, "OTHER", true)` for direct deductions. Route through `g_usedPlusManager:recordExpense()` when UsedPlus is present.
+
+### 2.3 FS25_NPCFavor
+- **URL:** https://github.com/TheCodingDad-TisonK/FS25_NPCFavor
+- **Integration point:** When NPCFavor is active, `CropConsultant.lua` registers "Alex Chen, Agronomist" as a named NPC via `g_npcFavorSystem:registerExternalNPC(config)`. Before that integration fires, the HUD overlay is the only feedback mechanism.
+- **Key lesson:** NPCFavor generates tasks at `relationship >= 25`. The consultant only starts sending proactive alerts once the player has visited the consultant's office placeable at least once.
+
+### 2.4 FS25_UsedPlus (the mod itself)
+- **Finance:** Route irrigation operational costs through `g_usedPlusManager:recordExpense("IRRIGATION", amount, {...})`.
+- **Used equipment marketplace:** Irrigation pump units and center-pivot heads can appear as pre-owned items with wear states.
+- **Vehicle DNA:** If a pump unit has high hours/wear via UsedPlus DNA, irrigation efficiency degrades. A worn pump delivers 80% of rated flow — subtle yield hits without explicit failure.
+
+---
+
+## 3. Technical Environment
+
+| Item | Value |
+|------|-------|
+| Game | Farming Simulator 25 |
+| Scripting language | Lua 5.1 (Giants custom runtime — no `goto`, no `continue`) |
+| Key API surface | GIANTS Engine + FS25 game scripts |
+| Save format | XML (savegameX/ sidecar file: `cropStressData.xml`) |
+| Mod folder | `%USERPROFILE%\Documents\My Games\FarmingSimulator2025\mods\FS25_SeasonalCropStress\` |
+| Game log | `%USERPROFILE%\Documents\My Games\FarmingSimulator2025\log.txt` |
+| Target platforms | PC (primary), Console (secondary — no `io.open`, no sidecar files on console) |
+| Multiplayer | Yes — moisture state synced server-authoritative every 10 in-game minutes |
+| Build command | `bash build.sh --deploy` |
+
+### Lua version constraints (Lua 5.1 sandbox)
+
+- No `goto` / no labels
+- No `continue` — use guard clauses or `if/else`
+- No `io.popen`, no `os.execute`, no `os.time()`, no `os.date()`
+- No `require` for external libraries
+- Use `g_currentMission.time` and `g_currentMission.environment.currentDay` instead of `os.time()`
+- `print()` → game `log.txt`. Use `g_logManager:devInfo("[CropStress]", message)` for structured output.
+
+---
+
+## 4. Repository & File Structure
+
+```
+FS25_SeasonalCropStress/
+│
+├── modDesc.xml                        ← Giants mod manifest (see Section 12)
+├── main.lua                           ← Entry point + lifecycle hooks
+├── CLAUDE.md                          ← Session collaboration rules (THIS file's companion)
+├── FS25_SeasonalCropStress_ModPlan.md ← THIS document
+├── icon.dds                           ← 512x512 mod icon
+├── icon_small.dds                     ← 64x64 minimap/HUD icon
+│
+├── config/
+│   └── cropStressDefaults.xml        ← Default per-crop thresholds, evaporation rates
+│
+├── src/
+│   ├── CropStressManager.lua          ← Central coordinator (owns all subsystems)
+│   ├── SoilMoistureSystem.lua         ← Per-field moisture state + evapotranspiration
+│   ├── IrrigationManager.lua          ← Pivot/drip system registration + scheduling
+│   ├── CropStressModifier.lua         ← Hooks growthManager, applies yield multipliers
+│   ├── WeatherIntegration.lua         ← Subscribes to rain/temp events, updates moisture
+│   ├── HUDOverlay.lua                 ← Field moisture HUD panel + forecast strip
+│   ├── CropConsultant.lua             ← NPC alert system (standalone + NPCFavor bridge)
+│   ├── NPCIntegration.lua             ← FS25_NPCFavor optional bridge
+│   ├── FinanceIntegration.lua         ← FS25_UsedPlus optional bridge
+│   └── SaveLoadHandler.lua            ← XML read/write for all persistent state
+│
+├── gui/
+│   ├── FieldMoisturePanel.xml         ← HUD overlay layout
+│   ├── FieldMoisturePanel.lua         ← HUD logic
+│   ├── IrrigationScheduleDialog.xml   ← Irrigation scheduling UI layout
+│   ├── IrrigationScheduleDialog.lua   ← Scheduling UI logic
+│   └── CropConsultantDialog.xml       ← Consultant interaction UI
+│
+├── placeables/
+│   ├── centerPivot/
+│   │   ├── centerPivot.xml
+│   │   ├── centerPivot.i3d
+│   │   └── centerPivot.lua
+│   ├── dripIrrigationLine/
+│   │   ├── dripLine.xml
+│   │   ├── dripLine.i3d
+│   │   └── dripLine.lua
+│   └── waterPump/
+│       ├── waterPump.xml
+│       ├── waterPump.i3d
+│       └── waterPump.lua
+│
+├── vehicles/
+│   └── irrigationPumpUnit/
+│       ├── irrigationPump.xml
+│       └── irrigationPump.lua
+│
+└── translations/
+    ├── translation_en.xml
+    ├── translation_de.xml
+    ├── translation_fr.xml
+    └── translation_nl.xml
+```
+
+**File size rule:** If any `.lua` file exceeds **1500 lines**, trigger an immediate refactor. Extract logical subsystems to new files, make the oversized file a coordinator. Update `main.lua` source order. Test thoroughly.
+
+---
+
+## 5. Core Systems Architecture
+
+### Module loading order (main.lua)
+
+`main.lua` uses `source()` to load in strict dependency order:
+
+1. **Core Systems** — `SoilMoistureSystem.lua`, `WeatherIntegration.lua`
+2. **Game Integration** — `CropStressModifier.lua`, `IrrigationManager.lua`
+3. **Player-Facing** — `HUDOverlay.lua`, `CropConsultant.lua`
+4. **Optional Bridges** — `NPCIntegration.lua`, `FinanceIntegration.lua`
+5. **Persistence** — `SaveLoadHandler.lua`
+6. **GUI** — `FieldMoisturePanel.lua`, `IrrigationScheduleDialog.lua`, `CropConsultantDialog.lua`
+7. **Coordinator** — `CropStressManager.lua`
+
+### Central coordinator
+
+```
+CropStressManager (g_cropStressManager)
+  ├── soilSystem         : SoilMoistureSystem
+  ├── irrigationManager  : IrrigationManager
+  ├── stressModifier     : CropStressModifier
+  ├── weatherIntegration : WeatherIntegration
+  ├── hudOverlay         : HUDOverlay
+  ├── consultant         : CropConsultant
+  ├── npcIntegration     : NPCIntegration      (optional)
+  ├── financeIntegration : FinanceIntegration  (optional)
+  └── saveLoad           : SaveLoadHandler
+```
+
+Global reference: `g_cropStressManager`.
+
+### Game hook pattern
+
+All lifecycle hooks use `Utils.appendedFunction`:
+
+| Hook | Purpose |
+|------|---------|
+| `Mission00.load` | Create `CropStressManager` instance |
+| `Mission00.loadMission00Finished` | Initialize all systems, enumerate fields |
+| `FSBaseMission.update` | Per-frame HUD update + hourly sim tick |
+| `FSBaseMission.draw` | HUD rendering |
+| `FSBaseMission.delete` | Cleanup + `unsubscribeAll` |
+| `FSCareerMissionInfo.saveToXMLFile` | Save moisture/stress/schedule state |
+| `Mission00.onStartMission` | Load saved state |
+| `FSBaseMission.sendInitialClientState` | Multiplayer initial sync |
+| `HarvestingMachine.doGroundWorkArea` | Intercept harvest fill → apply yield multiplier |
+
+### Message bus (g_messageCenter)
+
+All inter-system communication goes through `g_messageCenter`. Never call foreign system functions directly — this prevents crashes when optional mods are absent.
+
+| Event | Publisher | Subscribers | Payload |
+|-------|-----------|-------------|---------|
+| `CS_MOISTURE_UPDATED` | SoilMoistureSystem | HUDOverlay, CropConsultant | `{fieldId, oldValue, newValue}` |
+| `CS_STRESS_APPLIED` | CropStressModifier | HUDOverlay, FinanceIntegration | `{fieldId, cropType, multiplier}` |
+| `CS_IRRIGATION_STARTED` | IrrigationManager | SoilMoistureSystem, FinanceIntegration | `{placeableId, fieldId, ratePerHour}` |
+| `CS_IRRIGATION_STOPPED` | IrrigationManager | SoilMoistureSystem | `{placeableId, fieldId}` |
+| `CS_CONSULTANT_ALERT` | CropConsultant | HUDOverlay, NPCIntegration | `{fieldId, severity, message}` |
+| `CS_CRITICAL_THRESHOLD` | SoilMoistureSystem | CropConsultant | `{fieldId, cropType, moistureLevel}` |
+
+---
+
+## 6. System-by-System Implementation Guide
+
+---
+
+### 6.1 SoilMoistureSystem.lua
+
+**Responsibility:** Maintain moisture (0.0–1.0) per field. Update hourly via rain events + evapotranspiration. Publish change events for HUD and consultant.
+
+**Start of session planning dialog:**
+
+---
+
+**Claude** 🍵 *settles in with green tea*
+
+SoilMoistureSystem is the load-bearing foundation. Everything else reads from it. My plan: initialize a `fieldMoistureData` table keyed by `fieldId` inside `loadedMission()` — never in module scope — run evapotranspiration hourly via `addUpdateable`, and subscribe to weather events for rain gains. Clean, readable, no frame-rate dependency.
+
+---
+
+**Samantha** 🌺 *leans forward over her "coffee: the original debug fluid" mug*
+
+Agreed on the architecture. One UX thing I keep thinking about: the farmer loads an existing save and their fields are all at 50% because that's our default. That's going to feel wrong after a hot, dry in-game week they just lived through. Can we detect current season and temp on first load and backfill a plausible starting moisture?
+
+---
+
+**Claude** ☯️
+
+Yes — a "hydration estimate on first load" pass. Check current season and last 3 forecast days of temperature, apply a scaled offset from 0.5. Sandy soil in summer starts at ~0.35; clay in spring starts at ~0.65. Flag `data.wasEstimated = true` so we don't overwrite actual saved values on reload.
+
+---
+
+**Samantha** 🦋
+
+Perfect. That'll make the first play session feel alive instead of artificial. Do it.
+
+---
+
+#### Data model
+
+```lua
+-- Per-field state table, keyed by fieldId
+self.fieldMoistureData = {}
+-- {
+--   fieldId = number,
+--   moisture = float,        -- 0.0 to 1.0
+--   soilType = string,       -- "sandy", "loamy", "clay"
+--   lastUpdated = number,    -- game day
+--   irrigationActive = bool,
+--   wasEstimated = bool,     -- true if moisture was backfilled on first load
+-- }
+```
+
+#### Initialization (MUST be in loadedMission, never modLoaded)
+
+```lua
+function SoilMoistureSystem:initialize()
+    if g_currentMission == nil or g_currentMission.fieldManager == nil then return end
+
+    self.fieldMoistureData = {}
+    local fields = g_currentMission.fieldManager:getFields()  -- cache this, don't call every frame
+
+    for _, field in ipairs(fields) do
+        self.fieldMoistureData[field.fieldId] = {
+            fieldId      = field.fieldId,
+            moisture     = 0.5,
+            soilType     = self:detectSoilType(field),
+            lastUpdated  = g_currentMission.environment.currentDay,
+            irrigationActive = false,
+            wasEstimated = false,
+        }
+    end
+
+    self:applyFirstLoadEstimate()
+    self.isInitialized = true
+end
+```
+
+#### Evapotranspiration (hourly)
+
+```lua
+function SoilMoistureSystem:hourlyUpdate()
+    if not self.isInitialized then return end
+
+    local temp   = g_currentMission.environment.weather:getCurrentTemperature()
+    local season = g_currentMission.environment:currentSeason()  -- 0=spring 1=summer 2=autumn 3=winter
+
+    for fieldId, data in pairs(self.fieldMoistureData) do
+        local baseRate  = 0.004
+        local tempMod   = 1.0 + math.max(0, (temp - 15) * 0.03)
+        local seasonMod = ({[0]=0.8, [1]=1.4, [2]=0.9, [3]=0.2})[season] or 1.0
+        local soilMod   = ({sandy=1.4, loamy=1.0, clay=0.7})[data.soilType] or 1.0
+
+        local loss = baseRate * tempMod * seasonMod * soilMod
+        local gain = 0
+        if data.irrigationActive then
+            gain = self:getIrrigationRate(fieldId)
+        end
+
+        local old = data.moisture
+        data.moisture = math.max(0.0, math.min(1.0, data.moisture - loss + gain))
+
+        g_messageCenter:publish(MessageType.CS_MOISTURE_UPDATED, {
+            fieldId  = fieldId,
+            oldValue = old,
+            newValue = data.moisture,
+        })
+
+        -- Publish critical threshold event if needed
+        if data.moisture < 0.25 then
+            g_messageCenter:publish(MessageType.CS_CRITICAL_THRESHOLD, {
+                fieldId      = fieldId,
+                moistureLevel = data.moisture,
+            })
+        end
+    end
+end
+```
+
+#### Rain event handler
+
+```lua
+-- In initialize():
+g_messageCenter:subscribe(MessageType.WEATHER_CHANGED, self.onWeatherChanged, self)
+
+function SoilMoistureSystem:onWeatherChanged(data)
+    -- NOTE: Verify exact MessageType name against LUADOC before shipping.
+    if data.weatherType == "rain" or data.weatherType == "heavyRain" then
+        local gainPerHour = 0.012 * (data.intensity or 1.0)
+        for _, fieldData in pairs(self.fieldMoistureData) do
+            fieldData.moisture = math.min(1.0, fieldData.moisture + gainPerHour * (data.durationHours or 1))
+        end
+    end
+end
+```
+
+#### Soil type detection
+
+```lua
+function SoilMoistureSystem:detectSoilType(field)
+    -- 1. Try map terrainDetailLayer metadata
+    if g_currentMission.terrainDetailLayer ~= nil then
+        -- Implementation depends on map; check LUADOC for getTerrainAttributeAtWorldPos
+    end
+    -- 2. Try Precision Farming soil map
+    if g_precisionFarming ~= nil then
+        -- PF exposes soil type per coordinate; use field center
+    end
+    -- 3. Safe default
+    return "loamy"
+end
+```
+
+#### Cleanup (CRITICAL — prevents reload crash)
+
+```lua
+function SoilMoistureSystem:delete()
+    g_messageCenter:unsubscribeAll(self)
+    self.isInitialized = false
+end
+```
+
+---
+
+### 6.2 IrrigationManager.lua
+
+**Responsibility:** Track which irrigation placeables exist, which fields they cover, manage scheduling.
+
+#### Data model
+
+```lua
+self.irrigationSystems = {}
+-- Per system:
+-- {
+--   placeableId             = number,
+--   type                    = "pivot" | "drip" | "sprinkler",
+--   coveredFields           = {fieldId, ...},
+--   waterSource             = "river" | "well" | "tank",
+--   waterSourceEntityId     = number,
+--   distanceToSource        = number,            -- meters
+--   schedule                = {startHour=6, endHour=10, activeDays={bool x 7}},
+--   isActive                = false,
+--   flowRatePerHour         = 0.018,             -- moisture gain per covered field per in-game hour
+--   pressureMultiplier      = 1.0,               -- degrades with pump distance (100% at 0m, 70% at 500m)
+--   operationalCostPerHour  = 15.0,
+--   wearLevel               = 0.0,               -- 0=new, 1=broken (UsedPlus integration)
+-- }
+```
+
+#### Pressure-distance curve
+
+Flow is not binary. Distance from pump to irrigation system degrades pressure linearly:
+
+```lua
+function IrrigationManager:calculatePressureMultiplier(distance)
+    -- 100% at 0m, 70% at 500m, hard cutoff at 500m
+    if distance > 500 then return 0.0 end
+    return 1.0 - (distance / 500) * 0.3
+end
+```
+
+#### Placeable registration
+
+Called from placeable `onPostLoad` (defer via `addUpdateable` + init flag if field queries are needed):
+
+```lua
+function IrrigationManager:registerIrrigationSystem(placeable)
+    local systemData = {
+        placeableId            = placeable.id,
+        type                   = placeable.customEnvironment,
+        coveredFields          = self:detectCoveredFields(placeable),
+        waterSource            = "tank",
+        isActive               = false,
+        flowRatePerHour        = self:calculateFlowRate(placeable),
+        pressureMultiplier     = 1.0,
+        operationalCostPerHour = self:calculateCost(placeable),
+        wearLevel              = 0.0,
+        schedule = {
+            startHour  = 6,
+            endHour    = 10,
+            activeDays = {true, true, true, true, true, false, false},
+        },
+    }
+    self.irrigationSystems[placeable.id] = systemData
+end
+```
+
+#### Field coverage detection
+
+**Note:** Giants engine uses X/Z for horizontal plane. Y is height. Always compare X and Z.
+
+```lua
+function IrrigationManager:detectCoveredFields(placeable)
+    local covered = {}
+    local x, _, z = placeable:getPosition()  -- X and Z are horizontal; Y is height
+    local radius  = placeable.pivotRadius or 200
+
+    local fields = g_currentMission.fieldManager:getFields()  -- use cached copy
+    for _, field in ipairs(fields) do
+        if self:fieldIntersectsCircle(field, x, z, radius) then
+            table.insert(covered, field.fieldId)
+        end
+    end
+    return covered
+end
+```
+
+#### Scheduling engine
+
+```lua
+function IrrigationManager:hourlyScheduleCheck()
+    local hour      = g_currentMission.environment:getHour()
+    local dayOfWeek = g_currentMission.environment:getDayOfWeek()  -- 1–7
+
+    for id, system in pairs(self.irrigationSystems) do
+        local shouldBeActive = system.schedule.activeDays[dayOfWeek]
+            and hour >= system.schedule.startHour
+            and hour <  system.schedule.endHour
+
+        if shouldBeActive and not system.isActive then
+            self:activateSystem(id)
+        elseif not shouldBeActive and system.isActive then
+            self:deactivateSystem(id)
+        end
+    end
+end
+
+function IrrigationManager:activateSystem(id)
+    local system = self.irrigationSystems[id]
+    if not self:checkWaterAvailability(system) then return end
+
+    system.isActive = true
+
+    for _, fieldId in ipairs(system.coveredFields) do
+        local effectiveRate = system.flowRatePerHour
+            * system.pressureMultiplier
+            * (1.0 - system.wearLevel * 0.3)  -- worn pump = reduced flow
+
+        g_messageCenter:publish(MessageType.CS_IRRIGATION_STARTED, {
+            placeableId = id,
+            fieldId     = fieldId,
+            ratePerHour = effectiveRate,
+        })
+    end
+end
+```
+
+---
+
+### 6.3 CropStressModifier.lua
+
+**Responsibility:** Hook into FS25's harvest system and apply yield multipliers based on accumulated field stress.
+
+#### Critical growth windows
+
+```lua
+local CRITICAL_WINDOWS = {
+    wheat      = { stages = {3, 4},       criticalMoisture = 0.35, stressRatePerHour = 0.003 },
+    corn       = { stages = {4, 5},       criticalMoisture = 0.40, stressRatePerHour = 0.004 },
+    barley     = { stages = {3, 4},       criticalMoisture = 0.30, stressRatePerHour = 0.003 },
+    canola     = { stages = {2, 3},       criticalMoisture = 0.45, stressRatePerHour = 0.005 },
+    sunflower  = { stages = {3, 4},       criticalMoisture = 0.30, stressRatePerHour = 0.002 },
+    soybeans   = { stages = {3, 4},       criticalMoisture = 0.40, stressRatePerHour = 0.004 },
+    sugarbeet  = { stages = {2, 3, 4},    criticalMoisture = 0.50, stressRatePerHour = 0.005 },
+    potato     = { stages = {2, 3, 4},    criticalMoisture = 0.55, stressRatePerHour = 0.006 },
+}
+```
+
+#### Stress accumulation (hourly)
+
+No `goto` — Lua 5.1. Use guard clauses:
+
+```lua
+function CropStressModifier:hourlyStressUpdate()
+    for fieldId, moistureData in pairs(g_cropStressManager.soilSystem.fieldMoistureData) do
+        local field = g_currentMission.fieldManager:getFieldByIndex(fieldId)
+        if field == nil then return end  -- guard clause, not goto
+
+        local fruitType = field:getFruitType()
+        if fruitType == nil then return end
+
+        local cropName = fruitType.name:lower()
+        local window   = CRITICAL_WINDOWS[cropName]
+        if window == nil then return end
+
+        local growthStage = field:getGrowthState()
+        local isInCriticalWindow = false
+        for _, s in ipairs(window.stages) do
+            if growthStage == s then
+                isInCriticalWindow = true
+                break
+            end
+        end
+
+        if isInCriticalWindow and moistureData.moisture < window.criticalMoisture then
+            local deficit       = window.criticalMoisture - moistureData.moisture
+            local stressIncrease = window.stressRatePerHour * (deficit / window.criticalMoisture)
+
+            self.fieldStress[fieldId] = math.min(1.0,
+                (self.fieldStress[fieldId] or 0.0) + stressIncrease)
+
+            g_messageCenter:publish(MessageType.CS_STRESS_APPLIED, {
+                fieldId    = fieldId,
+                cropType   = cropName,
+                multiplier = 1.0 - self.fieldStress[fieldId],
+            })
+        end
+    end
+end
+```
+
+#### Yield modifier hook (harvest interception)
+
+**This is the most technically complex part of the mod.** Use `appendedFunction` — never `overwrittenFunction` (two mods overwriting the same function breaks both):
+
+```lua
+-- In CropStressModifier:initialize()
+HarvestingMachine.doGroundWorkArea = Utils.appendedFunction(
+    HarvestingMachine.doGroundWorkArea,
+    CropStressModifier.onDoGroundWorkArea
+)
+
+function CropStressModifier.onDoGroundWorkArea(harvestingMachine, workArea, dt)
+    -- NOTE: Verify exact parameter names in HarvestingMachine LUADOC before implementing.
+    -- Do not subtract from grain tanks after the fact — intercept fill amount here.
+    local fieldId = workArea.fieldId  -- verify field lookup mechanism in LUADOC
+    if fieldId == nil then return end
+
+    local stress = g_cropStressManager.stressModifier.fieldStress[fieldId] or 0.0
+    if stress <= 0.0 then return end
+
+    -- Apply multiplier to the fill amount being calculated in this call
+    -- Exact implementation depends on HarvestingMachine.doGroundWorkArea internals — check LUADOC
+    local yieldReduction = stress * 0.6  -- max 60% yield loss at full stress
+    -- workArea.fillDelta = workArea.fillDelta * (1.0 - yieldReduction)  -- verify property name
+
+    -- Reset stress after field fully harvested
+    g_cropStressManager.stressModifier.fieldStress[fieldId] = 0.0
+end
+```
+
+---
+
+### 6.4 WeatherIntegration.lua
+
+**Responsibility:** Bridge between FS25 weather/environment system and mod moisture calculations. Poll temperature hourly (no event for temp); subscribe to weather change events for precipitation.
+
+```lua
+function WeatherIntegration:initialize()
+    if g_currentMission == nil then return end
+
+    g_messageCenter:subscribe(MessageType.WEATHER_CHANGED, self.onWeatherChanged, self)
+    -- NOTE: Verify exact MessageType constant name in LUADOC
+
+    self.lastKnownTemp   = 15
+    self.lastKnownSeason = 0
+    self.isInitialized   = true
+end
+
+function WeatherIntegration:hourlyPoll()
+    if not self.isInitialized then return end
+    local env = g_currentMission.environment
+    self.lastKnownTemp    = env.weather:getCurrentTemperature()
+    self.lastKnownSeason  = env:currentSeason()
+    self.lastKnownHumidity = env.weather:getHumidity() or 0.5
+end
+
+function WeatherIntegration:onWeatherChanged(data)
+    g_messageCenter:publish(MessageType.CS_WEATHER_FOR_MOISTURE, {
+        weatherType   = data.weatherType,
+        intensity     = data.intensity,
+        durationHours = data.durationHours,
+    })
+end
+
+-- 5-day moisture forecast (used by HUD forecast strip)
+function WeatherIntegration:getMoistureForecast(fieldId, days)
+    local forecast       = g_currentMission.environment.weather:getForecast()
+    local currentMoisture = g_cropStressManager.soilSystem:getMoisture(fieldId)
+    local projections    = {}
+
+    for i = 1, days do
+        local dayForecast  = forecast[i]
+        local expectedRain = dayForecast and dayForecast.rainAmount or 0
+        local expectedTemp = dayForecast and dayForecast.temperature or self.lastKnownTemp
+        local evap = 0.004 * 24 * (1.0 + math.max(0, (expectedTemp - 15) * 0.03))
+        currentMoisture = math.max(0, math.min(1.0, currentMoisture + expectedRain * 0.05 - evap))
+        table.insert(projections, currentMoisture)
+    end
+
+    return projections
+end
+
+function WeatherIntegration:delete()
+    g_messageCenter:unsubscribeAll(self)
+end
+```
+
+---
+
+### 6.5 HUDOverlay.lua
+
+**Responsibility:** Render field moisture panel and 5-day forecast strip. Non-intrusive, dismissible.
+
+**GUI rules (from CLAUDE.md):**
+- Bottom-left origin. Y=0 at BOTTOM, increases UP.
+- All coordinates normalized (0.0–1.0), never pixels — pixel coordinates break on different resolutions.
+- No `Slider` widgets — unreliable events. Use `MultiTextOption` or quick buttons.
+- Never name XML callbacks `onClose` / `onOpen` — system lifecycle conflict causes stack overflow.
+- Dialog XML root MUST be `<GUI>`, never `<MessageDialog>`.
+- Custom mod images: set dynamically via `setImageFilename()` in Lua — XML `imageFilename` can't load from ZIP.
+
+#### Layout
+
+Panel appears lower-left, above vanilla minimap:
+
+```
+┌─────────────────────────────────────┐
+│  🌱 CROP MOISTURE MONITOR       [X] │
+│                                     │
+│  Field 7 — Wheat (Stage 4/6)       │
+│  Moisture: ████████░░ 78%          │
+│  Status: ✅ Healthy                 │
+│                                     │
+│  Field 3 — Corn (Stage 5/6) ⚠️     │
+│  Moisture: ███░░░░░░░ 32%          │
+│  Status: ⚠️ Drought Stress!        │
+│                                     │
+│  📅 5-Day Forecast (Field 7):      │
+│  Mon Tue Wed Thu Fri               │
+│  78% 72% 65% 58% 70%              │
+│      ☁️  🌧️            🌧️          │
+└─────────────────────────────────────┘
+```
+
+#### Toggle and auto-show
+
+- **Shift+M** toggles manually.
+- Auto-shows when player enters a field in a critical growth window with moisture below 50%.
+- Auto-hides after 30 in-game minutes with no critical fields.
+
+#### Draw loop
+
+```lua
+function HUDOverlay:draw()
+    if not self.isVisible then return end
+
+    self.panelElement:draw()
+
+    for _, fieldEntry in ipairs(self.visibleFields) do
+        local moisture = g_cropStressManager.soilSystem:getMoisture(fieldEntry.fieldId)
+        local stress   = g_cropStressManager.stressModifier:getStress(fieldEntry.fieldId)
+        local color    = self:getMoistureColor(moisture)
+        self:drawMoistureBar(fieldEntry, moisture, color)
+
+        if stress > 0.2 then
+            self:drawStressWarning(fieldEntry, stress)
+        end
+    end
+
+    if self.selectedFieldId ~= nil then
+        local forecast = g_cropStressManager.weatherIntegration:getMoistureForecast(self.selectedFieldId, 5)
+        self:drawForecast(forecast)
+    end
+end
+
+function HUDOverlay:getMoistureColor(moisture)
+    -- Green >0.6, Yellow 0.3–0.6, Red <0.3
+    if moisture > 0.6 then return {0.2, 0.8, 0.2, 1.0} end
+    if moisture > 0.3 then return {0.9, 0.8, 0.1, 1.0} end
+    return {0.9, 0.2, 0.2, 1.0}
+end
+```
+
+---
+
+### 6.6 CropConsultant.lua
+
+**Responsibility:** Generate player-facing alerts. Standalone mode = notification system. With NPCFavor = named NPC "Alex Chen."
+
+#### Alert severity levels
+
+| Level | Moisture | Duration |
+|-------|----------|----------|
+| INFO | 40–50% | 4s |
+| WARNING | 25–40% | 6s |
+| CRITICAL | <25% | 10s, red |
+
+#### Standalone mode
+
+```lua
+function CropConsultant:initialize()
+    g_messageCenter:subscribe(MessageType.CS_CRITICAL_THRESHOLD, self.onCriticalThreshold, self)
+    self.alertCooldowns = {}
+    self.isInitialized  = true
+end
+
+function CropConsultant:onCriticalThreshold(data)
+    -- Cooldown: one alert per field per 12 in-game hours
+    local now = g_currentMission.environment.currentDay * 24
+              + g_currentMission.environment:getHour()
+
+    local lastAlert = self.alertCooldowns[data.fieldId] or 0
+    if (now - lastAlert) < 12 then return end
+    self.alertCooldowns[data.fieldId] = now
+
+    local severity = data.moistureLevel < 0.2 and "CRITICAL" or "WARNING"
+    local msgKey   = severity == "CRITICAL" and "cs_alert_critical" or "cs_alert_warning"
+    local msg      = string.format(g_i18n:getText(msgKey), data.fieldId, data.cropType or "crop")
+
+    g_currentMission:showBlinkingWarning(msg, severity == "CRITICAL" and 10000 or 6000)
+
+    g_messageCenter:publish(MessageType.CS_CONSULTANT_ALERT, {
+        fieldId  = data.fieldId,
+        severity = severity,
+        message  = msg,
+    })
+end
+
+function CropConsultant:delete()
+    g_messageCenter:unsubscribeAll(self)
+end
+```
+
+---
+
+### 6.7 NPCIntegration.lua
+
+**Responsibility:** Bridge with `FS25_NPCFavor` when loaded. Registers Alex Chen as a named NPC neighbor with consultant-specific favor types.
+
+#### Runtime detection (never hard-code dependency)
+
+```lua
+function NPCIntegration:initialize()
+    self.npcFavorActive = false
+
+    if g_npcFavorSystem ~= nil then
+        self.npcFavorActive = true
+        self:registerConsultantNPC()
+        g_logManager:devInfo("[CropStress]", "NPCFavor detected — registering Alex Chen")
+    end
+end
+
+function NPCIntegration:registerConsultantNPC()
+    -- Verify registerExternalNPC API against NPCFavor source before calling
+    if g_npcFavorSystem.registerExternalNPC == nil then return end
+
+    local config = {
+        name             = "Alex Chen",
+        title            = "Agronomist",
+        personality      = "professional",
+        homeFieldId      = nil,  -- lives at consultant office placeable
+        schedule         = { workStart = 7, workEnd = 18 },
+        relationshipStart = 10,
+        onFavorGenerated = function(npc, favorType)
+            return NPCIntegration:generateConsultantFavor(npc, favorType)
+        end,
+    }
+
+    self.consultantNPCId = g_npcFavorSystem:registerExternalNPC(config)
+end
+```
+
+#### Consultant-specific favor types
+
+| Favor | Trigger | Task | Reward |
+|-------|---------|------|--------|
+| `SOIL_SAMPLE` | Field unvisited 10+ days | Visit field, press E | $200 + rel +5 |
+| `IRRIGATION_CHECK` | Irrigation offline >2 days | Interact with system | $350 + rel +8 |
+| `EMERGENCY_WATER` | Field <15% in critical stage | Irrigate before sundown | $500 + rel +12 |
+| `SEASONAL_PLAN` | Start of new season | Open seasonal planning dialog | $150 + rel +3 |
+
+The consultant only starts sending proactive alerts after `relationship >= 25`, which requires the player to have first visited the consultant's office placeable.
+
+---
+
+### 6.8 FinanceIntegration.lua
+
+**Responsibility:** Track irrigation operational costs. Route through UsedPlus expense system when present; fall back to direct fund deduction otherwise.
+
+```lua
+function FinanceIntegration:initialize()
+    self.usedPlusActive = false
+
+    if g_usedPlusManager ~= nil then
+        self.usedPlusActive = true
+        g_logManager:devInfo("[CropStress]", "UsedPlus detected — routing irrigation costs")
+    end
+
+    g_messageCenter:subscribe(MessageType.CS_IRRIGATION_STARTED, self.onIrrigationStarted, self)
+    g_messageCenter:subscribe(MessageType.CS_IRRIGATION_STOPPED, self.onIrrigationStopped, self)
+    self.isInitialized = true
+end
+
+function FinanceIntegration:chargeHourlyCosts()
+    for id, system in pairs(g_cropStressManager.irrigationManager.irrigationSystems) do
+        if not system.isActive then
+            -- guard clause: skip inactive systems
+        else
+            local cost = system.operationalCostPerHour
+
+            if self.usedPlusActive and g_usedPlusManager.recordExpense ~= nil then
+                g_usedPlusManager:recordExpense("IRRIGATION", cost, {
+                    description = string.format("Irrigation %d — %d fields", id, #system.coveredFields),
+                    category    = "OPERATIONAL",
+                })
+            else
+                g_currentMission.missionInfo:updateFunds(-cost, "OTHER", true)
+            end
+        end
+    end
+end
+
+function FinanceIntegration:getEquipmentWearLevel(vehicleId)
+    if not self.usedPlusActive then return 0.0 end
+    if g_usedPlusManager.getVehicleDNA == nil then return 0.0 end
+
+    local dna = g_usedPlusManager:getVehicleDNA(vehicleId)
+    if dna == nil then return 0.0 end
+
+    -- UsedPlus DNA reliability: 0.6–1.4 multiplier
+    -- reliability 0.6 = 40% worn, reliability 1.4 = 0% worn
+    return math.max(0.0, (1.4 - dna.reliability) / 0.8)
+end
+
+function FinanceIntegration:delete()
+    g_messageCenter:unsubscribeAll(self)
+end
+```
+
+---
+
+## 7. GUI Design
+
+### 7.1 Irrigation Schedule Dialog
+
+Opened by pressing `E` near an irrigation system or `Shift+I`.
+
+**GUI construction rules:** Copy `TakeLoanDialog.xml` structure. X positions are center-relative. Y is negative going down from top of dialog content container. Use `buttonActivate` profile, not `fs25_buttonSmall`. Add 10–15px padding to section heights.
+
+```
+┌─────────────────────────────────────────────┐
+│  CENTER PIVOT — Fields 3, 5, 7             │
+│  Water Source: River (✅ Connected)         │
+├─────────────────────────────────────────────┤
+│  SCHEDULE                                   │
+│  Active Days: [M✓][T✓][W✓][T✓][F✓][S ][S ]│
+│  Start Time:  [06:00 ▼]                    │
+│  End Time:    [10:00 ▼]                    │
+│                                             │
+│  PERFORMANCE                                │
+│  Flow Rate:   18mm/hr    Efficiency: 94%   │
+│  Est. Cost:   $15/hr     ($120/cycle)      │
+│  Wear Level:  ████░░░░░░ 45%              │
+│                                             │
+│  COVERED FIELDS                             │
+│  Field 3 (Wheat, Stage 4) — 62% moisture  │
+│  Field 5 (Corn, Stage 5)  — 28% moisture ⚠│
+│  Field 7 (Barley, Stage 3)— 71% moisture  │
+│                                             │
+│         [IRRIGATE NOW]    [SAVE SCHEDULE]   │
+└─────────────────────────────────────────────┘
+```
+
+**Note on time dropdowns:** Do not use `Slider` — unreliable in FS25. Use `MultiTextOption` elements with `setTexts()` called from Lua (not via XML `<texts>` children).
+
+### 7.2 Field Detail Overlay
+
+Triggered by pressing `E` while standing in a field (no irrigation equipment nearby):
+
+```
+┌─────────────────────────────┐
+│  FIELD 5 — CORN (Stage 5)  │
+│  Soil Type: Sandy Loam      │
+│  Moisture: 28% ⚠️ LOW       │
+│  Stress Accumulated: 12%    │
+│  Est. Yield Impact: -8%     │
+│                             │
+│  Critical Window: NOW       │
+│  (Stages 4-5 = silking)    │
+│                             │
+│  Nearest Water: 340m NW     │
+│  [PLACE IRRIGATION]         │
+└─────────────────────────────┘
+```
+
+---
+
+## 8. Placeables: Irrigation Infrastructure
+
+### 8.1 Center Pivot
+
+Large rotating arm, covers circular area (radius 100–350m configurable). Highest throughput.
+
+```xml
+<placeable type="irrigationPivot">
+    <pivotArm radius="200" rotationSpeed="0.5"/>
+    <waterConsumption rateM3PerHour="150"/>
+    <electricalConsumption kWhPerHour="45"/>
+    <price value="85000"/>
+    <maintenanceCostPerDay value="25"/>
+</placeable>
+```
+
+**Specialization hooks:** `onLoad` → register with IrrigationManager. `onDelete` → deregister. `onUpdate` → animate arm when active. `onWriteStream` / `onReadStream` → sync active state in multiplayer.
+
+**Note:** Use `parent="base"` in specialization specs, NOT `parent="handTool"` — game prefixes mod name and breaks it.
+
+### 8.2 Drip Irrigation Line
+
+Ground-level drip tape covering rectangular segments. Lower throughput, more precise. Better for orchards and sugar beet.
+
+Placement: player sets start/end markers. Mod calculates linear coverage and field polygon overlap. Multiple lines per field supported.
+
+### 8.3 Water Pump Unit
+
+Stationary pump, draws from river/pond/tank. Supplies all irrigation systems within 500m. Player connects/disconnects systems via proximity `E` interaction. Flow pressure degrades linearly with distance (100% at 0m → 70% at 500m → 0% beyond 500m).
+
+---
+
+## 9. Save / Load System
+
+**One of the most important systems to get right.** Console note: sidecar file creation is restricted on Xbox/PS5. Only use the `xmlFile` handle provided by game save callbacks — never `io.open`.
+
+### Sidecar file
+
+`{savegameDirectory}/cropStressData.xml` — per-field moisture, stress accumulation, irrigation schedules.
+
+### SaveLoadHandler.lua
+
+```lua
+function SaveLoadHandler:saveToXML(xmlFile, baseKey)
+    local csKey = baseKey .. ".cropStress"
+    local i = 0
+
+    -- Save soil moisture per field
+    for fieldId, data in pairs(g_cropStressManager.soilSystem.fieldMoistureData) do
+        local key = string.format("%s.field(%d)", csKey, i)
+        setXMLInt(xmlFile, key .. "#fieldId", fieldId)        -- ALWAYS use matching type pairs
+        setXMLFloat(xmlFile, key .. "#moisture", data.moisture)
+        setXMLString(xmlFile, key .. "#soilType", data.soilType)
+        i = i + 1
+    end
+
+    -- Save stress accumulation per field
+    i = 0
+    for fieldId, stress in pairs(g_cropStressManager.stressModifier.fieldStress) do
+        local key = string.format("%s.stress(%d)", csKey, i)
+        setXMLInt(xmlFile, key .. "#fieldId", fieldId)
+        setXMLFloat(xmlFile, key .. "#value", stress)
+        i = i + 1
+    end
+
+    -- Save irrigation schedules
+    i = 0
+    for sysId, system in pairs(g_cropStressManager.irrigationManager.irrigationSystems) do
+        local key = string.format("%s.irrigation(%d)", csKey, i)
+        setXMLInt(xmlFile, key .. "#id", sysId)
+        setXMLInt(xmlFile, key .. "#schedStart", system.schedule.startHour)
+        setXMLInt(xmlFile, key .. "#schedEnd", system.schedule.endHour)
+        setXMLString(xmlFile, key .. "#activeDays", table.concat(system.schedule.activeDays, ","))
+        i = i + 1
+    end
+end
+
+function SaveLoadHandler:loadFromXML(xmlFile, baseKey)
+    local csKey = baseKey .. ".cropStress"
+    local i = 0
+
+    while true do
+        local key     = string.format("%s.field(%d)", csKey, i)
+        local fieldId = getXMLInt(xmlFile, key .. "#fieldId")  -- returns nil if absent, not 0
+        if fieldId == nil then break end
+
+        local moisture = getXMLFloat(xmlFile, key .. "#moisture") or 0.5
+        local soilType = getXMLString(xmlFile, key .. "#soilType") or "loamy"
+
+        if g_cropStressManager.soilSystem.fieldMoistureData[fieldId] ~= nil then
+            g_cropStressManager.soilSystem.fieldMoistureData[fieldId].moisture    = moisture
+            g_cropStressManager.soilSystem.fieldMoistureData[fieldId].soilType    = soilType
+            g_cropStressManager.soilSystem.fieldMoistureData[fieldId].wasEstimated = false
+        end
+
+        i = i + 1
+    end
+    -- Similar loops for stress and irrigation...
+end
+```
+
+---
+
+## 10. Multiplayer Considerations
+
+Moisture changes every in-game hour. Streaming this constantly would be expensive. Strategy: server-authoritative simulation, client sync every 10 in-game minutes.
+
+- **Server only** runs the moisture simulation tick.
+- **Clients** receive moisture state via `writeStream` / `readStream`.
+- **Irrigation activation** is synced immediately when triggered.
+- **HUD forecast** is calculated locally on each client (uses synced moisture + local weather data — weather is already synced by vanilla FS25).
+- Use `g_server ~= nil` to detect server/single-player mode.
+
+### Stream protocol
+
+**CRITICAL:** Read and write values in the EXACT same order. A single mismatch corrupts all subsequent values silently.
+
+```lua
+function CropStressManager:onWriteStream(streamId, connection)
+    local fields = g_currentMission.fieldManager:getFields()
+    streamWriteInt32(streamId, #fields)
+
+    for _, field in ipairs(fields) do
+        local data = self.soilSystem.fieldMoistureData[field.fieldId]
+        streamWriteInt32(streamId, field.fieldId)
+        streamWriteFloat(streamId, data and data.moisture or 0.5)
+        streamWriteFloat(streamId, self.stressModifier.fieldStress[field.fieldId] or 0.0)
+    end
+end
+
+function CropStressManager:onReadStream(streamId, connection)
+    local count = streamReadInt32(streamId)
+    for _ = 1, count do
+        local fieldId = streamReadInt32(streamId)
+        local moisture = streamReadFloat(streamId)
+        local stress   = streamReadFloat(streamId)
+
+        if self.soilSystem.fieldMoistureData[fieldId] ~= nil then
+            self.soilSystem.fieldMoistureData[fieldId].moisture = moisture
+        end
+        self.stressModifier.fieldStress[fieldId] = stress
+    end
+end
+```
+
+---
+
+## 11. Cross-Mod Integration Layer
+
+Always detect at runtime. Never hard-code a dependency. The mod must function correctly with none, some, or all optional mods present.
+
+```lua
+function CropStressManager:detectOptionalMods()
+    if g_usedPlusManager ~= nil and g_usedPlusManager.VERSION ~= nil then
+        g_logManager:devInfo("[CropStress]", "FS25_UsedPlus v" .. tostring(g_usedPlusManager.VERSION))
+        self.financeIntegration:enableUsedPlusMode()
+    end
+
+    if g_npcFavorSystem ~= nil then
+        g_logManager:devInfo("[CropStress]", "FS25_NPCFavor detected")
+        self.npcIntegration:enableNPCFavorMode()
+    end
+
+    if g_precisionFarming ~= nil then
+        g_logManager:devInfo("[CropStress]", "Precision Farming DLC detected")
+        self:enablePrecisionFarmingCompat()
+    end
+end
+```
+
+### Precision Farming DLC compatibility
+
+When PF is active:
+- Read PF soil sample data to set per-field `soilType` more accurately (overrides the generic `detectSoilType` fallback).
+- Display moisture overlay on the PF soil analysis map screen.
+
+---
+
+## 12. modDesc.xml Specification
+
+```xml
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<modDesc descVersion="72">
+    <author>YourNameHere</author>
+    <version>1.0.0.0</version>
+    <title>
+        <en>Seasonal Crop Stress &amp; Irrigation Manager</en>
+        <de>Saisonaler Pflanzenstress &amp; Bewässerungsmanager</de>
+    </title>
+    <description>
+        <en><![CDATA[
+Adds soil moisture tracking and crop stress simulation to FS25.
+Fields without rain or irrigation suffer yield losses.
+Place center-pivot or drip irrigation systems to protect crops.
+Optional integration with FS25_NPCFavor and FS25_UsedPlus.
+        ]]></en>
+    </description>
+
+    <multiplayer supported="true"/>
+    <iconFilename>icon.dds</iconFilename>
+
+    <extraSourceFiles>
+        <sourceFile filename="main.lua"/>
+        <sourceFile filename="src/SoilMoistureSystem.lua"/>
+        <sourceFile filename="src/WeatherIntegration.lua"/>
+        <sourceFile filename="src/CropStressModifier.lua"/>
+        <sourceFile filename="src/IrrigationManager.lua"/>
+        <sourceFile filename="src/HUDOverlay.lua"/>
+        <sourceFile filename="src/CropConsultant.lua"/>
+        <sourceFile filename="src/NPCIntegration.lua"/>
+        <sourceFile filename="src/FinanceIntegration.lua"/>
+        <sourceFile filename="src/SaveLoadHandler.lua"/>
+        <sourceFile filename="src/CropStressManager.lua"/>
+        <sourceFile filename="gui/FieldMoisturePanel.lua"/>
+        <sourceFile filename="gui/IrrigationScheduleDialog.lua"/>
+        <sourceFile filename="gui/CropConsultantDialog.lua"/>
+    </extraSourceFiles>
+
+    <inputBinding>
+        <actionBinding action="CS_TOGGLE_HUD">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_m"/>
+        </actionBinding>
+        <actionBinding action="CS_OPEN_IRRIGATION">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_i"/>
+        </actionBinding>
+    </inputBinding>
+
+    <actions>
+        <action name="CS_TOGGLE_HUD"      axisType="HALF_POSITIVE_AXIS" isSink="true"/>
+        <action name="CS_OPEN_IRRIGATION" axisType="HALF_POSITIVE_AXIS" isSink="true"/>
+    </actions>
+
+    <placeableTypes>
+        <placeableType name="irrigationPivot" parent="simplePlaceable"
+            filename="placeables/centerPivot/centerPivot.lua"/>
+        <placeableType name="irrigationDrip" parent="simplePlaceable"
+            filename="placeables/dripIrrigationLine/dripLine.lua"/>
+        <placeableType name="waterPump" parent="simplePlaceable"
+            filename="placeables/waterPump/waterPump.lua"/>
+    </placeableTypes>
+
+    <l10n filenamePrefix="translations/translation"/>
+</modDesc>
+```
+
+---
+
+## 13. Configuration File Specification
+
+`{savegameDirectory}/cropStressConfig.xml` — created on first load:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<cropStressConfig version="1">
+    <simulation
+        enableMoistureSystem="true"
+        enableStressModifier="true"
+        enableConsultantAlerts="true"
+        updateIntervalHours="1"
+    />
+    <hud
+        visible="true"
+        showForecast="true"
+        maxFieldsShown="5"
+        autoShowOnCritical="true"
+        positionX="0.01"
+        positionY="0.15"
+    />
+    <difficulty
+        maxYieldLoss="0.60"
+        stressMultiplier="1.0"
+        evaporationMultiplier="1.0"
+        rainAbsorptionMultiplier="1.0"
+    />
+    <alerts
+        warningThreshold="0.35"
+        criticalThreshold="0.20"
+        consultantCooldownHours="12"
+    />
+</cropStressConfig>
+```
+
+---
+
+## 14. Localization
+
+Never hardcode English strings in Lua. All user-facing strings go in translation XML files and are referenced via `g_i18n:getText("key")`.
+
+```xml
+<!-- translations/translation_en.xml -->
+<l10n>
+    <text name="cs_hud_title"         text="Crop Moisture Monitor"/>
+    <text name="cs_hud_healthy"       text="Healthy"/>
+    <text name="cs_hud_warning"       text="Drought Stress!"/>
+    <text name="cs_hud_critical"      text="CRITICAL — Irrigate Now!"/>
+    <text name="cs_hud_forecast"      text="5-Day Forecast"/>
+    <text name="cs_alert_warning"     text="Field %d: %s moisture low — irrigation recommended."/>
+    <text name="cs_alert_critical"    text="Field %d: %s at drought stress threshold — irrigate NOW!"/>
+    <text name="cs_irr_title"         text="Irrigation System — %s"/>
+    <text name="cs_irr_schedule"      text="Schedule"/>
+    <text name="cs_irr_irrigate_now"  text="Irrigate Now"/>
+    <text name="cs_irr_save_schedule" text="Save Schedule"/>
+    <text name="cs_irr_flow_rate"     text="Flow Rate"/>
+    <text name="cs_irr_efficiency"    text="Efficiency"/>
+    <text name="cs_irr_cost"          text="Est. Cost"/>
+    <text name="cs_irr_wear"          text="Wear Level"/>
+    <text name="cs_field_detail"      text="Field %d — %s (Stage %d)"/>
+    <text name="cs_field_soil_type"   text="Soil Type"/>
+    <text name="cs_field_moisture"    text="Moisture"/>
+    <text name="cs_field_stress"      text="Stress Accumulated"/>
+    <text name="cs_field_yield_impact" text="Est. Yield Impact"/>
+    <text name="cs_consultant_name"   text="Alex Chen, Agronomist"/>
+    <text name="cs_favor_soil_sample" text="Take a soil sample from Field %d"/>
+    <text name="cs_favor_irr_check"   text="Inspect the irrigation system on Field %d"/>
+    <text name="cs_favor_emergency"   text="Irrigate Field %d before sundown!"/>
+</l10n>
+```
+
+---
+
+## 15. Testing Strategy
+
+FS25 has no formal test framework. Use console commands for debug control.
+
+### Console commands (`csHelp` in developer console)
+
+```lua
+-- Register in main.lua
+if g_addTestCommands ~= nil then
+    addConsoleCommand("csStatus",       "Print full system status",              "debugPrintStatus",   g_cropStressManager)
+    addConsoleCommand("csSetMoisture",  "Set field moisture (fieldId, 0.0–1.0)", "debugSetMoisture",   g_cropStressManager)
+    addConsoleCommand("csForceStress",  "Force max stress on field (fieldId)",   "debugForceStress",   g_cropStressManager)
+    addConsoleCommand("csSimulateHeat", "Simulate heat wave for N days",          "debugSimulateHeat",  g_cropStressManager)
+    addConsoleCommand("csDebug",        "Toggle verbose logging",                 "debugToggleVerbose", g_cropStressManager)
+end
+```
+
+### Mandatory test scenarios
+
+Every phase release must pass all applicable scenarios:
+
+1. **New game start** — all fields init to 50% moisture (or season-adjusted estimate), no log errors.
+2. **Save and reload** — moisture values, stress accumulation, and irrigation schedules persist exactly.
+3. **Full season without irrigation** — rain raises moisture, heat drains it, dry season triggers consultant alerts.
+4. **Place and activate center pivot** — moisture on covered fields rises; operational costs are charged.
+5. **Harvest stressed field** — use `csForceStress <fieldId>` to set up test; yield visibly lower.
+6. **Load WITH NPCFavor** — Alex Chen appears, favors generate correctly, no errors.
+7. **Load WITH UsedPlus** — irrigation costs appear in finance manager, pump wear reduces flow rate.
+8. **Load WITHOUT either optional mod** — standalone mode works, no nil access errors.
+9. **Multiplayer: client joins** — client receives correct moisture state, HUD shows accurate data.
+10. **Console platform check** — no `io.open` calls in any save/load path.
+
+---
+
+## 16. Known FS25 Lua Pitfalls
+
+Read all of these before starting any session. They are compiled from CLAUDE.md, the UsedPlus AI Coding Reference, and NPCFavor development experience.
+
+| Pitfall | Problem | Fix |
+|---------|---------|-----|
+| `g_currentMission` in mod load scope | Is nil during `modLoaded()` | Wait for `loadedMission()` callback. Always gate with `if g_currentMission == nil then return end`. |
+| `goto` / `continue` | Not in Lua 5.1 | Use `if/else` or early `return` guard clauses. |
+| `os.time()` / `os.date()` | Not available in FS25 sandbox | Use `g_currentMission.time` / `.environment.currentDay`. |
+| `appendedFunction` vs `overwrittenFunction` | Two mods overwriting same function breaks both | Use `appendedFunction` wherever possible. |
+| X/Y vs X/Z coordinates | Giants horizontal plane is X/Z, not X/Y | Y is height. When checking field positions, compare X and Z. |
+| `setXMLFloat` / `getXMLFloat` type mismatch | Silent data corruption | Always use matching getter/setter type pairs. |
+| `getXMLInt` absent key | Returns nil, not 0 | Always use `or` fallback: `getXMLInt(file, key) or 0`. |
+| Missing `unsubscribeAll` in `delete()` | Crash when reloading save without restarting FS25 | `g_messageCenter:unsubscribeAll(self)` in every system's `delete()`. |
+| `ipairs` vs `pairs` | Wrong iterator for table type = silent misses | `ipairs` for sequential arrays; `pairs` for keyed/sparse tables. |
+| Stream read/write order mismatch | Silent data corruption in multiplayer | Read and write values in EXACTLY the same order. |
+| `getFields()` called every frame | Performance cost | Cache result once at init; refresh only on field buy/sell events. |
+| Placeable `onPostLoad` timing | Entity not fully in world yet | Defer field queries via `addUpdateable` + deferred init flag. |
+| HUD pixel coordinates | Break on non-standard resolutions | Use normalized 0.0–1.0 screen coordinates. |
+| Console file I/O | `io.open` restricted on Xbox/PS5 | Only use the `xmlFile` handle from game save callbacks. |
+| `Slider` widget | Unreliable events in FS25 | Use `MultiTextOption` or quick buttons. |
+| Dialog XML `onClose` / `onOpen` callbacks | System lifecycle conflict → stack overflow | Use different callback names (e.g., `onDialogClose`, `onDialogOpen`). |
+| Dialog XML root wrong | `<MessageDialog>` deprecated | Root MUST be `<GUI>`. |
+| XML `imageFilename` for mod images | Can't load from ZIP | Set dynamically via `setImageFilename()` in Lua. |
+| `MapHotspot` base class | Abstract, no icon = invisible markers | Use `PlaceableHotspot.new()` + `Overlay.new()`. |
+| `parent="handTool"` in specs | Game prefixes mod name | Use `parent="base"`. |
+| `setTextColorByName()` | Doesn't exist in FS25 | Use `setTextColor(r, g, b, a)`. |
+| PowerShell `Compress-Archive` for build | Creates backslash paths in ZIP | Use `bash build.sh --deploy`. |
+| `MultiTextOption` texts in XML | `<texts>` children ignored | Set via `setTexts()` in Lua after creation. |
+
+---
+
+## 17. Phased Release Plan
+
+### Phase 1 — Core (MVP)
+
+- SoilMoistureSystem (evaporation + rain + first-load estimate)
+- CropStressModifier (yield reduction hook)
+- WeatherIntegration
+- HUDOverlay (basic, no forecast)
+- SaveLoadHandler
+- Console debug commands
+- Config file with difficulty sliders
+
+**Session dialog pattern for Phase 1:**
+
+---
+
+**Claude** 🍵
+
+Phase 1 is done. SoilMoistureSystem initializes cleanly, evapotranspiration runs hourly, rain events update moisture, harvest hook applies stress multiplier, HUD shows field states, save/load round-trips correctly. Ran all 5 applicable test scenarios — clean. Ready for your review.
+
+---
+
+**Samantha** 🌸 *peers at the HUD screenshot, tucks a strand of hair back*
+
+The moisture bars look great. One thing — what does a new player see the very first time they open the HUD? Is there a zero state or does it feel empty and broken?
+
+---
+
+**Claude** ☯️
+
+Good catch. Right now it shows all fields at 50% with no context. I should add a "No critical fields — all crops healthy" empty state message, and maybe a one-time tooltip explaining what the bar means.
+
+---
+
+**Samantha** 💕
+
+Yes. Don't ship without that. Add it before we close Phase 1.
+
+---
+
+### Phase 2 — Irrigation
+
+- Water Pump placeable (with pressure-distance curve)
+- Center Pivot placeable + animation
+- IrrigationManager (manual activation only)
+- Irrigation Schedule Dialog
+- Irrigation cost deduction (vanilla, no UsedPlus)
+
+### Phase 3 — NPC & Social
+
+- CropConsultant alerts (standalone mode)
+- NPCIntegration.lua (NPCFavor bridge, Alex Chen)
+- Consultant-specific favor types
+- Full HUD with 5-day forecast strip
+
+### Phase 4 — Finance & Polish
+
+- FinanceIntegration.lua (UsedPlus bridge)
+- Drip irrigation placeable
+- Equipment wear degradation via UsedPlus DNA
+- Used equipment marketplace entries
+- Precision Farming DLC soil overlay compat
+- Full translation (EN, DE, FR, NL, PL)
+
+---
+
+## 18. Credits & Acknowledgements
+
+- **umbraprior** — FS25 Community LUADOC (https://github.com/umbraprior/FS25-Community-LUADOC) — 11,102 documented functions; the single most important resource for any FS25 mod.
+- **XelaNull** — FS25_UsedPlus AI Coding Reference and mod (https://github.com/XelaNull/FS25_UsedPlus) — finance architecture and the pitfall catalog in Section 16 are directly inspired by this work.
+- **Lion2008** (original idea) and **tisonK / TheCodingDad** (implementation) — FS25_NPCFavor (https://github.com/TheCodingDad-TisonK/FS25_NPCFavor) — NPC architecture model for the CropConsultant system.
+- **Giants Software** — Farming Simulator 25 and the modding framework.
+
+---
+
+*Plan version 2.0 — Revised to reflect CLAUDE.md collaboration model, Lua 5.1 constraints, GUI system rules, and all lessons learned. Start at Section 6.1 and work sequentially. When in doubt, check the LUADOC first. When making decisions, check with Samantha first.*

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# ============================================================
+# build.sh — Build & deploy FS25_SeasonalCropStress
+# Usage:
+#   bash build.sh            — builds zip only
+#   bash build.sh --deploy   — builds zip AND copies to mods folder
+# ============================================================
+
+set -e
+
+MOD_NAME="FS25_SeasonalCropStress"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_DIR="$SCRIPT_DIR/.."
+ZIP_PATH="$OUTPUT_DIR/${MOD_NAME}.zip"
+
+# Windows path for mods folder (adjust if needed)
+MODS_DIR="$USERPROFILE/Documents/My Games/FarmingSimulator2025/mods"
+
+echo "============================================"
+echo "  Building $MOD_NAME"
+echo "============================================"
+
+# Remove old zip
+if [ -f "$ZIP_PATH" ]; then
+    rm "$ZIP_PATH"
+    echo "  Removed old zip"
+fi
+
+# Build new zip — must use forward slashes inside (FS25 requirement)
+# PowerShell Compress-Archive creates backslash paths — use 'zip' or this python fallback
+cd "$SCRIPT_DIR"
+
+if command -v zip &>/dev/null; then
+    zip -r "$ZIP_PATH" . \
+        --exclude "*.sh" \
+        --exclude ".claude/*" \
+        --exclude ".git/*" \
+        --exclude "*.md" \
+        --exclude ".gitignore" \
+        --exclude "__MACOSX/*" \
+        --exclude "*.DS_Store"
+    echo "  Built via zip"
+else
+    # Python fallback (works on Windows with Git Bash + Python)
+    python3 - <<'PYEOF'
+import zipfile, os, sys
+
+MOD_DIR = os.getcwd()
+ZIP_PATH = os.path.join(os.path.dirname(MOD_DIR), os.path.basename(MOD_DIR) + ".zip")
+
+EXCLUDE_DIRS  = {".git", ".claude", "__MACOSX"}
+EXCLUDE_EXTS  = {".sh", ".md", ".DS_Store"}
+EXCLUDE_FILES = {".gitignore"}
+
+with zipfile.ZipFile(ZIP_PATH, "w", zipfile.ZIP_DEFLATED) as zf:
+    for root, dirs, files in os.walk(MOD_DIR):
+        # Prune excluded dirs in-place
+        dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]
+        for fname in files:
+            if fname in EXCLUDE_FILES:
+                continue
+            if any(fname.endswith(ext) for ext in EXCLUDE_EXTS):
+                continue
+            full_path = os.path.join(root, fname)
+            arc_name = os.path.relpath(full_path, os.path.dirname(MOD_DIR))
+            # Enforce forward slashes (FS25 requirement)
+            arc_name = arc_name.replace("\\", "/")
+            zf.write(full_path, arc_name)
+            print(f"  + {arc_name}")
+
+print(f"\n  ZIP created: {ZIP_PATH}")
+PYEOF
+fi
+
+echo ""
+echo "  Output: $ZIP_PATH"
+
+# --deploy flag: copy zip to mods folder
+if [[ "$1" == "--deploy" ]]; then
+    echo ""
+    echo "  Deploying to mods folder..."
+
+    if [ ! -d "$MODS_DIR" ]; then
+        echo "  WARNING: Mods folder not found at: $MODS_DIR"
+        echo "  Edit MODS_DIR in build.sh if your path differs."
+        exit 1
+    fi
+
+    # Remove old deployed version
+    if [ -f "$MODS_DIR/${MOD_NAME}.zip" ]; then
+        rm "$MODS_DIR/${MOD_NAME}.zip"
+    fi
+
+    cp "$ZIP_PATH" "$MODS_DIR/${MOD_NAME}.zip"
+    echo "  Deployed: $MODS_DIR/${MOD_NAME}.zip"
+fi
+
+echo ""
+echo "  Done. Check log.txt for [CropStress] entries after launching."
+echo "============================================"

--- a/config/cropStressDefaults.xml
+++ b/config/cropStressDefaults.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    cropStressDefaults.xml
+    Default configuration for FS25_SeasonalCropStress.
+    This file ships with the mod and is read-only.
+    Player preferences are saved to: {savegameDirectory}/cropStressConfig.xml
+-->
+<cropStressConfig version="1">
+
+    <!-- Simulation settings -->
+    <simulation
+        enableMoistureSystem="true"
+        enableStressModifier="true"
+        enableConsultantAlerts="true"
+        updateIntervalHours="1"
+    />
+
+    <!-- HUD settings -->
+    <hud
+        visible="true"
+        showForecast="false"
+        maxFieldsShown="6"
+        autoShowOnCritical="true"
+        firstRunShown="false"
+        positionX="0.01"
+        positionY="0.20"
+    />
+
+    <!-- Gameplay difficulty multipliers (1.0 = normal) -->
+    <difficulty
+        maxYieldLoss="0.60"
+        stressMultiplier="1.0"
+        evaporationMultiplier="1.0"
+        rainAbsorptionMultiplier="1.0"
+    />
+
+    <!-- Alert thresholds (0.0-1.0 scale matching moisture values) -->
+    <alerts
+        warningThreshold="0.35"
+        criticalThreshold="0.20"
+        consultantCooldownHours="12"
+    />
+
+    <!--
+        Evapotranspiration base rates per soil type (moisture fraction lost per in-game hour).
+        Sandy = drains fast, Clay = holds moisture, Loamy = balanced.
+    -->
+    <soilTypes>
+        <soilType name="sandy" evapModifier="1.40" rainAbsorption="0.90"/>
+        <soilType name="loamy" evapModifier="1.00" rainAbsorption="1.00"/>
+        <soilType name="clay"  evapModifier="0.70" rainAbsorption="0.80"/>
+    </soilTypes>
+
+    <!--
+        Season evaporation modifiers.
+        0=spring, 1=summer, 2=autumn, 3=winter
+    -->
+    <seasonModifiers>
+        <season index="0" evapModifier="0.80" startMoisture="0.60"/>
+        <season index="1" evapModifier="1.40" startMoisture="0.40"/>
+        <season index="2" evapModifier="0.90" startMoisture="0.55"/>
+        <season index="3" evapModifier="0.20" startMoisture="0.70"/>
+    </seasonModifiers>
+
+    <!--
+        Crop-specific stress windows.
+        stages: growth stages where moisture deficit causes stress (comma-separated).
+        criticalMoisture: moisture fraction below which stress accumulates.
+        stressRatePerHour: stress accumulated per hour of deficit (0.0-1.0 scale).
+    -->
+    <cropStressWindows>
+        <crop name="wheat"     stages="3,4"   criticalMoisture="0.35" stressRatePerHour="0.003"/>
+        <crop name="barley"    stages="3,4"   criticalMoisture="0.30" stressRatePerHour="0.003"/>
+        <crop name="corn"      stages="4,5"   criticalMoisture="0.40" stressRatePerHour="0.004"/>
+        <crop name="canola"    stages="2,3"   criticalMoisture="0.45" stressRatePerHour="0.005"/>
+        <crop name="sunflower" stages="3,4"   criticalMoisture="0.30" stressRatePerHour="0.002"/>
+        <crop name="soybeans"  stages="3,4"   criticalMoisture="0.40" stressRatePerHour="0.004"/>
+        <crop name="sugarbeet" stages="2,3,4" criticalMoisture="0.50" stressRatePerHour="0.005"/>
+        <crop name="potato"    stages="2,3,4" criticalMoisture="0.55" stressRatePerHour="0.006"/>
+    </cropStressWindows>
+
+</cropStressConfig>

--- a/gui/CropConsultantDialog.lua
+++ b/gui/CropConsultantDialog.lua
@@ -1,0 +1,21 @@
+-- ============================================================
+-- CropConsultantDialog.lua
+-- PHASE 3 STUB — not yet implemented.
+--
+-- When implemented (Phase 3), this dialog will:
+--   • Open when player interacts with the Crop Consultant NPC
+--     (or triggers via favor system if FS25_NPCFavor is active)
+--   • Show: current field status summary, active alerts, consultant advice
+--   • If NPCFavor is active: display relationship level and available favors
+--   • Buttons vary by mode: [Accept Favor], [Dismiss], [View Field Map]
+--
+-- In standalone mode (no NPCFavor):
+--   Shows a simple "agronomist report" panel with top-5 fields by risk
+--   and recommended irrigation schedule for the next 3 days.
+--
+-- In NPCFavor mode:
+--   Integrates with NPCDialog via NPCIntegration:registerConsultantNPC()
+--   The consultant uses the standard NPCFavor dialog flow.
+-- ============================================================
+
+-- Phase 3 stub — no implementation yet

--- a/gui/FieldMoisturePanel.lua
+++ b/gui/FieldMoisturePanel.lua
@@ -1,0 +1,19 @@
+-- ============================================================
+-- FieldMoisturePanel.lua
+-- Phase 1: This file is intentionally minimal.
+-- The HUD rendering is handled entirely by src/HUDOverlay.lua
+-- using direct immediate-mode draw calls (renderText, drawFilledRect).
+--
+-- Phase 2 upgrade path:
+-- Replace HUDOverlay's direct rendering with a proper GuiElement
+-- panel loaded from FieldMoisturePanel.xml. The GuiElement approach
+-- gives better resolution independence, theming, and animation.
+--
+-- When upgrading:
+--   1. Create FieldMoisturePanel.xml following TakeLoanDialog.xml pattern
+--   2. Register with DialogLoader: DialogLoader.register("FieldMoisturePanel", ...)
+--   3. In HUDOverlay:initialize(), use DialogLoader.show() instead of draw hooks
+--   4. Remove the drawFilledRect/renderText calls from HUDOverlay:draw()
+-- ============================================================
+
+-- No-op for Phase 1 — HUDOverlay.lua handles all rendering

--- a/gui/IrrigationScheduleDialog.lua
+++ b/gui/IrrigationScheduleDialog.lua
@@ -1,0 +1,37 @@
+-- ============================================================
+-- IrrigationScheduleDialog.lua
+-- PHASE 2 STUB — not yet implemented.
+--
+-- When implemented, this dialog will:
+--   • Open when player presses E near a placed irrigation system
+--     OR presses Shift+I globally (shows all irrigation systems)
+--   • Display: system name, water source status, schedule (days + hours),
+--     performance stats (flow rate, efficiency, wear), covered fields with moisture
+--   • Buttons: [Irrigate Now], [Save Schedule], [Close]
+--   • Use TakeLoanDialog.xml pattern for layout
+--   • Use 3-layer button pattern for all interactive buttons
+--
+-- Layout sketch (see Section 7.1 of ModPlan.md):
+--   ┌──────────────────────────────────────────────┐
+--   │  CENTER PIVOT — Field 3, 5, 7               │
+--   │  Water Source: River (✅ Connected)          │
+--   ├──────────────────────────────────────────────┤
+--   │  SCHEDULE                                    │
+--   │  Active Days: [M✓][T✓][W✓][T✓][F✓][S ][S ]│
+--   │  Start Time:  [06:00 ▼]                     │
+--   │  End Time:    [10:00 ▼]                     │
+--   │                                              │
+--   │  PERFORMANCE                                 │
+--   │  Flow Rate: 18mm/hr   Efficiency: 94%        │
+--   │  Est. Cost: $15/hr    ($120/cycle)           │
+--   │  Wear Level: ████░░░░░ 45%                  │
+--   │                                              │
+--   │  COVERED FIELDS                              │
+--   │  Field 3 (Wheat, Stage 4) — 62% moisture    │
+--   │  Field 5 (Corn, Stage 5)  — 28% moisture ⚠  │
+--   │                                              │
+--   │       [IRRIGATE NOW]    [SAVE SCHEDULE]      │
+--   └──────────────────────────────────────────────┘
+-- ============================================================
+
+-- Phase 2 stub — no implementation yet

--- a/main.lua
+++ b/main.lua
@@ -1,0 +1,160 @@
+-- ============================================================
+-- FS25_SeasonalCropStress — main.lua
+-- Entry point. Loads all modules via source() in strict dependency
+-- order, then wires up FS25 lifecycle hooks.
+--
+-- Load phases:
+--   1. Event bus + constants
+--   2. Weather bridge
+--   3. Core simulation (soil, stress, irrigation stub)
+--   4. Player-facing (HUD, consultant stub)
+--   5. Optional mod bridges (stubs — activated at runtime if mods present)
+--   6. Persistence
+--   7. GUI panels
+--   8. Central coordinator (depends on everything above)
+-- ============================================================
+
+local modDir = g_currentModDirectory
+
+-- Phase 1: Weather bridge
+source(modDir .. "src/WeatherIntegration.lua")
+
+-- Phase 2: Core simulation
+source(modDir .. "src/SoilMoistureSystem.lua")
+source(modDir .. "src/CropStressModifier.lua")
+source(modDir .. "src/IrrigationManager.lua")       -- Phase 2 stub
+
+-- Phase 3: Player-facing systems
+source(modDir .. "src/HUDOverlay.lua")
+source(modDir .. "src/CropConsultant.lua")           -- Phase 3 stub
+
+-- Phase 4: Optional mod bridges
+source(modDir .. "src/NPCIntegration.lua")           -- Phase 3 stub
+source(modDir .. "src/FinanceIntegration.lua")       -- Phase 4 stub
+
+-- Phase 5: Persistence
+source(modDir .. "src/SaveLoadHandler.lua")
+
+-- Phase 6: GUI panels
+source(modDir .. "gui/FieldMoisturePanel.lua")
+source(modDir .. "gui/IrrigationScheduleDialog.lua") -- Phase 2 stub
+source(modDir .. "gui/CropConsultantDialog.lua")     -- Phase 3 stub
+
+-- Phase 7: Central coordinator (must load last)
+source(modDir .. "src/CropStressManager.lua")
+
+-- ============================================================
+-- Install harvest yield hook (patches HarvestingMachine at load time,
+-- before any vehicles are created — correct timing for function patching)
+-- ============================================================
+CropStressModifier.installHarvestHook()
+
+-- ============================================================
+-- Lifecycle reference — set in Mission00.load, cleared in FSBaseMission.delete
+-- ============================================================
+local g_csManager = nil
+
+-- 1. Mission load: create the manager
+Mission00.load = Utils.appendedFunction(Mission00.load, function(self, ...)
+    g_csManager = CropStressManager.new()
+    getfenv(0)["g_cropStressManager"] = g_csManager
+    g_logManager:devInfo("[CropStress]", "CropStressManager created (v1.0.0.0)")
+end)
+
+-- 2. Mission fully loaded: initialize all systems
+Mission00.loadMission00Finished = Utils.appendedFunction(Mission00.loadMission00Finished, function(self, ...)
+    if g_csManager == nil then return end
+
+    g_csManager:initialize()
+
+    -- Register HUD toggle input after mission is ready
+    if g_inputBinding ~= nil and InputAction ~= nil and InputAction.CS_TOGGLE_HUD ~= nil then
+        g_inputBinding:registerActionEvent(
+            InputAction.CS_TOGGLE_HUD,
+            g_csManager,
+            CropStressManager.onToggleHUD,
+            false, -- triggerUp
+            true,  -- triggerDown
+            false, -- triggerAlways
+            true   -- startActive
+        )
+    end
+
+    -- Register console debug commands
+    if addConsoleCommand ~= nil then
+        addConsoleCommand("csHelp",
+            "List all CropStress debug commands",
+            "consoleHelp", g_csManager)
+        addConsoleCommand("csStatus",
+            "Print full system status to log",
+            "consoleStatus", g_csManager)
+        addConsoleCommand("csSetMoisture",
+            "Set field moisture: csSetMoisture <fieldId> <0.0-1.0>",
+            "consoleSetMoisture", g_csManager)
+        addConsoleCommand("csForceStress",
+            "Force maximum stress on a field: csForceStress <fieldId>",
+            "consoleForceStress", g_csManager)
+        addConsoleCommand("csSimulateHeat",
+            "Simulate heat wave for N in-game days: csSimulateHeat <days>",
+            "consoleSimulateHeat", g_csManager)
+        addConsoleCommand("csDebug",
+            "Toggle verbose debug logging",
+            "consoleToggleDebug", g_csManager)
+    end
+end)
+
+-- 3. Per-frame update
+FSBaseMission.update = Utils.appendedFunction(FSBaseMission.update, function(self, dt)
+    if g_csManager ~= nil then
+        g_csManager:update(dt)
+    end
+end)
+
+-- 4. Draw hook (HUD rendering)
+FSBaseMission.draw = Utils.appendedFunction(FSBaseMission.draw, function(self)
+    if g_csManager ~= nil then
+        g_csManager:draw()
+    end
+end)
+
+-- 5. Cleanup on mission unload
+FSBaseMission.delete = Utils.appendedFunction(FSBaseMission.delete, function(self)
+    if g_csManager ~= nil then
+        g_csManager:delete()
+        g_csManager = nil
+        getfenv(0)["g_cropStressManager"] = nil
+
+        if removeConsoleCommand ~= nil then
+            removeConsoleCommand("csHelp")
+            removeConsoleCommand("csStatus")
+            removeConsoleCommand("csSetMoisture")
+            removeConsoleCommand("csForceStress")
+            removeConsoleCommand("csSimulateHeat")
+            removeConsoleCommand("csDebug")
+        end
+    end
+end)
+
+-- 6. Save
+FSCareerMissionInfo.saveToXMLFile = Utils.appendedFunction(FSCareerMissionInfo.saveToXMLFile, function(self, xmlFile)
+    if g_csManager ~= nil then
+        g_csManager:saveToXMLFile(xmlFile)
+    end
+end)
+
+-- 7. Load saved state (fires after fields are populated)
+Mission00.onStartMission = Utils.appendedFunction(Mission00.onStartMission, function(self, ...)
+    if g_csManager ~= nil then
+        g_csManager:loadFromXMLFile()
+    end
+end)
+
+-- 8. Multiplayer: send initial state to new client
+FSBaseMission.sendInitialClientState = Utils.appendedFunction(
+    FSBaseMission.sendInitialClientState,
+    function(self, connection, objectId, farmId)
+        if g_csManager ~= nil then
+            g_csManager:sendInitialClientState(connection)
+        end
+    end
+)

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<modDesc descVersion="105">
+    <author>TisonK</author>
+    <version>1.0.0.0</version>
+
+    <title>
+        <en>Seasonal Crop Stress &amp; Irrigation Manager</en>
+        <de>Saisonaler Pflanzenstress &amp; Bewässerungsmanager</de>
+        <fr>Stress saisonnier des cultures &amp; gestionnaire d'irrigation</fr>
+        <nl>Seizoensgebonden gewassstress &amp; irrigatiebeheer</nl>
+    </title>
+
+    <description>
+        <en><![CDATA[Adds soil moisture tracking and crop stress simulation to Farming Simulator 25.
+
+Each field tracks a soil moisture percentage (0-100%) that rises with rain and falls through evapotranspiration driven by temperature, season, and soil type. When moisture drops below crop-specific thresholds during critical growth windows, yield stress accumulates and reduces your harvest at season's end.
+
+PHASE 1 FEATURES:
+• Per-field soil moisture simulation driven by real weather
+• Seasonal & temperature-adjusted evapotranspiration
+• Soil type modifiers: sandy drains fast, clay holds moisture
+• Crop-specific critical growth windows (wheat, corn, barley, canola, and more)
+• Yield reduction at harvest — up to 60% loss at maximum stress
+• Field moisture HUD overlay (press Shift+M to toggle)
+• Full save/load persistence of all field state
+• Debug console commands (type csHelp in developer console)
+
+COMING SOON: Center-pivot & drip irrigation systems, scheduling UI, Crop Consultant NPC, optional FS25_NPCFavor and FS25_UsedPlus integration.
+        ]]></en>
+        <de><![CDATA[Fügt Bodenfeuchteverfolgung und Pflanzenstresssimulation zu FS25 hinzu.
+
+Jedes Feld verfolgt einen Bodenfeuchteanteil, der mit Regen steigt und durch Evapotranspiration (Temperatur, Jahreszeit, Bodentyp) sinkt. Wenn die Feuchte in kritischen Wachstumsphasen zu niedrig ist, akkumuliert sich Stress und reduziert den Ernteertrag.
+        ]]></de>
+    </description>
+
+    <multiplayer supported="true"/>
+
+    <!-- Phase 1: no 3D assets yet. Replace with real icon before publishing. -->
+    <!-- <iconFilename>icon.dds</iconFilename> -->
+
+    <!--
+        All source files are loaded by main.lua via source() calls in strict
+        dependency order. Only main.lua is listed here.
+    -->
+    <extraSourceFiles>
+        <sourceFile filename="main.lua"/>
+    </extraSourceFiles>
+
+    <!--
+        Phase 1 input: HUD toggle only.
+        Phase 2 will add CS_OPEN_IRRIGATION (Shift+I).
+        Phase 3 will add CS_OPEN_CONSULTANT.
+    -->
+    <inputBinding>
+        <actionBinding action="CS_TOGGLE_HUD">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_m"
+                     axisComponent="+" index="1" isInverted="false" isTurnAxis="false"/>
+        </actionBinding>
+    </inputBinding>
+
+    <actions>
+        <action name="CS_TOGGLE_HUD" axisType="HALF_POSITIVE_AXIS" isSink="true"/>
+    </actions>
+
+    <l10n filenamePrefix="translations/translation"/>
+</modDesc>

--- a/src/CropConsultant.lua
+++ b/src/CropConsultant.lua
@@ -1,0 +1,46 @@
+-- ============================================================
+-- CropConsultant.lua
+-- PHASE 3 STUB — not yet implemented.
+--
+-- When implemented, this system will:
+--   • Subscribe to CS_CRITICAL_THRESHOLD events
+--   • Generate player-facing alert notifications at 3 severity levels
+--   • Enforce per-field alert cooldowns (12 in-game hours)
+--   • In standalone mode: show blinking HUD warnings
+--   • When FS25_NPCFavor is active: delegate alerts to NPCIntegration
+--     which presents them as NPC dialog from "Alex Chen, Agronomist"
+--
+-- Alert severity levels:
+--   INFO     (40-50% moisture)  — "Field X getting dry — monitor conditions."
+--   WARNING  (25-40% moisture)  — "Field X moisture low — irrigation recommended."
+--   CRITICAL (<25% moisture)    — "Field X at drought stress threshold — irrigate NOW!"
+--
+-- See Section 6.6 of FS25_SeasonalCropStress_ModPlan.md for full spec.
+-- ============================================================
+
+CropConsultant = {}
+CropConsultant.__index = CropConsultant
+
+function CropConsultant.new(manager)
+    local self = setmetatable({}, CropConsultant)
+    self.manager = manager
+    self.alertCooldowns = {}  -- fieldId → lastAlertHourKey
+    self.isInitialized = false
+    return self
+end
+
+function CropConsultant:initialize()
+    -- Phase 3: subscribe to events and optionally register NPC
+    self.isInitialized = true
+end
+
+function CropConsultant:onCriticalThreshold(data)
+    -- Phase 3: generate alerts
+end
+
+function CropConsultant:delete()
+    if self.manager ~= nil and self.manager.eventBus ~= nil then
+        self.manager.eventBus.unsubscribeAll(self)
+    end
+    self.isInitialized = false
+end

--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -1,0 +1,365 @@
+-- ============================================================
+-- CropStressManager.lua
+-- Central coordinator. Owns all subsystems, manages the lifecycle
+-- (initialize → hourly tick → draw → delete → save/load) and
+-- exposes the global g_cropStressManager reference.
+--
+-- Also houses CropEventBus — a lightweight internal event emitter
+-- used for loose coupling between subsystems. Avoids depending on
+-- g_messageCenter's integer-mapped MessageType IDs.
+-- ============================================================
+
+-- ============================================================
+-- CROP EVENT BUS
+-- Simple publish/subscribe for mod-internal events.
+-- Subscribers receive (context, data) where context is the
+-- object registered as the listener's self/context.
+-- ============================================================
+CropEventBus = {}
+CropEventBus.listeners = {}
+
+function CropEventBus.subscribe(eventName, callback, context)
+    if CropEventBus.listeners[eventName] == nil then
+        CropEventBus.listeners[eventName] = {}
+    end
+    table.insert(CropEventBus.listeners[eventName], { cb = callback, ctx = context })
+end
+
+function CropEventBus.publish(eventName, data)
+    local list = CropEventBus.listeners[eventName]
+    if list == nil then return end
+    for _, listener in ipairs(list) do
+        listener.cb(listener.ctx, data)
+    end
+end
+
+function CropEventBus.unsubscribeAll(context)
+    for _, list in pairs(CropEventBus.listeners) do
+        for i = #list, 1, -1 do
+            if list[i].ctx == context then
+                table.remove(list, i)
+            end
+        end
+    end
+end
+
+-- ============================================================
+-- CROP STRESS MANAGER
+-- ============================================================
+CropStressManager = {}
+CropStressManager.__index = CropStressManager
+
+function CropStressManager.new()
+    local self = setmetatable({}, CropStressManager)
+
+    self.eventBus = CropEventBus
+
+    -- State
+    self.isInitialized = false
+    self.debugMode     = false
+
+    -- Hourly tick tracking (monotonic day * 24 + hour)
+    self.lastHourKey   = -1
+
+    -- Subsystems (constructed here, initialized in :initialize() when g_currentMission is ready)
+    self.weatherIntegration = WeatherIntegration.new(self)
+    self.soilSystem         = SoilMoistureSystem.new(self)
+    self.stressModifier     = CropStressModifier.new(self)
+    self.irrigationManager  = IrrigationManager.new(self)       -- Phase 2 stub
+    self.hudOverlay         = HUDOverlay.new(self)
+    self.consultant         = CropConsultant.new(self)          -- Phase 3 stub
+    self.npcIntegration     = NPCIntegration.new(self)          -- Phase 3 stub
+    self.financeIntegration = FinanceIntegration.new(self)      -- Phase 4 stub
+    self.saveLoad           = SaveLoadHandler.new(self)
+
+    return self
+end
+
+-- Called from Mission00.loadMission00Finished — g_currentMission is ready here
+function CropStressManager:initialize()
+    if g_currentMission == nil then
+        g_logManager:devInfo("[CropStress]", "CRITICAL: g_currentMission nil at initialize — aborting")
+        return
+    end
+
+    -- Initialize subsystems in dependency order
+    self.weatherIntegration:initialize()
+    self.soilSystem:initialize()
+    self.stressModifier:initialize()
+    self.irrigationManager:initialize()
+    self.hudOverlay:initialize()
+    self.consultant:initialize()
+
+    -- Optional mod bridges — each checks for their mod's global at runtime
+    self:detectOptionalMods()
+    self.npcIntegration:initialize()
+    self.financeIntegration:initialize()
+
+    -- Persistence handler
+    self.saveLoad:initialize()
+
+    -- Capture first hour key so hourly tick fires correctly from the start
+    local env = g_currentMission.environment
+    if env ~= nil then
+        local day  = env.currentMonotonicDay or 0
+        local hour = env:getHour() or 0
+        self.lastHourKey = day * 24 + hour
+    end
+
+    self.isInitialized = true
+
+    g_logManager:devInfo("[CropStress]", string.format(
+        "CropStressManager initialized. Fields tracked: %d",
+        self.soilSystem:getFieldCount()
+    ))
+end
+
+-- ============================================================
+-- PER-FRAME UPDATE (called from FSBaseMission.update hook)
+-- ============================================================
+function CropStressManager:update(dt)
+    if not self.isInitialized then return end
+    if g_currentMission == nil then return end
+
+    local env = g_currentMission.environment
+    if env == nil then return end
+
+    -- Hourly tick detection
+    local day      = env.currentMonotonicDay or 0
+    local hour     = env:getHour() or 0
+    local hourKey  = day * 24 + hour
+
+    if hourKey ~= self.lastHourKey then
+        self.lastHourKey = hourKey
+        self:onHourlyTick()
+    end
+
+    -- HUD frame update (handles auto-show, input response)
+    self.hudOverlay:update(dt)
+end
+
+function CropStressManager:onHourlyTick()
+    -- 1. Poll current weather state
+    self.weatherIntegration:update()
+
+    -- 2. Advance soil moisture simulation
+    self.soilSystem:hourlyUpdate(self.weatherIntegration)
+
+    -- 3. Accumulate crop stress where moisture is critical
+    self.stressModifier:hourlyUpdate()
+
+    -- Phase 2: Irrigation scheduling check
+    -- self.irrigationManager:hourlyScheduleCheck()
+
+    -- Phase 3: Consultant alert evaluation
+    -- self.consultant:hourlyEvaluate()
+
+    -- Phase 4: Charge irrigation operational costs
+    -- self.financeIntegration:chargeHourlyCosts()
+
+    if self.debugMode then
+        g_logManager:devInfo("[CropStress]", string.format(
+            "Hourly tick complete. Season=%d Temp=%.1f Rain=%s",
+            self.weatherIntegration:getCurrentSeason(),
+            self.weatherIntegration:getCurrentTemp(),
+            tostring(self.weatherIntegration.isRaining)
+        ))
+    end
+end
+
+-- ============================================================
+-- DRAW (called from FSBaseMission.draw hook)
+-- ============================================================
+function CropStressManager:draw()
+    if not self.isInitialized then return end
+    self.hudOverlay:draw()
+end
+
+-- ============================================================
+-- SAVE / LOAD
+-- ============================================================
+function CropStressManager:saveToXMLFile(xmlFile)
+    if not self.isInitialized then return end
+    self.saveLoad:saveToXMLFile(xmlFile)
+end
+
+function CropStressManager:loadFromXMLFile()
+    if not self.isInitialized then return end
+    self.saveLoad:loadFromXMLFile()
+end
+
+-- ============================================================
+-- MULTIPLAYER
+-- ============================================================
+function CropStressManager:sendInitialClientState(connection)
+    if not self.isInitialized then return end
+    if g_server == nil then return end  -- only server sends
+
+    -- Broadcast current moisture + stress state to the new client
+    -- Phase 1: simple approach — send all fields in one stream message
+    -- For large maps (100+ fields) consider chunking in Phase 2
+    self:writeStreamToConnection(connection)
+end
+
+function CropStressManager:writeStreamToConnection(connection)
+    -- Enumerate fields and build payload
+    local fieldData = self.soilSystem.fieldData
+    if fieldData == nil then return end
+
+    -- Count active fields
+    local count = 0
+    for _ in pairs(fieldData) do count = count + 1 end
+
+    local stream = connection:getStream()  -- NOTE: verify FS25 API for stream access
+    -- LUADOC NOTE: The exact multiplayer stream API needs verification.
+    -- Pattern from NPCFavor / UsedPlus uses NetworkNode:writeStream pattern.
+    -- For Phase 1, log a notice and skip MP stream (implement fully in Phase 2).
+    g_logManager:devInfo("[CropStress]", "MP: initial client state sync — implement stream in Phase 2")
+end
+
+-- ============================================================
+-- OPTIONAL MOD DETECTION
+-- ============================================================
+function CropStressManager:detectOptionalMods()
+    -- FS25_NPCFavor
+    if getfenv(0)["g_npcFavorSystem"] ~= nil then
+        g_logManager:devInfo("[CropStress]", "FS25_NPCFavor detected — enabling NPC integration")
+        self.npcIntegration.npcFavorActive = true
+    end
+
+    -- FS25_UsedPlus
+    if getfenv(0)["g_usedPlusManager"] ~= nil then
+        g_logManager:devInfo("[CropStress]", "FS25_UsedPlus detected — enabling finance integration")
+        self.financeIntegration.usedPlusActive = true
+    end
+
+    -- Precision Farming DLC
+    if getfenv(0)["g_precisionFarming"] ~= nil then
+        g_logManager:devInfo("[CropStress]", "Precision Farming DLC detected — enabling PF compat (Phase 4)")
+    end
+end
+
+-- ============================================================
+-- INPUT EVENT — HUD TOGGLE
+-- ============================================================
+function CropStressManager:onToggleHUD()
+    self.hudOverlay:toggle()
+end
+
+-- ============================================================
+-- CLEANUP
+-- ============================================================
+function CropStressManager:delete()
+    -- Unsubscribe all event bus listeners
+    CropEventBus.listeners = {}
+
+    -- Subsystem cleanup (reverse order of init)
+    self.financeIntegration:delete()
+    self.npcIntegration:delete()
+    self.consultant:delete()
+    self.hudOverlay:delete()
+    self.irrigationManager:delete()
+    self.stressModifier:delete()
+    self.soilSystem:delete()
+    self.weatherIntegration:delete()
+    self.saveLoad:delete()
+
+    self.isInitialized = false
+    g_logManager:devInfo("[CropStress]", "CropStressManager deleted")
+end
+
+-- ============================================================
+-- DEBUG CONSOLE COMMANDS
+-- ============================================================
+function CropStressManager:consoleHelp()
+    print("=== FS25_SeasonalCropStress Debug Commands ===")
+    print("  csStatus               — Print system status overview")
+    print("  csSetMoisture <id> <v> — Set field moisture (0.0-1.0)")
+    print("  csForceStress <id>     — Force max stress on a field")
+    print("  csSimulateHeat <days>  — Simulate heat wave for N in-game days")
+    print("  csDebug                — Toggle verbose debug logging")
+    print("==============================================")
+end
+
+function CropStressManager:consoleStatus()
+    print("=== CropStress Status ===")
+    print(string.format("  Initialized: %s", tostring(self.isInitialized)))
+    print(string.format("  Debug mode:  %s", tostring(self.debugMode)))
+
+    if self.weatherIntegration ~= nil then
+        local seas = WeatherIntegration.SEASON_NAMES[self.weatherIntegration.currentSeason] or "?"
+        print(string.format("  Season: %s  Temp: %.1f°C  Raining: %s",
+            seas, self.weatherIntegration.currentTemp,
+            tostring(self.weatherIntegration.isRaining)))
+    end
+
+    print(string.format("  Fields tracked: %d", self.soilSystem:getFieldCount()))
+
+    -- Print top 5 driest fields
+    local sorted = self.soilSystem:getFieldsSortedByMoisture()
+    print("  Driest fields:")
+    for i = 1, math.min(5, #sorted) do
+        local f = sorted[i]
+        local stress = self.stressModifier:getStress(f.fieldId)
+        print(string.format("    Field %d: %.1f%% moisture, stress %.2f",
+            f.fieldId, f.moisture * 100, stress))
+    end
+end
+
+function CropStressManager:consoleSetMoisture(fieldIdStr, valueStr)
+    local fieldId = tonumber(fieldIdStr)
+    local value   = tonumber(valueStr)
+    if fieldId == nil or value == nil then
+        print("Usage: csSetMoisture <fieldId> <0.0-1.0>")
+        return
+    end
+    value = math.max(0.0, math.min(1.0, value))
+    if self.soilSystem:setMoisture(fieldId, value) then
+        print(string.format("Field %d moisture set to %.1f%%", fieldId, value * 100))
+    else
+        print(string.format("Field %d not found in moisture data", fieldId))
+    end
+end
+
+function CropStressManager:consoleForceStress(fieldIdStr)
+    local fieldId = tonumber(fieldIdStr)
+    if fieldId == nil then
+        print("Usage: csForceStress <fieldId>")
+        return
+    end
+    self.stressModifier.fieldStress[fieldId] = 1.0
+    print(string.format("Field %d stress forced to maximum (1.0)", fieldId))
+end
+
+function CropStressManager:consoleSimulateHeat(daysStr)
+    local days = tonumber(daysStr) or 1
+    if days < 1 or days > 30 then
+        print("Usage: csSimulateHeat <1-30>")
+        return
+    end
+
+    -- Simulate by running hourly updates with a high-temp weather state
+    -- We temporarily override the weather state for the simulation
+    local savedTemp  = self.weatherIntegration.currentTemp
+    local savedRain  = self.weatherIntegration.hourlyRainAmount
+
+    self.weatherIntegration.currentTemp      = 38.0  -- extreme heat
+    self.weatherIntegration.hourlyRainAmount = 0.0   -- no rain
+
+    for d = 1, days do
+        for h = 1, 24 do
+            self.soilSystem:hourlyUpdate(self.weatherIntegration)
+            self.stressModifier:hourlyUpdate()
+        end
+    end
+
+    self.weatherIntegration.currentTemp      = savedTemp
+    self.weatherIntegration.hourlyRainAmount = savedRain
+
+    print(string.format("Simulated %d-day heat wave. Check csStatus for field state.", days))
+end
+
+function CropStressManager:consoleToggleDebug()
+    self.debugMode = not self.debugMode
+    print(string.format("CropStress debug mode: %s", tostring(self.debugMode)))
+end

--- a/src/CropStressModifier.lua
+++ b/src/CropStressModifier.lua
@@ -1,0 +1,296 @@
+-- ============================================================
+-- CropStressModifier.lua
+-- Tracks accumulated yield stress per field and hooks into the
+-- harvesting pipeline to reduce yield proportionally.
+--
+-- Stress accumulates each in-game hour when:
+--   • The field has a crop in a "critical growth window" AND
+--   • Soil moisture is below the crop's criticalMoisture threshold
+--
+-- At harvest, yield is reduced by: stress * MAX_YIELD_LOSS (default 60%)
+--
+-- HARVEST HOOK IMPLEMENTATION NOTES:
+--   Uses Utils.overwrittenFunction on HarvestingMachine.doGroundWorkArea.
+--   This intercepts before+after fill levels and removes the stress
+--   portion. If two mods both overwrite this function, the last one loaded
+--   wins — flag this in modDesc.xml compatibility notes if needed.
+--   Verify exact function signature against LUADOC before testing.
+-- ============================================================
+
+CropStressModifier = {}
+CropStressModifier.__index = CropStressModifier
+
+-- Maximum yield reduction at stress = 1.0 (full stress)
+CropStressModifier.MAX_YIELD_LOSS = 0.60
+
+-- Crop stress configuration (matches cropStressDefaults.xml)
+-- key = lowercase fruit type name as returned by FS25 field:getFruitType().name
+CropStressModifier.CROP_WINDOWS = {
+    wheat      = { stages = {3,4},     criticalMoisture = 0.35, stressRatePerHour = 0.003 },
+    barley     = { stages = {3,4},     criticalMoisture = 0.30, stressRatePerHour = 0.003 },
+    corn       = { stages = {4,5},     criticalMoisture = 0.40, stressRatePerHour = 0.004 },
+    canola     = { stages = {2,3},     criticalMoisture = 0.45, stressRatePerHour = 0.005 },
+    sunflower  = { stages = {3,4},     criticalMoisture = 0.30, stressRatePerHour = 0.002 },
+    soybeans   = { stages = {3,4},     criticalMoisture = 0.40, stressRatePerHour = 0.004 },
+    sugarbeet  = { stages = {2,3,4},   criticalMoisture = 0.50, stressRatePerHour = 0.005 },
+    potato     = { stages = {2,3,4},   criticalMoisture = 0.55, stressRatePerHour = 0.006 },
+}
+
+-- Whether the harvest hook has been installed (static flag, module-level)
+CropStressModifier.harvestHookInstalled = false
+
+function CropStressModifier.new(manager)
+    local self = setmetatable({}, CropStressModifier)
+    self.manager = manager
+
+    -- Per-field accumulated stress: fieldId → float (0.0–1.0)
+    self.fieldStress = {}
+
+    self.isInitialized = false
+    return self
+end
+
+function CropStressModifier:initialize()
+    self.isInitialized = true
+end
+
+-- ============================================================
+-- HOURLY STRESS ACCUMULATION
+-- Called by CropStressManager:onHourlyTick()
+-- ============================================================
+function CropStressModifier:hourlyUpdate()
+    if not self.isInitialized then return end
+    if g_currentMission == nil or g_currentMission.fieldManager == nil then return end
+
+    local soilSystem = self.manager.soilSystem
+    if soilSystem == nil then return end
+
+    for fieldId, data in pairs(soilSystem.fieldData) do
+        local moisture = data.moisture
+
+        -- Get the field object to read crop type and growth stage
+        -- NOTE: getFieldByIndex vs getFields() — verify the correct lookup in LUADOC.
+        -- Some FS25 versions use fieldManager:getFieldByIndex(id), others differ.
+        local field = nil
+        if g_currentMission.fieldManager.getFieldByIndex ~= nil then
+            field = g_currentMission.fieldManager:getFieldByIndex(fieldId)
+        end
+        if field == nil then
+            -- Fallback: iterate all fields (slower but safe)
+            local fields = g_currentMission.fieldManager:getFields()
+            for _, f in pairs(fields) do
+                if f.fieldId == fieldId then
+                    field = f
+                    break
+                end
+            end
+        end
+        if field == nil then
+            -- Not found this tick — skip silently
+        else
+            self:processFieldStress(field, fieldId, moisture)
+        end
+    end
+end
+
+function CropStressModifier:processFieldStress(field, fieldId, moisture)
+    -- Get fruit type name
+    local fruitType = nil
+    if type(field.getFruitType) == "function" then
+        fruitType = field:getFruitType()
+    elseif field.fruitType ~= nil then
+        fruitType = field.fruitType
+    end
+    if fruitType == nil then return end
+
+    local cropName = fruitType.name and fruitType.name:lower() or nil
+    if cropName == nil then return end
+
+    local window = CropStressModifier.CROP_WINDOWS[cropName]
+    if window == nil then return end  -- Crop not in our config — no stress
+
+    -- Get growth stage
+    -- FS25: field:getGrowthState() or field.growthState or similar
+    -- LUADOC NOTE: verify exact method name
+    local growthStage = nil
+    if type(field.getGrowthState) == "function" then
+        growthStage = field:getGrowthState()
+    elseif field.growthState ~= nil then
+        growthStage = field.growthState
+    end
+    if growthStage == nil then return end
+
+    -- Check if in a critical growth window
+    local inCriticalWindow = false
+    for _, s in ipairs(window.stages) do
+        if growthStage == s then
+            inCriticalWindow = true
+            break
+        end
+    end
+    if not inCriticalWindow then return end
+
+    -- Below critical moisture threshold → accumulate stress
+    if moisture < window.criticalMoisture then
+        local deficit = window.criticalMoisture - moisture
+        local deficitRatio = deficit / window.criticalMoisture  -- 0.0-1.0
+        local stressIncrease = window.stressRatePerHour * deficitRatio
+
+        local prev = self.fieldStress[fieldId] or 0.0
+        self.fieldStress[fieldId] = math.min(1.0, prev + stressIncrease)
+
+        -- Publish via event bus
+        if self.manager ~= nil and self.manager.eventBus ~= nil then
+            self.manager.eventBus.publish("CS_STRESS_APPLIED", {
+                fieldId    = fieldId,
+                cropType   = cropName,
+                stress     = self.fieldStress[fieldId],
+                multiplier = 1.0 - (self.fieldStress[fieldId] * CropStressModifier.MAX_YIELD_LOSS),
+            })
+        end
+
+        if self.manager.debugMode then
+            g_logManager:devInfo("[CropStress]", string.format(
+                "Stress Field %d (%s stage %d): +%.4f → total %.3f (moisture %.1f%% < %.0f%%)",
+                fieldId, cropName, growthStage, stressIncrease,
+                self.fieldStress[fieldId], moisture * 100, window.criticalMoisture * 100
+            ))
+        end
+    end
+end
+
+-- ============================================================
+-- GETTERS
+-- ============================================================
+function CropStressModifier:getStress(fieldId)
+    return self.fieldStress[fieldId] or 0.0
+end
+
+function CropStressModifier:resetStress(fieldId)
+    self.fieldStress[fieldId] = 0.0
+end
+
+-- Returns estimated yield impact as a display string, e.g. "-18%"
+function CropStressModifier:getYieldImpactString(fieldId)
+    local stress = self:getStress(fieldId)
+    local loss = stress * CropStressModifier.MAX_YIELD_LOSS * 100
+    if loss < 0.5 then return "0%" end
+    return string.format("-%.0f%%", loss)
+end
+
+-- ============================================================
+-- POSITION → FIELD ID HELPER
+-- Used by the harvest hook to find which field is being harvested.
+-- ============================================================
+function CropStressModifier.getFieldIdAtPosition(x, z)
+    if g_currentMission == nil or g_currentMission.fieldManager == nil then return nil end
+
+    local fields = g_currentMission.fieldManager:getFields()
+    for _, field in pairs(fields) do
+        -- Preferred: native containment check
+        -- LUADOC: look for fieldManager:getFieldAtWorldPos(x, z) or field:containsPoint(x, z)
+        if type(field.containsPoint) == "function" then
+            if field:containsPoint(x, z) then
+                return field.fieldId
+            end
+        else
+            -- Fallback: bounding-circle estimate using field center + dimensions
+            -- This is imprecise — upgrade when exact API is confirmed
+            local cx = field.posX or (field.startX and (field.startX + (field.widthX or 0) * 0.5))
+            local cz = field.posZ or (field.startZ and (field.startZ + (field.heightZ or 0) * 0.5))
+            local r  = field.fieldRadius or 80  -- conservative radius estimate
+
+            if cx ~= nil and cz ~= nil then
+                local dx = x - cx
+                local dz = z - cz
+                if (dx * dx + dz * dz) <= (r * r) then
+                    return field.fieldId
+                end
+            end
+        end
+    end
+    return nil
+end
+
+-- ============================================================
+-- HARVEST HOOK INSTALLATION
+-- Called from main.lua at module-load time (before vehicles exist).
+-- ============================================================
+function CropStressModifier.installHarvestHook()
+    if CropStressModifier.harvestHookInstalled then return end
+    if HarvestingMachine == nil then
+        g_logManager:devInfo("[CropStress]", "HarvestingMachine not found — harvest hook skipped")
+        return
+    end
+    if HarvestingMachine.doGroundWorkArea == nil then
+        g_logManager:devInfo("[CropStress]", "HarvestingMachine.doGroundWorkArea not found — hook skipped")
+        return
+    end
+
+    -- Using overwrittenFunction for before+after fill level tracking.
+    -- This gives us a superFunc trampoline, letting us measure the fill delta.
+    -- COMPATIBILITY NOTE: If another mod also uses overwrittenFunction on this
+    -- same function, load order in modDesc.xml determines precedence.
+    HarvestingMachine.doGroundWorkArea = Utils.overwrittenFunction(
+        HarvestingMachine.doGroundWorkArea,
+        function(vehicle, superFunc, workArea, dt)
+            -- Record fill levels BEFORE harvest
+            local fillBefore = {}
+            if vehicle.spec_fillUnit ~= nil and vehicle.spec_fillUnit.fillUnits ~= nil then
+                for i, fu in ipairs(vehicle.spec_fillUnit.fillUnits) do
+                    fillBefore[i] = fu.fillLevel or 0
+                end
+            end
+
+            -- Run original harvest logic
+            superFunc(vehicle, workArea, dt)
+
+            -- Apply stress reduction if manager is active
+            if g_cropStressManager == nil or not g_cropStressManager.isInitialized then return end
+            if vehicle.spec_fillUnit == nil or vehicle.spec_fillUnit.fillUnits == nil then return end
+
+            -- Find which field this is (using work area start position)
+            local wx, _, wz = getWorldTranslation(workArea.start)
+            local fieldId = CropStressModifier.getFieldIdAtPosition(wx, wz)
+            if fieldId == nil then return end
+
+            local stress = g_cropStressManager.stressModifier:getStress(fieldId)
+            if stress <= 0.01 then return end
+
+            -- Calculate yield reduction factor
+            local reduction = stress * CropStressModifier.MAX_YIELD_LOSS
+            local keepFactor = 1.0 - reduction
+
+            -- Apply reduction to each fill unit that received grain this pass
+            local farmId = vehicle:getOwnerFarmId()
+            for i, fu in ipairs(vehicle.spec_fillUnit.fillUnits) do
+                local prev = fillBefore[i] or 0
+                local gained = (fu.fillLevel or 0) - prev
+                if gained > 0 then
+                    local targetLevel = prev + (gained * keepFactor)
+                    -- setFillUnitFillLevel(farmId, fillUnitIndex, value, fillType, toolType, fillPositionData)
+                    -- LUADOC NOTE: verify exact signature — second arg may be 1-based index
+                    vehicle:setFillUnitFillLevel(farmId, i, targetLevel, fu.fillType, nil, nil)
+                end
+            end
+
+            -- Log and reset stress for this field
+            if g_cropStressManager.debugMode then
+                g_logManager:devInfo("[CropStress]", string.format(
+                    "Harvest field %d: stress=%.2f → yield reduced by %.0f%%",
+                    fieldId, stress, reduction * 100
+                ))
+            end
+            g_cropStressManager.stressModifier:resetStress(fieldId)
+        end
+    )
+
+    CropStressModifier.harvestHookInstalled = true
+    g_logManager:devInfo("[CropStress]", "Harvest yield hook installed on HarvestingMachine.doGroundWorkArea")
+end
+
+function CropStressModifier:delete()
+    self.isInitialized = false
+    -- Note: the harvest hook patch cannot be uninstalled without storing the original.
+    -- On mod reload, the whole game restarts so this is not a concern.
+end

--- a/src/FinanceIntegration.lua
+++ b/src/FinanceIntegration.lua
@@ -1,0 +1,51 @@
+-- ============================================================
+-- FinanceIntegration.lua
+-- PHASE 4 STUB — not yet implemented.
+--
+-- When implemented, this system will:
+--   • Detect FS25_UsedPlus at runtime via g_usedPlusManager global
+--   • Subscribe to CS_IRRIGATION_STARTED / CS_IRRIGATION_STOPPED events
+--   • Charge hourly operational costs for active irrigation systems:
+--       — Via g_usedPlusManager:recordExpense("IRRIGATION", cost, {...}) if UsedPlus active
+--       — Via g_currentMission.missionInfo:updateFunds(-cost, "OTHER", true) if standalone
+--   • Pull equipment wear levels from UsedPlus DNA to degrade irrigation flow rates
+--     (worn pump = reduced flow → less moisture gain per hour)
+--
+-- Finance path for fund deductions (FS25 standard):
+--   g_currentMission.missionInfo:updateFunds(amount, "OTHER", true)
+--   amount is NEGATIVE for deductions. The third arg = true flags it as "other costs".
+--
+-- See Section 6.8 of FS25_SeasonalCropStress_ModPlan.md for full spec.
+-- ============================================================
+
+FinanceIntegration = {}
+FinanceIntegration.__index = FinanceIntegration
+
+function FinanceIntegration.new(manager)
+    local self = setmetatable({}, FinanceIntegration)
+    self.manager = manager
+    self.usedPlusActive = false  -- set by CropStressManager:detectOptionalMods()
+    self.isInitialized  = false
+    return self
+end
+
+function FinanceIntegration:initialize()
+    -- Phase 4: subscribe to irrigation events
+    self.isInitialized = true
+end
+
+function FinanceIntegration:chargeHourlyCosts()
+    -- Phase 4: iterate active irrigation systems, deduct operational costs
+end
+
+function FinanceIntegration:getEquipmentWearLevel(vehicleId)
+    -- Phase 4: query UsedPlus DNA for pump wear, return 0.0-1.0
+    return 0.0
+end
+
+function FinanceIntegration:delete()
+    if self.manager ~= nil and self.manager.eventBus ~= nil then
+        self.manager.eventBus.unsubscribeAll(self)
+    end
+    self.isInitialized = false
+end

--- a/src/HUDOverlay.lua
+++ b/src/HUDOverlay.lua
@@ -1,0 +1,296 @@
+-- ============================================================
+-- HUDOverlay.lua
+-- Renders the field moisture panel in the lower-left corner of
+-- the screen using FS25's immediate-mode render functions.
+--
+-- Phase 1: Direct draw rendering (no XML dialog — simple and reliable)
+-- Phase 2+: Upgrade to a proper GuiElement / XML dialog for better theming
+--
+-- Layout (bottom-left, above minimap):
+-- ┌────────────────────────────────────────────┐
+-- │  CROP MOISTURE MONITOR              [M]    │
+-- │                                            │
+-- │  Field 7 · Wheat (Stage 4)    ██████░░ 78%│
+-- │  Field 3 · Corn  (Stage 5) ⚠  ███░░░░░ 32%│
+-- │  Field 5 · Corn  (Stage 3)    ████████ 80%│
+-- └────────────────────────────────────────────┘
+--
+-- HUD coordinates are normalized: 0.0–1.0 (bottom-left origin).
+-- Y=0 is BOTTOM of screen. Text and rect calls use this space.
+-- ============================================================
+
+HUDOverlay = {}
+HUDOverlay.__index = HUDOverlay
+
+-- Panel layout constants (normalized screen coordinates)
+HUDOverlay.PANEL_X         = 0.010   -- left edge
+HUDOverlay.PANEL_Y         = 0.175   -- bottom edge of panel
+HUDOverlay.PANEL_W         = 0.220   -- panel width
+HUDOverlay.ROW_H           = 0.024   -- height per field row
+HUDOverlay.HEADER_H        = 0.028   -- header row height
+HUDOverlay.PADDING         = 0.004
+HUDOverlay.BAR_W           = 0.080   -- moisture bar width
+HUDOverlay.BAR_H           = 0.012
+HUDOverlay.TEXT_SIZE        = 0.013
+HUDOverlay.HEADER_TEXT_SIZE = 0.014
+HUDOverlay.MAX_FIELDS       = 6      -- max rows shown
+
+-- Colors (r, g, b, a)
+HUDOverlay.COLOR_BG         = {0.05, 0.05, 0.05, 0.78}
+HUDOverlay.COLOR_HEADER_BG  = {0.10, 0.10, 0.10, 0.85}
+HUDOverlay.COLOR_TEXT        = {0.90, 0.90, 0.90, 1.00}
+HUDOverlay.COLOR_HEADER_TEXT = {1.00, 1.00, 1.00, 1.00}
+HUDOverlay.COLOR_BAR_BG     = {0.20, 0.20, 0.20, 0.80}
+HUDOverlay.COLOR_HEALTHY    = {0.20, 0.75, 0.20, 1.00}  -- green  >60%
+HUDOverlay.COLOR_WARNING    = {0.85, 0.70, 0.10, 1.00}  -- yellow 30-60%
+HUDOverlay.COLOR_CRITICAL   = {0.85, 0.20, 0.10, 1.00}  -- red    <30%
+HUDOverlay.COLOR_STRESS_IND = {0.90, 0.35, 0.10, 1.00}  -- orange stress indicator
+
+-- First-run auto-show: show panel automatically when a field first hits warning
+HUDOverlay.FIRST_RUN_MOISTURE_TRIGGER = 0.50
+
+function HUDOverlay.new(manager)
+    local self = setmetatable({}, HUDOverlay)
+    self.manager = manager
+    self.isVisible = false
+    self.firstRunShown = false
+
+    -- List of {fieldId, moisture, stress, cropName, growthStage} for current frame
+    self.displayRows = {}
+
+    -- Auto-show state
+    self.autoShowActive = false
+    self.autoHideTimer  = 0   -- countdown in seconds (real time); 0 = don't auto-hide
+
+    self.isInitialized = false
+    return self
+end
+
+function HUDOverlay:initialize()
+    -- Subscribe to events via CropEventBus
+    if self.manager ~= nil and self.manager.eventBus ~= nil then
+        self.manager.eventBus.subscribe("CS_MOISTURE_UPDATED", self.onMoistureUpdated, self)
+        self.manager.eventBus.subscribe("CS_CRITICAL_THRESHOLD", self.onCriticalThreshold, self)
+    end
+
+    self.isInitialized = true
+    g_logManager:devInfo("[CropStress]", "HUDOverlay initialized")
+end
+
+-- Called per frame by CropStressManager:update()
+function HUDOverlay:update(dt)
+    if not self.isInitialized then return end
+
+    -- Auto-hide countdown (real seconds)
+    if self.autoHideTimer > 0 then
+        self.autoHideTimer = self.autoHideTimer - dt
+        if self.autoHideTimer <= 0 then
+            self.autoHideTimer = 0
+            -- Only auto-hide if user hasn't manually shown it
+            if self.autoShowActive then
+                self.autoShowActive = false
+                self.isVisible = false
+            end
+        end
+    end
+
+    -- Rebuild display rows each frame from current system state
+    self:rebuildDisplayRows()
+end
+
+-- Called per frame draw by CropStressManager:draw()
+function HUDOverlay:draw()
+    if not self.isInitialized or not self.isVisible then return end
+    if g_currentMission == nil then return end
+
+    local numRows = math.min(#self.displayRows, HUDOverlay.MAX_FIELDS)
+    if numRows == 0 then return end
+
+    local panelH = HUDOverlay.HEADER_H
+        + (numRows * HUDOverlay.ROW_H)
+        + HUDOverlay.PADDING * 2
+
+    local px = HUDOverlay.PANEL_X
+    local py = HUDOverlay.PANEL_Y
+
+    -- Background panel
+    setTextColor(unpack(HUDOverlay.COLOR_BG))
+    drawFilledRect(px, py, HUDOverlay.PANEL_W, panelH)
+
+    -- Header bar
+    setTextColor(unpack(HUDOverlay.COLOR_HEADER_BG))
+    drawFilledRect(px, py + panelH - HUDOverlay.HEADER_H, HUDOverlay.PANEL_W, HUDOverlay.HEADER_H)
+
+    -- Header text
+    setTextColor(unpack(HUDOverlay.COLOR_HEADER_TEXT))
+    setTextBold(true)
+    renderText(
+        px + HUDOverlay.PADDING,
+        py + panelH - HUDOverlay.HEADER_H + HUDOverlay.PADDING,
+        HUDOverlay.HEADER_TEXT_SIZE,
+        g_i18n:getText("cs_hud_title") or "CROP MOISTURE"
+    )
+    -- Key hint on the right
+    renderText(
+        px + HUDOverlay.PANEL_W - 0.030,
+        py + panelH - HUDOverlay.HEADER_H + HUDOverlay.PADDING,
+        HUDOverlay.TEXT_SIZE,
+        "[M]"
+    )
+    setTextBold(false)
+
+    -- Field rows (lowest moisture first)
+    for i = 1, numRows do
+        local row = self.displayRows[i]
+        local rowY = py + panelH - HUDOverlay.HEADER_H - (i * HUDOverlay.ROW_H)
+        self:drawFieldRow(row, px, rowY)
+    end
+end
+
+function HUDOverlay:drawFieldRow(row, px, rowY)
+    local moisture = row.moisture or 0
+    local stress   = row.stress   or 0
+
+    -- Row label: "Field 7 · Wheat"
+    local cropLabel = row.cropName or "?"
+    local stageStr  = row.growthStage and (" S" .. tostring(row.growthStage)) or ""
+    local label = string.format("F%d · %s%s", row.fieldId, cropLabel, stageStr)
+
+    -- Stress indicator
+    local indicatorStr = ""
+    if stress > 0.15 then
+        indicatorStr = " !"
+    end
+
+    setTextColor(unpack(HUDOverlay.COLOR_TEXT))
+    renderText(
+        px + HUDOverlay.PADDING,
+        rowY + HUDOverlay.PADDING,
+        HUDOverlay.TEXT_SIZE,
+        label .. indicatorStr
+    )
+
+    -- Moisture bar background
+    local barX = px + HUDOverlay.PANEL_W - HUDOverlay.BAR_W - HUDOverlay.PADDING * 2
+    local barY = rowY + (HUDOverlay.ROW_H - HUDOverlay.BAR_H) * 0.5
+    setTextColor(unpack(HUDOverlay.COLOR_BAR_BG))
+    drawFilledRect(barX, barY, HUDOverlay.BAR_W, HUDOverlay.BAR_H)
+
+    -- Moisture bar fill
+    local barColor = HUDOverlay:getMoistureColor(moisture)
+    setTextColor(unpack(barColor))
+    drawFilledRect(barX, barY, HUDOverlay.BAR_W * moisture, HUDOverlay.BAR_H)
+
+    -- Percentage text
+    setTextColor(unpack(HUDOverlay.COLOR_TEXT))
+    renderText(
+        barX + HUDOverlay.BAR_W + HUDOverlay.PADDING,
+        rowY + HUDOverlay.PADDING,
+        HUDOverlay.TEXT_SIZE,
+        string.format("%d%%", math.floor(moisture * 100 + 0.5))
+    )
+end
+
+function HUDOverlay:getMoistureColor(moisture)
+    if moisture >= 0.60 then
+        return HUDOverlay.COLOR_HEALTHY
+    elseif moisture >= 0.30 then
+        return HUDOverlay.COLOR_WARNING
+    else
+        return HUDOverlay.COLOR_CRITICAL
+    end
+end
+
+-- Rebuild the display rows list from current soil + stress state
+function HUDOverlay:rebuildDisplayRows()
+    self.displayRows = {}
+
+    if self.manager == nil or self.manager.soilSystem == nil then return end
+
+    local sortedFields = self.manager.soilSystem:getFieldsSortedByMoisture()
+    if sortedFields == nil then return end
+
+    for _, entry in ipairs(sortedFields) do
+        if #self.displayRows >= HUDOverlay.MAX_FIELDS then break end
+
+        local stress = 0
+        local cropName = "?"
+        local growthStage = nil
+
+        if self.manager.stressModifier ~= nil then
+            stress = self.manager.stressModifier:getStress(entry.fieldId)
+        end
+
+        -- Try to get crop info from the field object
+        if g_currentMission ~= nil and g_currentMission.fieldManager ~= nil then
+            local field = nil
+            if g_currentMission.fieldManager.getFieldByIndex ~= nil then
+                field = g_currentMission.fieldManager:getFieldByIndex(entry.fieldId)
+            end
+            if field ~= nil then
+                local ft = type(field.getFruitType) == "function" and field:getFruitType() or field.fruitType
+                if ft ~= nil and ft.name ~= nil then
+                    -- Capitalize first letter
+                    cropName = ft.name:sub(1,1):upper() .. ft.name:sub(2):lower()
+                end
+                if type(field.getGrowthState) == "function" then
+                    growthStage = field:getGrowthState()
+                elseif field.growthState ~= nil then
+                    growthStage = field.growthState
+                end
+            end
+        end
+
+        table.insert(self.displayRows, {
+            fieldId     = entry.fieldId,
+            moisture    = entry.moisture,
+            stress      = stress,
+            cropName    = cropName,
+            growthStage = growthStage,
+        })
+    end
+end
+
+-- Toggle visibility (bound to CS_TOGGLE_HUD input action)
+function HUDOverlay:toggle()
+    self.isVisible = not self.isVisible
+    self.autoShowActive = false
+    self.autoHideTimer  = 0
+
+    if self.isVisible and not self.firstRunShown then
+        self.firstRunShown = true
+    end
+
+    g_logManager:devInfo("[CropStress]", "HUD toggled: " .. tostring(self.isVisible))
+end
+
+-- Auto-show when a critical threshold fires (if not already visible)
+function HUDOverlay:onCriticalThreshold(data)
+    if not self.isInitialized then return end
+    if not self.isVisible then
+        self.isVisible = true
+        self.autoShowActive = true
+        self.autoHideTimer  = 120  -- auto-hide after 120 real seconds if not interacted with
+    end
+
+    -- First-run explanation (show once)
+    if not self.firstRunShown then
+        self.firstRunShown = true
+        g_currentMission:showBlinkingWarning(
+            (g_i18n:getText("cs_hud_first_run") or
+             "Crop Moisture Monitor active. Press Shift+M to toggle the HUD."),
+            6000
+        )
+    end
+end
+
+function HUDOverlay:onMoistureUpdated(data)
+    -- No per-event work needed — we rebuild each frame from current state
+end
+
+function HUDOverlay:delete()
+    if self.manager ~= nil and self.manager.eventBus ~= nil then
+        self.manager.eventBus.unsubscribeAll(self)
+    end
+    self.isInitialized = false
+end

--- a/src/IrrigationManager.lua
+++ b/src/IrrigationManager.lua
@@ -1,0 +1,45 @@
+-- ============================================================
+-- IrrigationManager.lua
+-- PHASE 2 STUB — not yet implemented.
+--
+-- When implemented, this system will:
+--   • Track all placed irrigation placeables (center-pivot, drip, pump)
+--   • Calculate which fields each system covers
+--   • Run a scheduling engine (per-day start/end hours, active days)
+--   • Set irrigationGain on covered fields in SoilMoistureSystem
+--   • Publish CS_IRRIGATION_STARTED / CS_IRRIGATION_STOPPED events
+--
+-- See Section 6.2 of FS25_SeasonalCropStress_ModPlan.md for full spec.
+-- ============================================================
+
+IrrigationManager = {}
+IrrigationManager.__index = IrrigationManager
+
+function IrrigationManager.new(manager)
+    local self = setmetatable({}, IrrigationManager)
+    self.manager = manager
+    self.irrigationSystems = {}  -- placeableId → system data table
+    self.isInitialized = false
+    return self
+end
+
+function IrrigationManager:initialize()
+    -- Phase 2: enumerate existing placeables and register any irrigation systems
+    self.isInitialized = true
+end
+
+function IrrigationManager:hourlyScheduleCheck()
+    -- Phase 2: activate/deactivate irrigation systems per schedule
+end
+
+function IrrigationManager:registerIrrigationSystem(placeable)
+    -- Phase 2: called from placeable onPostLoad
+end
+
+function IrrigationManager:deregisterIrrigationSystem(placeableId)
+    -- Phase 2: called from placeable onDelete
+end
+
+function IrrigationManager:delete()
+    self.isInitialized = false
+end

--- a/src/NPCIntegration.lua
+++ b/src/NPCIntegration.lua
@@ -1,0 +1,48 @@
+-- ============================================================
+-- NPCIntegration.lua
+-- PHASE 3 STUB — not yet implemented.
+--
+-- When implemented, this system will:
+--   • Detect FS25_NPCFavor at runtime via g_npcFavorSystem global
+--   • Register "Alex Chen, Agronomist" as an external NPC via NPCFavor API
+--   • Generate consultant-specific favor types:
+--       SOIL_SAMPLE      — visit a field that hasn't been inspected in 10+ days
+--       IRRIGATION_CHECK — inspect an offline irrigation system
+--       EMERGENCY_WATER  — irrigate a critically stressed field before sundown
+--       SEASONAL_PLAN    — open the seasonal planning dialog (Phase 3+)
+--
+-- Integration point:
+--   The global g_npcFavorSystem is set by FS25_NPCFavor v1.2+.
+--   Check g_npcFavorSystem.registerExternalNPC for the registration API.
+--
+-- See Section 6.7 of FS25_SeasonalCropStress_ModPlan.md for full spec.
+-- ============================================================
+
+NPCIntegration = {}
+NPCIntegration.__index = NPCIntegration
+
+function NPCIntegration.new(manager)
+    local self = setmetatable({}, NPCIntegration)
+    self.manager = manager
+    self.npcFavorActive  = false  -- set by CropStressManager:detectOptionalMods()
+    self.consultantNPCId = nil
+    self.isInitialized   = false
+    return self
+end
+
+function NPCIntegration:initialize()
+    if not self.npcFavorActive then
+        self.isInitialized = true
+        return
+    end
+    -- Phase 3: register consultant NPC via g_npcFavorSystem API
+    self.isInitialized = true
+end
+
+function NPCIntegration:sendConsultantAlert(data)
+    -- Phase 3: forward alert to NPC dialog system
+end
+
+function NPCIntegration:delete()
+    self.isInitialized = false
+end

--- a/src/SaveLoadHandler.lua
+++ b/src/SaveLoadHandler.lua
@@ -1,0 +1,184 @@
+-- ============================================================
+-- SaveLoadHandler.lua
+-- Handles reading and writing all persistent mod state.
+--
+-- Storage strategy:
+--   • Sidecar file: {savegameDirectory}/cropStressData.xml
+--     — per-field moisture, stress accumulation
+--   • Player config: {savegameDirectory}/cropStressConfig.xml
+--     — HUD preferences, difficulty settings (Phase 2)
+--
+-- CONSOLE COMPATIBILITY NOTE:
+--   On Xbox/PS5, file system access is restricted. All save/load
+--   MUST use the xmlFile handle provided by the game's save callbacks,
+--   OR write to the savegame's own XML via setXMLInt/Float/String.
+--   Never use io.open() for persistent data.
+--
+-- For Phase 1, we write our data block inside the career savegame XML.
+-- Phase 2 will migrate large data to a sidecar file once tested on PC.
+-- ============================================================
+
+SaveLoadHandler = {}
+SaveLoadHandler.__index = SaveLoadHandler
+
+-- XML key prefix inside the career savegame file
+SaveLoadHandler.XML_ROOT_KEY = "careerSavegame.cropStress"
+
+function SaveLoadHandler.new(manager)
+    local self = setmetatable({}, SaveLoadHandler)
+    self.manager = manager
+    self.isInitialized = false
+    return self
+end
+
+function SaveLoadHandler:initialize()
+    self.isInitialized = true
+end
+
+-- ============================================================
+-- SAVE — called from FSCareerMissionInfo.saveToXMLFile hook
+-- ============================================================
+function SaveLoadHandler:saveToXMLFile(xmlFile)
+    if xmlFile == nil then
+        g_logManager:devInfo("[CropStress]", "SaveLoad: xmlFile is nil — save skipped")
+        return
+    end
+
+    local root = SaveLoadHandler.XML_ROOT_KEY
+
+    -- Write schema version
+    setXMLInt(xmlFile, root .. "#version", 1)
+
+    -- Save per-field moisture state
+    local soilSystem = self.manager.soilSystem
+    if soilSystem ~= nil and soilSystem.fieldData ~= nil then
+        local i = 0
+        for fieldId, data in pairs(soilSystem.fieldData) do
+            local key = string.format("%s.field(%d)", root, i)
+            setXMLInt(xmlFile,    key .. "#id",       fieldId)
+            setXMLFloat(xmlFile,  key .. "#moisture",  data.moisture)
+            setXMLString(xmlFile, key .. "#soilType",  data.soilType or "loamy")
+            i = i + 1
+        end
+        g_logManager:devInfo("[CropStress]", string.format("Saved moisture for %d fields", i))
+    end
+
+    -- Save per-field stress accumulation
+    local stressModifier = self.manager.stressModifier
+    if stressModifier ~= nil and stressModifier.fieldStress ~= nil then
+        local i = 0
+        for fieldId, stress in pairs(stressModifier.fieldStress) do
+            if stress > 0.001 then  -- skip zero entries
+                local key = string.format("%s.stress(%d)", root, i)
+                setXMLInt(xmlFile,   key .. "#id",    fieldId)
+                setXMLFloat(xmlFile, key .. "#value", stress)
+                i = i + 1
+            end
+        end
+        g_logManager:devInfo("[CropStress]", string.format("Saved stress for %d fields", i))
+    end
+
+    -- Save HUD state
+    local hud = self.manager.hudOverlay
+    if hud ~= nil then
+        local hudKey = root .. ".hud"
+        setXMLBool(xmlFile, hudKey .. "#visible",      hud.isVisible)
+        setXMLBool(xmlFile, hudKey .. "#firstRunShown", hud.firstRunShown)
+    end
+
+    g_logManager:devInfo("[CropStress]", "Save complete")
+end
+
+-- ============================================================
+-- LOAD — called from Mission00.onStartMission hook
+-- ============================================================
+function SaveLoadHandler:loadFromXMLFile()
+    if g_currentMission == nil then return end
+    local savegameDir = g_currentMission.missionInfo
+        and g_currentMission.missionInfo.savegameDirectory
+
+    if savegameDir == nil then
+        g_logManager:devInfo("[CropStress]", "SaveLoad: no savegame directory — using defaults")
+        return
+    end
+
+    -- Build path to career savegame XML
+    local savePath = savegameDir .. "/careerSavegame.xml"
+
+    -- loadXMLFile returns handle or nil
+    local xmlFile = loadXMLFile("cropStressSave", savePath)
+    if xmlFile == nil then
+        g_logManager:devInfo("[CropStress]", "SaveLoad: careerSavegame.xml not found — fresh start")
+        return
+    end
+
+    local root = SaveLoadHandler.XML_ROOT_KEY
+
+    -- Check version
+    local version = getXMLInt(xmlFile, root .. "#version") or 0
+    if version < 1 then
+        g_logManager:devInfo("[CropStress]", "SaveLoad: no cropStress data in save — using defaults")
+        delete(xmlFile)
+        return
+    end
+
+    -- Load moisture per field
+    local soilSystem = self.manager.soilSystem
+    local loadedMoistureCount = 0
+    if soilSystem ~= nil and soilSystem.fieldData ~= nil then
+        local i = 0
+        while true do
+            local key = string.format("%s.field(%d)", root, i)
+            local fieldId = getXMLInt(xmlFile, key .. "#id")
+            if fieldId == nil then break end
+
+            local moisture = getXMLFloat(xmlFile,  key .. "#moisture")  or 0.5
+            local soilType = getXMLString(xmlFile, key .. "#soilType")  or "loamy"
+
+            if soilSystem.fieldData[fieldId] ~= nil then
+                soilSystem.fieldData[fieldId].moisture = math.max(0.0, math.min(1.0, moisture))
+                soilSystem.fieldData[fieldId].soilType = soilType
+                loadedMoistureCount = loadedMoistureCount + 1
+            end
+            i = i + 1
+        end
+    end
+
+    -- Load stress per field
+    local stressModifier = self.manager.stressModifier
+    local loadedStressCount = 0
+    if stressModifier ~= nil then
+        local i = 0
+        while true do
+            local key = string.format("%s.stress(%d)", root, i)
+            local fieldId = getXMLInt(xmlFile, key .. "#id")
+            if fieldId == nil then break end
+
+            local stress = getXMLFloat(xmlFile, key .. "#value") or 0.0
+            stressModifier.fieldStress[fieldId] = math.max(0.0, math.min(1.0, stress))
+            loadedStressCount = loadedStressCount + 1
+            i = i + 1
+        end
+    end
+
+    -- Load HUD state
+    local hud = self.manager.hudOverlay
+    if hud ~= nil then
+        local hudKey = root .. ".hud"
+        local savedVisible = getXMLBool(xmlFile, hudKey .. "#visible")
+        if savedVisible ~= nil then hud.isVisible = savedVisible end
+
+        local savedFirstRun = getXMLBool(xmlFile, hudKey .. "#firstRunShown")
+        if savedFirstRun ~= nil then hud.firstRunShown = savedFirstRun end
+    end
+
+    delete(xmlFile)
+    g_logManager:devInfo("[CropStress]", string.format(
+        "Load complete. Moisture: %d fields, Stress: %d fields",
+        loadedMoistureCount, loadedStressCount
+    ))
+end
+
+function SaveLoadHandler:delete()
+    self.isInitialized = false
+end

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -1,0 +1,208 @@
+-- ============================================================
+-- SoilMoistureSystem.lua
+-- Maintains a soil moisture value (0.0–1.0) for every field on
+-- the map. Updated every in-game hour via CropStressManager's
+-- hourly tick.
+--
+-- Moisture rises from:
+--   • Rainfall (via WeatherIntegration poll)
+--   • Irrigation (Phase 2 — IrrigationManager sets irrigationGainRate)
+-- Moisture falls from:
+--   • Evapotranspiration: base rate × temp modifier × season modifier × soil modifier
+-- ============================================================
+
+SoilMoistureSystem = {}
+SoilMoistureSystem.__index = SoilMoistureSystem
+
+-- Base evaporation per in-game hour (before modifiers).
+-- At 1.0 modifier: 0.004 = 0.4% per hour → full evap in ~104 hours (~4 game days)
+SoilMoistureSystem.BASE_EVAP_RATE = 0.004
+
+-- Soil type evaporation modifiers and rain absorption coefficients
+SoilMoistureSystem.SOIL_PARAMS = {
+    sandy = { evapMod = 1.40, rainAbsorb = 0.90 },
+    loamy = { evapMod = 1.00, rainAbsorb = 1.00 },
+    clay  = { evapMod = 0.70, rainAbsorb = 0.80 },
+}
+
+-- Season-aware starting moisture (used when no saved state exists)
+-- 0=spring, 1=summer, 2=autumn, 3=winter
+SoilMoistureSystem.SEASON_START_MOISTURE = { [0]=0.60, [1]=0.40, [2]=0.55, [3]=0.70 }
+
+-- Critical threshold — below this, fire CS_CRITICAL_THRESHOLD
+SoilMoistureSystem.CRITICAL_MOISTURE = 0.25
+
+function SoilMoistureSystem.new(manager)
+    local self = setmetatable({}, SoilMoistureSystem)
+    self.manager = manager
+
+    -- keyed by fieldId (integer)
+    -- Each entry:
+    -- {
+    --   fieldId         = number,
+    --   moisture        = float (0.0-1.0),
+    --   soilType        = string ("sandy"/"loamy"/"clay"),
+    --   irrigationGain  = float (0.0 = none; set by IrrigationManager in Phase 2),
+    -- }
+    self.fieldData = {}
+
+    -- Track which fields have already had a first-run HUD trigger
+    self.criticalAlertCooldown = {}  -- fieldId → lastAlertHourKey
+
+    self.isInitialized = false
+    return self
+end
+
+function SoilMoistureSystem:initialize()
+    if g_currentMission == nil or g_currentMission.fieldManager == nil then
+        g_logManager:devInfo("[CropStress]", "SoilMoistureSystem: fieldManager unavailable at init")
+        return
+    end
+
+    local season = 0
+    if g_currentMission.environment ~= nil then
+        season = g_currentMission.environment:currentSeason() or 0
+    end
+    local startMoisture = SoilMoistureSystem.SEASON_START_MOISTURE[season] or 0.50
+
+    local fields = g_currentMission.fieldManager:getFields()
+    local count = 0
+
+    for _, field in pairs(fields) do
+        local fid = field.fieldId
+        if fid ~= nil then
+            self.fieldData[fid] = {
+                fieldId        = fid,
+                moisture       = startMoisture,
+                soilType       = self:detectSoilType(field),
+                irrigationGain = 0.0,
+            }
+            count = count + 1
+        end
+    end
+
+    self.isInitialized = true
+    g_logManager:devInfo("[CropStress]", string.format(
+        "SoilMoistureSystem initialized. %d fields tracked. Start moisture=%.0f%% (season %d)",
+        count, startMoisture * 100, season
+    ))
+end
+
+-- Called every in-game hour
+function SoilMoistureSystem:hourlyUpdate(weather)
+    if not self.isInitialized then return end
+    if weather == nil then return end
+
+    local evapMultiplier  = weather:getHourlyEvapMultiplier()
+    local rainAmount      = weather:getHourlyRainAmount()
+
+    local env = g_currentMission and g_currentMission.environment
+    local hourKey = env and ((env.currentMonotonicDay or 0) * 24 + (env:getHour() or 0)) or 0
+
+    for fieldId, data in pairs(self.fieldData) do
+        local soilParams = SoilMoistureSystem.SOIL_PARAMS[data.soilType]
+            or SoilMoistureSystem.SOIL_PARAMS.loamy
+
+        -- Evapotranspiration loss this hour
+        local evapLoss = SoilMoistureSystem.BASE_EVAP_RATE
+            * evapMultiplier
+            * soilParams.evapMod
+
+        -- Rain gain (modulated by soil absorption)
+        local rainGain = rainAmount * soilParams.rainAbsorb
+
+        -- Irrigation gain (Phase 2: set externally by IrrigationManager)
+        local irrigGain = data.irrigationGain or 0.0
+
+        local prevMoisture = data.moisture
+        data.moisture = math.max(0.0, math.min(1.0,
+            data.moisture - evapLoss + rainGain + irrigGain))
+
+        -- Fire event via CropEventBus
+        if self.manager ~= nil and self.manager.eventBus ~= nil then
+            self.manager.eventBus.publish("CS_MOISTURE_UPDATED", {
+                fieldId  = fieldId,
+                previous = prevMoisture,
+                current  = data.moisture,
+            })
+        end
+
+        -- Critical threshold check (with cooldown to avoid spam)
+        if data.moisture <= SoilMoistureSystem.CRITICAL_MOISTURE then
+            local lastAlert = self.criticalAlertCooldown[fieldId] or -999
+            if (hourKey - lastAlert) >= 12 then
+                self.criticalAlertCooldown[fieldId] = hourKey
+                if self.manager ~= nil and self.manager.eventBus ~= nil then
+                    self.manager.eventBus.publish("CS_CRITICAL_THRESHOLD", {
+                        fieldId      = fieldId,
+                        moistureLevel = data.moisture,
+                    })
+                end
+            end
+        end
+
+        if self.manager.debugMode then
+            g_logManager:devInfo("[CropStress]", string.format(
+                "Field %d: %.1f%% → %.1f%% (evap=%.4f rain=%.4f irr=%.4f)",
+                fieldId, prevMoisture * 100, data.moisture * 100,
+                evapLoss, rainGain, irrigGain
+            ))
+        end
+    end
+end
+
+-- Returns moisture (0.0–1.0) for a field, or nil if unknown
+function SoilMoistureSystem:getMoisture(fieldId)
+    local d = self.fieldData[fieldId]
+    return d and d.moisture or nil
+end
+
+-- Force-set moisture (for debug console commands)
+function SoilMoistureSystem:setMoisture(fieldId, value)
+    if self.fieldData[fieldId] ~= nil then
+        self.fieldData[fieldId].moisture = math.max(0.0, math.min(1.0, value))
+        return true
+    end
+    return false
+end
+
+function SoilMoistureSystem:getFieldCount()
+    local count = 0
+    for _ in pairs(self.fieldData) do count = count + 1 end
+    return count
+end
+
+-- Returns a sorted list of {fieldId, moisture, soilType} for HUD display
+function SoilMoistureSystem:getFieldsSortedByMoisture()
+    local list = {}
+    for fieldId, data in pairs(self.fieldData) do
+        table.insert(list, { fieldId = fieldId, moisture = data.moisture, soilType = data.soilType })
+    end
+    table.sort(list, function(a, b) return a.moisture < b.moisture end)
+    return list
+end
+
+-- Detect soil type from FS25 map metadata.
+-- FS25 maps vary widely in what metadata they expose.
+-- This uses a best-effort hierarchy; defaults to "loamy".
+function SoilMoistureSystem:detectSoilType(field)
+    -- 1. Try field's custom attribute if map author set it
+    if field.soilType ~= nil then
+        local s = tostring(field.soilType):lower()
+        if SoilMoistureSystem.SOIL_PARAMS[s] ~= nil then return s end
+    end
+
+    -- 2. Try terrain detail layer at field center
+    -- (Requires map support — many vanilla maps don't expose this)
+    -- NOTE: If FS25 LUADOC documents getTerrainAttributeAtWorldPos, implement here.
+
+    -- 3. Heuristic: use field position's biome/map region if available
+    -- (Placeholder for future map-specific support)
+
+    -- 4. Default
+    return "loamy"
+end
+
+function SoilMoistureSystem:delete()
+    self.isInitialized = false
+end

--- a/src/WeatherIntegration.lua
+++ b/src/WeatherIntegration.lua
@@ -1,0 +1,135 @@
+-- ============================================================
+-- WeatherIntegration.lua
+-- Bridges FS25's environment/weather API to the moisture system.
+-- Polled every in-game hour by CropStressManager:onHourlyTick().
+--
+-- Does NOT subscribe to MessageType events (FS25 event IDs are
+-- integer-mapped and may differ by version). Instead, polls the
+-- weather state directly — reliable and version-agnostic.
+-- ============================================================
+
+WeatherIntegration = {}
+WeatherIntegration.__index = WeatherIntegration
+
+-- Season indices (matches g_currentMission.environment:currentSeason())
+WeatherIntegration.SEASON_SPRING = 0
+WeatherIntegration.SEASON_SUMMER = 1
+WeatherIntegration.SEASON_AUTUMN = 2
+WeatherIntegration.SEASON_WINTER = 3
+
+-- Season display names (English — UI uses i18n keys)
+WeatherIntegration.SEASON_NAMES = { [0]="Spring", [1]="Summer", [2]="Autumn", [3]="Winter" }
+
+function WeatherIntegration.new(manager)
+    local self = setmetatable({}, WeatherIntegration)
+    self.manager = manager
+
+    -- Cached state (updated each hourly poll)
+    self.currentTemp     = 15.0   -- degrees Celsius
+    self.currentSeason   = WeatherIntegration.SEASON_SPRING
+    self.currentHumidity = 0.5    -- 0.0-1.0
+
+    -- Rain state: rainScale is the FS25 normalized rain intensity (0.0-1.0)
+    self.rainScale       = 0.0
+    self.isRaining       = false
+
+    -- Accumulated rain for the current hour (in moisture fraction units)
+    -- Calculated from rainScale * absorption coefficient
+    self.hourlyRainAmount = 0.0
+
+    self.isInitialized = false
+    return self
+end
+
+function WeatherIntegration:initialize()
+    if g_currentMission == nil then
+        g_logManager:devInfo("[CropStress]", "WeatherIntegration: g_currentMission nil at init")
+        return
+    end
+
+    -- Do an immediate poll to populate cached values
+    self:update()
+    self.isInitialized = true
+    g_logManager:devInfo("[CropStress]", string.format(
+        "WeatherIntegration initialized. Season=%s Temp=%.1f°C Rain=%s",
+        WeatherIntegration.SEASON_NAMES[self.currentSeason] or "?",
+        self.currentTemp,
+        tostring(self.isRaining)
+    ))
+end
+
+-- Called every in-game hour by CropStressManager:onHourlyTick()
+function WeatherIntegration:update()
+    if g_currentMission == nil then return end
+    local env = g_currentMission.environment
+    if env == nil then return end
+
+    -- Season
+    self.currentSeason = env:currentSeason() or WeatherIntegration.SEASON_SPRING
+
+    -- Temperature
+    -- FS25: env.weather.temperature or env.weather:getCurrentTemperature()
+    -- Try multiple access paths for compatibility across patch versions
+    local temp = 15.0
+    if env.weather ~= nil then
+        if env.weather.temperature ~= nil then
+            temp = env.weather.temperature
+        elseif type(env.weather.getCurrentTemperature) == "function" then
+            temp = env.weather:getCurrentTemperature() or 15.0
+        end
+    end
+    self.currentTemp = temp
+
+    -- Humidity (optional — used for extended forecast; fall back gracefully)
+    if env.weather ~= nil and env.weather.relativeHumidity ~= nil then
+        self.currentHumidity = env.weather.relativeHumidity
+    end
+
+    -- Rain intensity
+    -- FS25: env.weather.rainScale is a 0.0-1.0 normalized rain amount
+    self.rainScale = 0.0
+    if env.weather ~= nil then
+        if env.weather.rainScale ~= nil then
+            self.rainScale = env.weather.rainScale or 0.0
+        elseif type(env.weather.getRainFallScale) == "function" then
+            self.rainScale = env.weather:getRainFallScale() or 0.0
+        end
+    end
+    self.isRaining = self.rainScale > 0.01
+
+    -- Translate rain scale to moisture gain per hour.
+    -- Base: 0.012 moisture fraction per hour at rainScale=1.0
+    -- Heavy rain (scale ~1.5) gives 0.018/hr; drizzle (0.3) gives 0.0036/hr
+    self.hourlyRainAmount = self.isRaining and (0.012 * self.rainScale) or 0.0
+end
+
+-- Evaporation multiplier for the current hour, combining temperature and season.
+-- Returns a float (typically 0.2 – 2.5). Used by SoilMoistureSystem.
+function WeatherIntegration:getHourlyEvapMultiplier()
+    -- Temperature component: +3% per °C above 15°C
+    local tempMod = 1.0 + math.max(0.0, (self.currentTemp - 15.0) * 0.03)
+
+    -- Season component
+    local seasonMods = { [0]=0.80, [1]=1.40, [2]=0.90, [3]=0.20 }
+    local seasonMod = seasonMods[self.currentSeason] or 1.0
+
+    return tempMod * seasonMod
+end
+
+-- Returns the moisture gain per hour from current rainfall.
+function WeatherIntegration:getHourlyRainAmount()
+    return self.hourlyRainAmount
+end
+
+function WeatherIntegration:getCurrentSeason()
+    return self.currentSeason
+end
+
+function WeatherIntegration:getCurrentTemp()
+    return self.currentTemp
+end
+
+function WeatherIntegration:delete()
+    -- No subscriptions to clean up (we poll instead)
+    self.isInitialized = false
+end

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <text name="cs_hud_title"         text="BODENFEUCHTE"/>
+    <text name="cs_hud_healthy"       text="Gesund"/>
+    <text name="cs_hud_warning"       text="Trockenstress"/>
+    <text name="cs_hud_critical"      text="KRITISCH — Jetzt bewässern!"/>
+    <text name="cs_hud_no_crop"       text="Keine Frucht"/>
+    <text name="cs_hud_forecast"      text="5-Tage-Prognose"/>
+    <text name="cs_hud_first_run"     text="Bodenfeuchte-Monitor ist jetzt aktiv. Shift+M zum Ein-/Ausblenden."/>
+    <text name="cs_field_moisture"    text="Feuchte"/>
+    <text name="cs_field_soil_type"   text="Bodentyp"/>
+    <text name="cs_field_stress"      text="Akkumulierter Stress"/>
+    <text name="cs_field_yield_impact" text="Gesch. Ertragseinbuße"/>
+    <text name="cs_soil_sandy"        text="Sandig"/>
+    <text name="cs_soil_loamy"        text="Lehmig"/>
+    <text name="cs_soil_clay"         text="Tonig"/>
+    <text name="cs_alert_info"        text="Feld %d: %s Feuchte sinkt — Lage beobachten."/>
+    <text name="cs_alert_warning"     text="Feld %d: %s Feuchte niedrig — Bewässerung empfohlen."/>
+    <text name="cs_alert_critical"    text="Feld %d: %s Trockenstress-Grenzwert — jetzt bewässern!"/>
+    <text name="cs_irr_irrigate_now"  text="Jetzt bewässern"/>
+    <text name="cs_irr_save_schedule" text="Zeitplan speichern"/>
+    <text name="cs_consultant_name"   text="Alex Chen, Agronom"/>
+    <text name="input_CS_TOGGLE_HUD"      text="Feuchte-HUD umschalten"/>
+    <text name="input_CS_OPEN_IRRIGATION" text="Bewässerungsmanager öffnen"/>
+</l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <!-- ========== HUD OVERLAY ========== -->
+    <text name="cs_hud_title"         text="CROP MOISTURE"/>
+    <text name="cs_hud_healthy"       text="Healthy"/>
+    <text name="cs_hud_warning"       text="Drought Stress"/>
+    <text name="cs_hud_critical"      text="CRITICAL — Irrigate Now!"/>
+    <text name="cs_hud_no_crop"       text="No crop"/>
+    <text name="cs_hud_forecast"      text="5-Day Forecast"/>
+    <text name="cs_hud_first_run"     text="Crop Moisture Monitor is now active. Press Shift+M to toggle the field status panel."/>
+
+    <!-- ========== FIELD STATUS ========== -->
+    <text name="cs_field_moisture"    text="Moisture"/>
+    <text name="cs_field_soil_type"   text="Soil Type"/>
+    <text name="cs_field_stress"      text="Stress Accumulated"/>
+    <text name="cs_field_yield_impact" text="Est. Yield Impact"/>
+    <text name="cs_field_critical_window" text="Critical Window: NOW"/>
+    <text name="cs_field_nearest_water"   text="Nearest Water"/>
+
+    <!-- ========== SOIL TYPES ========== -->
+    <text name="cs_soil_sandy"        text="Sandy"/>
+    <text name="cs_soil_loamy"        text="Loamy"/>
+    <text name="cs_soil_clay"         text="Clay"/>
+
+    <!-- ========== ALERTS ========== -->
+    <text name="cs_alert_info"        text="Field %d: %s moisture dropping — monitor conditions."/>
+    <text name="cs_alert_warning"     text="Field %d: %s moisture low — irrigation recommended."/>
+    <text name="cs_alert_critical"    text="Field %d: %s at drought stress threshold — irrigate NOW!"/>
+
+    <!-- ========== IRRIGATION (Phase 2) ========== -->
+    <text name="cs_irr_title"         text="Irrigation System — %s"/>
+    <text name="cs_irr_water_source"  text="Water Source"/>
+    <text name="cs_irr_connected"     text="Connected"/>
+    <text name="cs_irr_disconnected"  text="Disconnected"/>
+    <text name="cs_irr_schedule"      text="Schedule"/>
+    <text name="cs_irr_flow_rate"     text="Flow Rate"/>
+    <text name="cs_irr_efficiency"    text="Efficiency"/>
+    <text name="cs_irr_cost"          text="Est. Cost"/>
+    <text name="cs_irr_wear"          text="Wear Level"/>
+    <text name="cs_irr_covered_fields" text="Covered Fields"/>
+    <text name="cs_irr_irrigate_now"  text="Irrigate Now"/>
+    <text name="cs_irr_save_schedule" text="Save Schedule"/>
+    <text name="cs_irr_pivot"         text="Center Pivot"/>
+    <text name="cs_irr_drip"          text="Drip Line"/>
+    <text name="cs_irr_pump"          text="Water Pump"/>
+
+    <!-- ========== CONSULTANT (Phase 3) ========== -->
+    <text name="cs_consultant_name"   text="Alex Chen, Agronomist"/>
+    <text name="cs_favor_soil_sample"     text="Take a soil sample from Field %d"/>
+    <text name="cs_favor_irr_check"       text="Inspect the irrigation system near Field %d"/>
+    <text name="cs_favor_emergency_water" text="Irrigate Field %d before sundown!"/>
+    <text name="cs_favor_seasonal_plan"   text="Review the seasonal irrigation plan"/>
+
+    <!-- ========== INPUT ACTIONS ========== -->
+    <text name="input_CS_TOGGLE_HUD"      text="Toggle Moisture HUD"/>
+    <text name="input_CS_OPEN_IRRIGATION" text="Open Irrigation Manager"/>
+</l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <text name="cs_hud_title"         text="HUMIDITÉ DU SOL"/>
+    <text name="cs_hud_healthy"       text="Sain"/>
+    <text name="cs_hud_warning"       text="Stress hydrique"/>
+    <text name="cs_hud_critical"      text="CRITIQUE — Irriguer maintenant !"/>
+    <text name="cs_hud_no_crop"       text="Pas de culture"/>
+    <text name="cs_hud_forecast"      text="Prévisions 5 jours"/>
+    <text name="cs_hud_first_run"     text="Moniteur d'humidité actif. Maj+M pour afficher/masquer."/>
+    <text name="cs_field_moisture"    text="Humidité"/>
+    <text name="cs_field_soil_type"   text="Type de sol"/>
+    <text name="cs_field_stress"      text="Stress accumulé"/>
+    <text name="cs_field_yield_impact" text="Impact rendement estimé"/>
+    <text name="cs_soil_sandy"        text="Sableux"/>
+    <text name="cs_soil_loamy"        text="Limoneux"/>
+    <text name="cs_soil_clay"         text="Argileux"/>
+    <text name="cs_alert_info"        text="Champ %d : %s humidité baisse — surveiller."/>
+    <text name="cs_alert_warning"     text="Champ %d : %s humidité faible — irrigation recommandée."/>
+    <text name="cs_alert_critical"    text="Champ %d : %s seuil de stress hydrique — irriguer !"/>
+    <text name="cs_irr_irrigate_now"  text="Irriguer maintenant"/>
+    <text name="cs_irr_save_schedule" text="Enregistrer le programme"/>
+    <text name="cs_consultant_name"   text="Alex Chen, Agronome"/>
+    <text name="input_CS_TOGGLE_HUD"      text="Afficher/masquer HUD humidité"/>
+    <text name="input_CS_OPEN_IRRIGATION" text="Ouvrir gestionnaire d'irrigation"/>
+</l10n>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<l10n>
+    <text name="cs_hud_title"         text="BODEMVOCHTIGHEID"/>
+    <text name="cs_hud_healthy"       text="Gezond"/>
+    <text name="cs_hud_warning"       text="Droogtestress"/>
+    <text name="cs_hud_critical"      text="KRITIEK — Irrigeer nu!"/>
+    <text name="cs_hud_no_crop"       text="Geen gewas"/>
+    <text name="cs_hud_forecast"      text="5-dagenprognose"/>
+    <text name="cs_hud_first_run"     text="Bodemvochtmonitor actief. Shift+M om te schakelen."/>
+    <text name="cs_field_moisture"    text="Vochtigheid"/>
+    <text name="cs_field_soil_type"   text="Bodemtype"/>
+    <text name="cs_field_stress"      text="Geaccumuleerde stress"/>
+    <text name="cs_field_yield_impact" text="Geschatte opbrengstderving"/>
+    <text name="cs_soil_sandy"        text="Zandig"/>
+    <text name="cs_soil_loamy"        text="Lemig"/>
+    <text name="cs_soil_clay"         text="Kleiig"/>
+    <text name="cs_alert_info"        text="Veld %d: %s vochtigheid daalt — situatie volgen."/>
+    <text name="cs_alert_warning"     text="Veld %d: %s vochtigheid laag — irrigatie aanbevolen."/>
+    <text name="cs_alert_critical"    text="Veld %d: %s droogtestress-drempel — irrigeer nu!"/>
+    <text name="cs_irr_irrigate_now"  text="Nu irrigeren"/>
+    <text name="cs_irr_save_schedule" text="Schema opslaan"/>
+    <text name="cs_consultant_name"   text="Alex Chen, Agronoom"/>
+    <text name="input_CS_TOGGLE_HUD"      text="HUD vochtigheid in-/uitschakelen"/>
+    <text name="input_CS_OPEN_IRRIGATION" text="Irrigatiebeheer openen"/>
+</l10n>


### PR DESCRIPTION
## Summary

This PR delivers Phase 1 of `FS25_SeasonalCropStress` — the complete MVP simulation layer.

- **SoilMoistureSystem** — per-field moisture (0–100%) driven by real weather: evapotranspiration adjusts hourly based on temperature × season × soil type, rainfall from `env.weather.rainScale` adds moisture each hour. Season-aware initialization (spring 60%, summer 40%, autumn 55%, winter 70%)
- **WeatherIntegration** — polls FS25 environment API each hourly tick; multi-path fallbacks for temp and rain access across FS25 patch versions
- **CropStressModifier** — tracks critical growth windows per crop type; accumulates yield stress when moisture < threshold; harvest hook via `Utils.overwrittenFunction` on `HarvestingMachine.doGroundWorkArea` applies up to 60% yield reduction
- **CropStressManager** — central coordinator with `CropEventBus` (internal event emitter, avoids dependence on integer-mapped MessageType IDs), hourly tick via monotonic day+hour key, runtime detection of optional mods (NPCFavor, UsedPlus, PF DLC)
- **HUDOverlay** — immediate-mode rendering (renderText / drawFilledRect), color-coded moisture bars (green/yellow/red), auto-show on critical threshold, first-run tooltip, Shift+M toggle
- **SaveLoadHandler** — saves moisture + stress state inside `careerSavegame.xml` under `careerSavegame.cropStress`
- **Console commands** — `csHelp`, `csStatus`, `csSetMoisture`, `csForceStress`, `csSimulateHeat`, `csDebug`

Phase 2–4 stubs load cleanly and document their own implementation specs in header comments.

## Test plan

- [ ] Load new save → `csStatus` shows N fields at season-appropriate moisture, no log errors
- [ ] Run `csSimulateHeat 5` → fields drain, `csStatus` shows lower moisture
- [ ] Run `csForceStress <fieldId>` then harvest that field → yield visibly reduced
- [ ] Save and reload → moisture and stress values persist exactly
- [ ] Shift+M → HUD panel shows, color-coded bars update each hour
- [ ] Load without NPCFavor / UsedPlus → no nil access errors in log
- [ ] Check `[CropStress]` lines in log.txt for clean initialization sequence

## API verification needed (before Phase 2)

These FS25 API calls have multi-path fallbacks in code but need live game verification:
- `HarvestingMachine.doGroundWorkArea` parameter names + `setFillUnitFillLevel` signature
- `field:getFruitType()` vs `field.fruitType` (method vs property)
- `field:getGrowthState()` vs `field.growthState`
- `env.weather.temperature` vs `env.weather:getCurrentTemperature()`
- `env.weather.rainScale` vs `env.weather:getRainFallScale()`
- `field:containsPoint(x, z)` for position→field lookup

## Files changed

| File | Status |
|------|--------|
| `modDesc.xml` | New — descVersion 105, Phase 1 bindings |
| `main.lua` | New — lifecycle hooks + module load order |
| `src/CropStressManager.lua` | New — coordinator + CropEventBus |
| `src/SoilMoistureSystem.lua` | New — moisture simulation |
| `src/WeatherIntegration.lua` | New — weather polling bridge |
| `src/CropStressModifier.lua` | New — stress + harvest hook |
| `src/HUDOverlay.lua` | New — field moisture display |
| `src/SaveLoadHandler.lua` | New — persistence |
| `src/IrrigationManager.lua` | New — Phase 2 stub |
| `src/CropConsultant.lua` | New — Phase 3 stub |
| `src/NPCIntegration.lua` | New — Phase 3 stub |
| `src/FinanceIntegration.lua` | New — Phase 4 stub |
| `gui/*.lua` | New — Phase 2/3 stubs |
| `translations/translation_*.xml` | New — EN full, DE/FR/NL Phase 1 keys |
| `config/cropStressDefaults.xml` | New — all tunable defaults |
| `build.sh` | New — zip + deploy |
| `CLAUDE.md` | New — project-specific session rules |
| `FS25_SeasonalCropStress_ModPlan.md` | New — v2.0, full phase status + implementation guides |