### PR TITLE
feat: CoursePlay, AutoDrive, and SoilFertilizer mod integrations

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -71,6 +71,9 @@ source(modDir .. "src/NPCIntegration.lua")
 source(modDir .. "src/FinanceIntegration.lua")
 source(modDir .. "src/UsedEquipmentMarketplace.lua")
 source(modDir .. "src/PrecisionFarmingOverlay.lua")
+source(modDir .. "src/SoilFertilizerIntegration.lua")
+source(modDir .. "src/CoursePlayIntegration.lua")
+source(modDir .. "src/AutoDriveIntegration.lua")
 
 -- Event bus
 source(modDir .. "src/events/CropStressSettingsSyncEvent.lua")

--- a/src/AutoDriveIntegration.lua
+++ b/src/AutoDriveIntegration.lua
@@ -1,0 +1,209 @@
+-- ============================================================
+-- AutoDriveIntegration.lua
+-- Optional integration with AutoDrive for FS25.
+--
+-- Reads AutoDrive destination data to inform the player about
+-- available water-hauling infrastructure when a critical drought
+-- alert fires. When AutoDrive is detected and destinations are
+-- configured, the Crop Consultant appends a one-line hint to
+-- CRITICAL alerts suggesting the player set up a water route.
+--
+-- This integration is READ-ONLY. We never call StartDriving or
+-- modify AutoDrive state in any way.
+--
+-- Detection global: AutoDrive (no g_ prefix — confirmed FS25 source)
+-- NOTE: FS22 used g_autoDrive. FS25 uses AutoDrive (bare table).
+--
+-- API used (confirmed from ExternalInterface.lua):
+--   AutoDrive:GetAvailableDestinations()
+--     Returns: { [id] = { name, x, y, z, id }, ... }
+--
+-- Water destination heuristic: if a destination's name contains
+-- any of the water-related keywords below, it is counted as a
+-- possible water source for irrigation water hauling.
+-- ============================================================
+
+local function csLog(msg)
+    if g_logManager ~= nil then g_logManager:devInfo("[CropStress]", msg)
+    else print("[CropStress] " .. tostring(msg)) end
+end
+
+AutoDriveIntegration = {}
+AutoDriveIntegration.__index = AutoDriveIntegration
+
+-- Cache TTL in in-game hours; destinations rarely change mid-session
+AutoDriveIntegration.CACHE_TTL_HOURS = 6
+
+-- Lowercase substrings that suggest a destination is a water source.
+-- Checked against the destination's `name` field (case-insensitive).
+AutoDriveIntegration.WATER_KEYWORDS = {
+    "water", "pump", "tank", "irrig", "pond", "lake",
+    "river", "well", "cistern", "reservoir",
+}
+
+-- ============================================================
+-- CONSTRUCTOR
+-- ============================================================
+function AutoDriveIntegration.new(manager)
+    local self = setmetatable({}, AutoDriveIntegration)
+    self.manager       = manager
+    self.adActive      = false     -- set by CropStressManager:detectOptionalMods()
+    self.isInitialized = false
+
+    -- Cached counts (refreshed hourly)
+    self.destinationCount      = 0
+    self.waterDestinationCount = 0
+    self.lastCacheHourKey      = -1
+
+    return self
+end
+
+-- ============================================================
+-- INITIALIZE
+-- ============================================================
+function AutoDriveIntegration:initialize()
+    self.isInitialized = true
+    if not self.adActive then
+        csLog("AutoDriveIntegration: AutoDrive not detected — running without AD context")
+        return
+    end
+    -- Populate cache immediately so first-tick alerts have data
+    self:refreshDestinationCache(-1)
+    csLog(string.format(
+        "AutoDriveIntegration: active — %d destinations (%d water-related)",
+        self.destinationCount, self.waterDestinationCount))
+end
+
+-- ============================================================
+-- ACTIVATION
+-- Called by CropStressManager:detectOptionalMods().
+-- ============================================================
+function AutoDriveIntegration:enableAutoDriveMode()
+    self.adActive = true
+end
+
+-- ============================================================
+-- IS ACTIVE
+-- ============================================================
+function AutoDriveIntegration:isActive()
+    return self.adActive and self.isInitialized
+end
+
+-- ============================================================
+-- HOURLY REFRESH
+-- Updates the destination cache if the TTL has elapsed.
+-- Called from CropStressManager:onHourlyTick().
+-- ============================================================
+function AutoDriveIntegration:hourlyRefresh()
+    if not self:isActive() then return end
+
+    local env     = g_currentMission and g_currentMission.environment
+    local hourKey = 0
+    if env ~= nil then
+        hourKey = (env.currentMonotonicDay or 0) * 24 + (env.currentHour or 0)
+    end
+
+    if (hourKey - self.lastCacheHourKey) < AutoDriveIntegration.CACHE_TTL_HOURS then
+        return  -- Still fresh
+    end
+
+    self:refreshDestinationCache(hourKey)
+end
+
+-- ============================================================
+-- REFRESH DESTINATION CACHE
+-- Calls the confirmed AutoDrive public API and counts destinations.
+-- ============================================================
+function AutoDriveIntegration:refreshDestinationCache(hourKey)
+    self.destinationCount      = 0
+    self.waterDestinationCount = 0
+    self.lastCacheHourKey      = hourKey
+
+    -- Guard: AutoDrive table and GetAvailableDestinations must both exist
+    if AutoDrive == nil then return end
+    if type(AutoDrive.GetAvailableDestinations) ~= "function" then return end
+
+    local ok, destinations = pcall(function()
+        return AutoDrive:GetAvailableDestinations()
+    end)
+    if not ok or type(destinations) ~= "table" then return end
+
+    for _, dest in pairs(destinations) do
+        self.destinationCount = self.destinationCount + 1
+        if dest ~= nil and self:isWaterDestination(dest) then
+            self.waterDestinationCount = self.waterDestinationCount + 1
+        end
+    end
+
+    if self.manager and self.manager.debugMode then
+        csLog(string.format(
+            "AutoDriveIntegration: cache refreshed — %d destinations (%d water)",
+            self.destinationCount, self.waterDestinationCount))
+    end
+end
+
+-- ============================================================
+-- WATER DESTINATION HEURISTIC
+-- Checks a destination's name for water-related keywords.
+-- ============================================================
+function AutoDriveIntegration:isWaterDestination(dest)
+    local name = dest.name
+    if name == nil then return false end
+    local lower = string.lower(tostring(name))
+    for _, keyword in ipairs(AutoDriveIntegration.WATER_KEYWORDS) do
+        if lower:find(keyword, 1, true) then
+            return true
+        end
+    end
+    return false
+end
+
+-- ============================================================
+-- PUBLIC ACCESSORS
+-- ============================================================
+
+function AutoDriveIntegration:getDestinationCount()
+    return self.destinationCount
+end
+
+function AutoDriveIntegration:getWaterDestinationCount()
+    return self.waterDestinationCount
+end
+
+-- Returns a short localised hint for CRITICAL stress alerts,
+-- or nil if AutoDrive is inactive or has no destinations.
+function AutoDriveIntegration:getCriticalAlertHint()
+    if not self:isActive() then return nil end
+    if self.destinationCount == 0 then return nil end
+
+    -- getText() returns the key itself when a translation is missing — the standard FS25 pattern.
+    -- Hardcoded English fallback ensures players never see a raw "cs_ad_..." key.
+    local function getLocalised(key, ...)
+        if g_i18n ~= nil then
+            local t = g_i18n:getText(key)
+            if t ~= nil and t ~= key then return string.format(t, ...) end
+        end
+        return nil
+    end
+
+    -- With identified water destinations: direct hint
+    if self.waterDestinationCount > 0 then
+        return getLocalised("cs_ad_water_hint", self.waterDestinationCount)
+            or string.format(
+                "AutoDrive: %d water destination(s) available — consider a hauling route",
+                self.waterDestinationCount)
+    end
+
+    -- Destinations exist but none matched water keywords
+    return getLocalised("cs_ad_destinations", self.destinationCount)
+        or string.format("AutoDrive: %d destination(s) configured", self.destinationCount)
+end
+
+-- ============================================================
+-- CLEANUP
+-- ============================================================
+function AutoDriveIntegration:delete()
+    self.destinationCount      = 0
+    self.waterDestinationCount = 0
+    self.isInitialized         = false
+end

--- a/src/CoursePlayIntegration.lua
+++ b/src/CoursePlayIntegration.lua
@@ -1,0 +1,248 @@
+-- ============================================================
+-- CoursePlayIntegration.lua
+-- Optional integration with CoursePlay for FS25.
+--
+-- Detects CoursePlay presence and reads vehicle activity to
+-- enrich crop stress alerts with context about which stressed
+-- fields are currently being worked by autonomous vehicles.
+--
+-- This integration is READ-ONLY. We never start, stop, or
+-- redirect CoursePlay vehicles. We only report status to the
+-- player via the Crop Consultant alert system.
+--
+-- Detection global: g_Courseplay (capital P — confirmed FS25 source)
+-- NOTE: FS22 used g_courseplay (lowercase). FS25 uses g_Courseplay.
+--
+-- Vehicle API used (confirmed from CpAIWorker.lua specialization):
+--   vehicle:getIsCpActive()    → bool: CP job currently running
+--   vehicle:hasCourse()        → bool: vehicle has an assigned course
+--
+-- Vehicle position: getWorldTranslation(vehicle.rootNode) → x, y, z
+-- Field position matching uses g_currentMission.fieldManager:getFields()
+-- and compares against each field's boundary with a radius fallback.
+-- ============================================================
+
+local function csLog(msg)
+    if g_logManager ~= nil then g_logManager:devInfo("[CropStress]", msg)
+    else print("[CropStress] " .. tostring(msg)) end
+end
+
+CoursePlayIntegration = {}
+CoursePlayIntegration.__index = CoursePlayIntegration
+
+-- Radius (metres) used to associate a vehicle with a field when
+-- precise field boundary data is not available on the field object.
+CoursePlayIntegration.FIELD_MATCH_RADIUS = 75
+
+-- ============================================================
+-- CONSTRUCTOR
+-- ============================================================
+function CoursePlayIntegration.new(manager)
+    local self = setmetatable({}, CoursePlayIntegration)
+    self.manager       = manager
+    self.cpActive      = false     -- set by CropStressManager:detectOptionalMods()
+    self.isInitialized = false
+
+    -- Cache: fieldId → vehicle count; refreshed each hourly tick
+    self.vehiclesPerField  = {}
+    self.totalActiveVehicles = 0
+
+    return self
+end
+
+-- ============================================================
+-- INITIALIZE
+-- ============================================================
+function CoursePlayIntegration:initialize()
+    self.isInitialized = true
+    if not self.cpActive then
+        csLog("CoursePlayIntegration: CoursePlay not detected — running without CP context")
+        return
+    end
+    csLog("CoursePlayIntegration: active — CP vehicle activity will appear in stress alerts")
+end
+
+-- ============================================================
+-- ACTIVATION
+-- Called by CropStressManager:detectOptionalMods().
+-- ============================================================
+function CoursePlayIntegration:enableCoursePlayMode()
+    self.cpActive = true
+end
+
+-- ============================================================
+-- IS ACTIVE
+-- ============================================================
+function CoursePlayIntegration:isActive()
+    return self.cpActive and self.isInitialized
+end
+
+-- ============================================================
+-- HOURLY REFRESH
+-- Scans all vehicles, counts CP-active ones, and maps them to
+-- fields by world position. Called from CropStressManager:onHourlyTick().
+-- ============================================================
+function CoursePlayIntegration:hourlyRefresh()
+    if not self:isActive() then return end
+    if g_currentMission == nil then return end
+
+    -- Reset counters
+    self.vehiclesPerField    = {}
+    self.totalActiveVehicles = 0
+
+    local vehicles = g_currentMission.vehicles
+    if vehicles == nil then return end
+
+    -- Pre-fetch field list once (not every vehicle iteration)
+    local fields = nil
+    if g_currentMission.fieldManager ~= nil then
+        local ok, result = pcall(function()
+            return g_currentMission.fieldManager:getFields()
+        end)
+        if ok then fields = result end
+    end
+
+    for _, vehicle in pairs(vehicles) do
+        if vehicle == nil then
+            -- Sparse table may have nil entries; skip
+        elseif type(vehicle.getIsCpActive) == "function" then
+            local ok, isActive = pcall(function()
+                return vehicle:getIsCpActive()
+            end)
+            if ok and isActive then
+                self.totalActiveVehicles = self.totalActiveVehicles + 1
+                -- Map to field
+                local fieldId = self:getFieldForVehicle(vehicle, fields)
+                if fieldId ~= nil then
+                    self.vehiclesPerField[fieldId] = (self.vehiclesPerField[fieldId] or 0) + 1
+                end
+            end
+        end
+    end
+
+    if self.manager and self.manager.debugMode then
+        csLog(string.format("CoursePlayIntegration: %d active CP vehicles", self.totalActiveVehicles))
+    end
+end
+
+-- ============================================================
+-- FIELD LOOKUP FOR A VEHICLE
+-- Returns the fieldId of the field the vehicle is currently in,
+-- or nil if no match found. Uses bounding box when available,
+-- falls back to centre-point + radius.
+-- ============================================================
+function CoursePlayIntegration:getFieldForVehicle(vehicle, fields)
+    if vehicle.rootNode == nil then return nil end
+    if fields == nil then return nil end
+
+    local ok, vx, _, vz = pcall(function()
+        return getWorldTranslation(vehicle.rootNode)
+    end)
+    if not ok then return nil end
+
+    for _, field in pairs(fields) do
+        if self:positionInField(field, vx, vz) then
+            return field.fieldId
+        end
+    end
+    return nil
+end
+
+-- ============================================================
+-- POSITION-IN-FIELD TEST
+-- Uses bounding box from field object when present; falls back
+-- to centre + radius approximation.
+-- ============================================================
+function CoursePlayIntegration:positionInField(field, x, z)
+    -- Prefer axis-aligned bounding box if the field object exposes it
+    if field.minX ~= nil and field.maxX ~= nil
+    and field.minZ ~= nil and field.maxZ ~= nil then
+        return (x >= field.minX and x <= field.maxX
+            and z >= field.minZ and z <= field.maxZ)
+    end
+
+    -- Fallback: centre + configured radius
+    local fx = field.posX
+        or (field.startX and (field.startX + (field.widthX  or 0) * 0.5))
+        or x + 999  -- no match if position is unknown
+    local fz = field.posZ
+        or (field.startZ and (field.startZ + (field.heightZ or 0) * 0.5))
+        or z + 999
+    local radius = field.fieldRadius or CoursePlayIntegration.FIELD_MATCH_RADIUS
+
+    local dx = x - fx
+    local dz = z - fz
+    return (dx * dx + dz * dz) <= (radius * radius)
+end
+
+-- ============================================================
+-- PUBLIC ACCESSORS
+-- ============================================================
+
+-- Total number of CoursePlay-active vehicles across the entire map.
+function CoursePlayIntegration:getActiveVehicleCount()
+    return self.totalActiveVehicles
+end
+
+-- Number of CP-active vehicles currently on a specific field.
+-- Returns 0 if none.
+function CoursePlayIntegration:getVehiclesOnField(fieldId)
+    return self.vehiclesPerField[fieldId] or 0
+end
+
+-- Returns a snapshot of {fieldId → vehicleCount} for all fields
+-- that have at least one active CP vehicle.
+function CoursePlayIntegration:getVehiclesOnStressedFields()
+    if not self:isActive() then return {} end
+
+    local result = {}
+    local soilSystem = self.manager and self.manager.soilSystem
+    if soilSystem == nil then return result end
+
+    local critThreshold = (self.manager.soilSystem.getCriticalMoisture ~= nil)
+        and self.manager.soilSystem:getCriticalMoisture()
+        or 0.30  -- fallback to conservative threshold
+
+    for fieldId, vehicleCount in pairs(self.vehiclesPerField) do
+        if vehicleCount > 0 then
+            local moisture = soilSystem:getMoisture(fieldId)
+            if moisture ~= nil and moisture <= critThreshold * 1.5 then
+                -- Include fields that are stressed or approaching stress
+                result[fieldId] = vehicleCount
+            end
+        end
+    end
+
+    return result
+end
+
+-- Returns a short localised context string for alert messages.
+-- Returns nil when CoursePlay is inactive or no vehicles are relevant.
+function CoursePlayIntegration:getContextForField(fieldId)
+    if not self:isActive() then return nil end
+
+    local count = self:getVehiclesOnField(fieldId)
+    if count == 0 then return nil end
+
+    -- getText() returns the key itself when a translation is missing — the standard FS25 pattern.
+    -- Falling back to hardcoded English ensures players never see a raw "cs_cp_..." key.
+    local key = (count == 1) and "cs_cp_vehicle_on_field" or "cs_cp_vehicles_on_field"
+    if g_i18n ~= nil then
+        local template = g_i18n:getText(key)
+        if template ~= nil and template ~= key then
+            return string.format(template, count)
+        end
+    end
+    return string.format(count == 1
+        and "CoursePlay: %d vehicle on this field"
+        or  "CoursePlay: %d vehicles on this field", count)
+end
+
+-- ============================================================
+-- CLEANUP
+-- ============================================================
+function CoursePlayIntegration:delete()
+    self.vehiclesPerField    = {}
+    self.totalActiveVehicles = 0
+    self.isInitialized       = false
+end

--- a/src/CropConsultant.lua
+++ b/src/CropConsultant.lua
@@ -226,6 +226,24 @@ function CropConsultant:showAlert(fieldId, moisture, severity, cropName)
     csLog(string.format("CropConsultant [%s] Field %d (%.0f%%): %s",
         severity, fieldId, moisture * 100, msg))
 
+    -- CoursePlay context: if CP vehicles are on this stressed field, show a follow-up hint
+    if self.manager ~= nil and self.manager.coursePlayIntegration ~= nil then
+        local cpCtx = self.manager.coursePlayIntegration:getContextForField(fieldId)
+        if cpCtx ~= nil then
+            g_currentMission:showBlinkingWarning(cpCtx, 4000)
+        end
+    end
+
+    -- AutoDrive context: for CRITICAL alerts, suggest setting up a water hauling route
+    if severity == "CRITICAL"
+    and self.manager ~= nil
+    and self.manager.autoDriveIntegration ~= nil then
+        local adHint = self.manager.autoDriveIntegration:getCriticalAlertHint()
+        if adHint ~= nil then
+            g_currentMission:showBlinkingWarning(adHint, 5000)
+        end
+    end
+
     -- Forward to NPC integration for dialog / favor generation
     if self.npcFavorMode
     and self.manager ~= nil

--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -111,6 +111,35 @@ function CropStressManager.new()
         csLog("WARNING: PrecisionFarmingOverlay class not loaded — check main.lua source() order")
         self.precisionFarmingOverlay = { initialize=function()end, delete=function()end, enablePrecisionFarmingMode=function()end }
     end
+
+    -- New optional mod bridges (loaded in main.lua after PrecisionFarmingOverlay)
+    local function makeNoop(methods)
+        local stub = {}
+        for _, m in ipairs(methods) do stub[m] = function() end end
+        return stub
+    end
+
+    if SoilFertilizerIntegration ~= nil then
+        self.soilFertilizerIntegration = SoilFertilizerIntegration.new(self)
+    else
+        csLog("WARNING: SoilFertilizerIntegration class not loaded — check main.lua source() order")
+        self.soilFertilizerIntegration = makeNoop({"initialize","delete","enableSoilFertilizerMode","hourlyRefresh","isActive","getFieldEvapMod","getFieldStressMod","getSummary"})
+    end
+
+    if CoursePlayIntegration ~= nil then
+        self.coursePlayIntegration = CoursePlayIntegration.new(self)
+    else
+        csLog("WARNING: CoursePlayIntegration class not loaded — check main.lua source() order")
+        self.coursePlayIntegration = makeNoop({"initialize","delete","enableCoursePlayMode","hourlyRefresh","isActive","getActiveVehicleCount","getVehiclesOnField","getContextForField"})
+    end
+
+    if AutoDriveIntegration ~= nil then
+        self.autoDriveIntegration = AutoDriveIntegration.new(self)
+    else
+        csLog("WARNING: AutoDriveIntegration class not loaded — check main.lua source() order")
+        self.autoDriveIntegration = makeNoop({"initialize","delete","enableAutoDriveMode","hourlyRefresh","isActive","getDestinationCount","getWaterDestinationCount","getCriticalAlertHint"})
+    end
+
     self.saveLoad           = SaveLoadHandler.new(self)
 
     return self
@@ -137,6 +166,9 @@ function CropStressManager:initialize()
     self.financeIntegration:initialize()
     self.usedEquipmentMarketplace:initialize()
     self.precisionFarmingOverlay:initialize()
+    self.soilFertilizerIntegration:initialize()
+    self.coursePlayIntegration:initialize()
+    self.autoDriveIntegration:initialize()
 
     -- Persistence handler
     self.saveLoad:initialize()
@@ -233,7 +265,12 @@ function CropStressManager:onHourlyTick()
     -- 1. Poll current weather state
     self.weatherIntegration:update()
 
-    -- 2. Advance soil moisture simulation
+    -- 2a. Refresh optional mod data caches before the simulation tick
+    self.soilFertilizerIntegration:hourlyRefresh()  -- pH + OM modifiers per field
+    self.coursePlayIntegration:hourlyRefresh()        -- CP vehicle positions
+    self.autoDriveIntegration:hourlyRefresh()         -- AutoDrive destination count
+
+    -- 2b. Advance soil moisture simulation (reads SoilFertilizer cache internally)
     self.soilSystem:hourlyUpdate(self.weatherIntegration)
 
     -- 3. Accumulate crop stress where moisture is critical
@@ -317,6 +354,27 @@ function CropStressManager:detectOptionalMods()
         csLog("Precision Farming DLC detected — enabling PF compat (Phase 4)")
         self.precisionFarmingOverlay:enablePrecisionFarmingMode()
     end
+
+    -- FS25_SoilFertilizer (sibling mod by same author)
+    -- Global: g_SoilFertilityManager (confirmed from SoilFertilizer main.lua)
+    if g_SoilFertilityManager ~= nil then
+        csLog("FS25_SoilFertilizer detected — soil pH and organic matter will affect moisture simulation")
+        self.soilFertilizerIntegration:enableSoilFertilizerMode()
+    end
+
+    -- CoursePlay FS25
+    -- Global: g_Courseplay (capital P — confirmed from Courseplay.lua; FS22 used lowercase g_courseplay)
+    if g_Courseplay ~= nil then
+        csLog("CoursePlay detected — CP vehicle activity will appear in stress alerts")
+        self.coursePlayIntegration:enableCoursePlayMode()
+    end
+
+    -- AutoDrive FS25
+    -- Global: AutoDrive (no g_ prefix — confirmed from AutoDrive.lua; FS22 used g_autoDrive)
+    if AutoDrive ~= nil then
+        csLog("AutoDrive detected — water destination hints will appear in critical alerts")
+        self.autoDriveIntegration:enableAutoDriveMode()
+    end
 end
 
 -- ============================================================
@@ -374,6 +432,9 @@ function CropStressManager:delete()
     CropEventBus.listeners = {}
 
     -- Subsystem cleanup (reverse order of init)
+    self.autoDriveIntegration:delete()
+    self.coursePlayIntegration:delete()
+    self.soilFertilizerIntegration:delete()
     self.precisionFarmingOverlay:delete()
     self.usedEquipmentMarketplace:delete()
     self.financeIntegration:delete()
@@ -417,6 +478,20 @@ function CropStressManager:consoleStatus()
     end
 
     print(string.format("  Fields tracked: %d", self.soilSystem:getFieldCount()))
+
+    -- Optional mod integration status
+    print("  Optional integrations:")
+    print(string.format("    NPCFavor:       %s", tostring(self.npcIntegration.npcFavorActive)))
+    print(string.format("    UsedPlus:       %s", tostring(self.financeIntegration.usedPlusActive)))
+    print(string.format("    PrecisionFarm:  %s", tostring(self.precisionFarmingOverlay.pfActive)))
+    print(string.format("    SoilFertilizer: %s", tostring(self.soilFertilizerIntegration.sfActive)))
+    print(string.format("    CoursePlay:     %s (vehicles active: %d)",
+        tostring(self.coursePlayIntegration.cpActive),
+        self.coursePlayIntegration:getActiveVehicleCount() or 0))
+    print(string.format("    AutoDrive:      %s (destinations: %d, water: %d)",
+        tostring(self.autoDriveIntegration.adActive),
+        self.autoDriveIntegration:getDestinationCount()      or 0,
+        self.autoDriveIntegration:getWaterDestinationCount() or 0))
 
     -- Print top 5 driest fields
     local sorted = self.soilSystem:getFieldsSortedByMoisture()

--- a/src/SoilFertilizerIntegration.lua
+++ b/src/SoilFertilizerIntegration.lua
@@ -1,0 +1,217 @@
+-- ============================================================
+-- SoilFertilizerIntegration.lua
+-- Optional integration with FS25_SoilFertilizer (sibling mod).
+--
+-- Reads per-field soil chemistry (pH, organic matter) from the
+-- sibling mod and translates it into modifiers that affect our
+-- moisture simulation:
+--
+--   organicMatter → evaporation modifier
+--     High OM (>5%) improves water retention → lower evap rate
+--     Low  OM (<2%) reduces water retention  → higher evap rate
+--
+--   soil pH → stress threshold modifier
+--     Optimal pH (6.0-7.5): no effect
+--     Acidic  (<6.0):  +0.03 to criticalMoisture (crops stress earlier)
+--     Alkaline (>7.5): +0.02 to criticalMoisture
+--
+-- Detection global: g_SoilFertilityManager
+-- API used:
+--   g_SoilFertilityManager.soilSystem:getFieldInfo(fieldId)
+--   Returns: { pH, organicMatter, nitrogen, phosphorus, potassium, ... }
+--
+-- All reads are pcall-wrapped and nil-guarded. If the API differs
+-- or SoilFertilizer is absent, all modifiers silently return neutral
+-- values (evapMod=1.0, stressMod=0.0) and the simulation is unaffected.
+-- ============================================================
+
+local function csLog(msg)
+    if g_logManager ~= nil then g_logManager:devInfo("[CropStress]", msg)
+    else print("[CropStress] " .. tostring(msg)) end
+end
+
+SoilFertilizerIntegration = {}
+SoilFertilizerIntegration.__index = SoilFertilizerIntegration
+
+-- Organic matter bands → evaporation multiplier
+-- Values sourced from soil science: humus content > 4% substantially
+-- improves water-holding capacity; depleted soils drain fast.
+SoilFertilizerIntegration.OM_EVAP_HIGH  = 0.85  -- OM > 5%:  good retention
+SoilFertilizerIntegration.OM_EVAP_MID   = 0.92  -- OM 3-5%:  above average
+SoilFertilizerIntegration.OM_EVAP_LOW   = 1.10  -- OM 1-3%:  below average
+SoilFertilizerIntegration.OM_EVAP_POOR  = 1.18  -- OM < 1%:  poor retention
+
+-- pH bands → additive critical-moisture modifier (fraction, not %)
+SoilFertilizerIntegration.PH_STRESS_ACID  = 0.04  -- pH < 6.0: +4% threshold
+SoilFertilizerIntegration.PH_STRESS_ALK   = 0.02  -- pH > 7.5: +2% threshold
+
+-- Cache TTL: refresh field modifiers every 4 in-game hours at most
+-- (soil chemistry changes slowly; per-hour polling is excessive)
+SoilFertilizerIntegration.CACHE_TTL_HOURS = 4
+
+-- ============================================================
+-- CONSTRUCTOR
+-- ============================================================
+function SoilFertilizerIntegration.new(manager)
+    local self = setmetatable({}, SoilFertilizerIntegration)
+    self.manager       = manager
+    self.sfActive      = false      -- set by CropStressManager:detectOptionalMods()
+    self.isInitialized = false
+
+    -- Per-field cache: fieldId → { evapMod, stressMod, lastHourKey }
+    self.fieldCache = {}
+
+    return self
+end
+
+-- ============================================================
+-- INITIALIZE
+-- ============================================================
+function SoilFertilizerIntegration:initialize()
+    self.isInitialized = true
+    if not self.sfActive then
+        csLog("SoilFertilizerIntegration: FS25_SoilFertilizer not detected — running without soil chemistry")
+        return
+    end
+    csLog("SoilFertilizerIntegration: active — pH and organic matter will affect moisture simulation")
+end
+
+-- ============================================================
+-- ACTIVATION
+-- Called by CropStressManager:detectOptionalMods() when
+-- g_SoilFertilityManager is present.
+-- ============================================================
+function SoilFertilizerIntegration:enableSoilFertilizerMode()
+    self.sfActive = true
+end
+
+-- ============================================================
+-- IS ACTIVE
+-- ============================================================
+function SoilFertilizerIntegration:isActive()
+    return self.sfActive and self.isInitialized
+end
+
+-- ============================================================
+-- HOURLY REFRESH
+-- Called by CropStressManager:onHourlyTick() so the cache stays
+-- current without querying the SoilFertilizer API every frame.
+-- Only rebuilds entries that have exceeded the cache TTL.
+-- ============================================================
+function SoilFertilizerIntegration:hourlyRefresh()
+    if not self:isActive() then return end
+    if g_SoilFertilityManager == nil then return end
+
+    local env     = g_currentMission and g_currentMission.environment
+    local hourKey = 0
+    if env ~= nil then
+        hourKey = (env.currentMonotonicDay or 0) * 24 + (env.currentHour or 0)
+    end
+
+    -- Refresh stale cache entries for all tracked fields
+    local soilSystem = self.manager and self.manager.soilSystem
+    if soilSystem == nil or soilSystem.fieldData == nil then return end
+
+    for fieldId, _ in pairs(soilSystem.fieldData) do
+        local cached = self.fieldCache[fieldId]
+        if cached == nil or (hourKey - (cached.lastHourKey or 0)) >= SoilFertilizerIntegration.CACHE_TTL_HOURS then
+            self:refreshField(fieldId, hourKey)
+        end
+    end
+end
+
+-- ============================================================
+-- REFRESH SINGLE FIELD
+-- Queries SoilFertilizer for a field and updates cache entry.
+-- ============================================================
+function SoilFertilizerIntegration:refreshField(fieldId, hourKey)
+    -- getFieldInfo is the confirmed public method on SoilFertilitySystem
+    local sfSystem = g_SoilFertilityManager
+        and g_SoilFertilityManager.soilSystem
+    if sfSystem == nil then
+        self.fieldCache[fieldId] = { evapMod = 1.0, stressMod = 0.0, lastHourKey = hourKey or 0 }
+        return
+    end
+
+    local ok, info = pcall(function()
+        return sfSystem:getFieldInfo(fieldId)
+    end)
+
+    if not ok or info == nil then
+        self.fieldCache[fieldId] = { evapMod = 1.0, stressMod = 0.0, lastHourKey = hourKey or 0 }
+        return
+    end
+
+    local evapMod  = self:computeEvapMod(info.organicMatter)
+    local stressMod = self:computeStressMod(info.pH)
+
+    self.fieldCache[fieldId] = {
+        evapMod    = evapMod,
+        stressMod  = stressMod,
+        lastHourKey = hourKey or 0,
+    }
+end
+
+-- ============================================================
+-- COMPUTE EVAP MODIFIER FROM ORGANIC MATTER
+-- organicMatter is a float in SoilFertilizer's range (0.0–10.0+).
+-- ============================================================
+function SoilFertilizerIntegration:computeEvapMod(om)
+    if om == nil then return 1.0 end
+    if om >= 5.0 then return SoilFertilizerIntegration.OM_EVAP_HIGH  end
+    if om >= 3.0 then return SoilFertilizerIntegration.OM_EVAP_MID   end
+    if om >= 1.0 then return SoilFertilizerIntegration.OM_EVAP_LOW   end
+    return SoilFertilizerIntegration.OM_EVAP_POOR
+end
+
+-- ============================================================
+-- COMPUTE STRESS THRESHOLD MODIFIER FROM PH
+-- Returns an additive offset applied to criticalMoisture per field.
+-- ============================================================
+function SoilFertilizerIntegration:computeStressMod(pH)
+    if pH == nil then return 0.0 end
+    if pH < 6.0 then return SoilFertilizerIntegration.PH_STRESS_ACID end
+    if pH > 7.5 then return SoilFertilizerIntegration.PH_STRESS_ALK  end
+    return 0.0
+end
+
+-- ============================================================
+-- PUBLIC ACCESSORS
+-- Return cached values; neutral defaults if cache is empty.
+-- ============================================================
+function SoilFertilizerIntegration:getFieldEvapMod(fieldId)
+    if not self:isActive() then return 1.0 end
+    local cached = self.fieldCache[fieldId]
+    return (cached ~= nil) and cached.evapMod or 1.0
+end
+
+function SoilFertilizerIntegration:getFieldStressMod(fieldId)
+    if not self:isActive() then return 0.0 end
+    local cached = self.fieldCache[fieldId]
+    return (cached ~= nil) and cached.stressMod or 0.0
+end
+
+-- Returns a human-readable summary for the consultant dialog.
+-- Shows how many fields have chemistry outside the optimal range.
+function SoilFertilizerIntegration:getSummary()
+    if not self:isActive() then return nil end
+
+    local highEvap, poorPH = 0, 0
+    for _, cached in pairs(self.fieldCache) do
+        if cached.evapMod > 1.0 then highEvap = highEvap + 1 end
+        if cached.stressMod > 0.0 then poorPH  = poorPH  + 1 end
+    end
+
+    return {
+        highEvapFields = highEvap,
+        poorPHFields   = poorPH,
+    }
+end
+
+-- ============================================================
+-- CLEANUP
+-- ============================================================
+function SoilFertilizerIntegration:delete()
+    self.fieldCache    = {}
+    self.isInitialized = false
+end

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -137,18 +137,28 @@ function SoilMoistureSystem:hourlyUpdate(weather)
         hourKey = (env.currentMonotonicDay or 0) * 24 + (env.currentHour or 0)
     end
 
+    -- Hoist SoilFertilizer integration reference outside the field loop — it is
+    -- constant for the entire tick and resolving it per-field is wasteful.
+    local settingsEvapMult = self.evapMultiplier or 1.0
+    local sfInteg = self.manager and self.manager.soilFertilizerIntegration
+    local sfHasEvap   = sfInteg ~= nil and type(sfInteg.getFieldEvapMod)   == "function"
+    local sfHasStress = sfInteg ~= nil and type(sfInteg.getFieldStressMod) == "function"
+
     for fieldId, data in pairs(self.fieldData) do
         local soilParams = SoilMoistureSystem.SOIL_PARAMS[data.soilType]
             or SoilMoistureSystem.SOIL_PARAMS.loamy
 
         -- Evapotranspiration loss this hour.
-        -- evapMultiplier  = weather-based (temperature + season) from WeatherIntegration
+        -- evapMultiplier   = weather-based (temperature + season) from WeatherIntegration
         -- settingsEvapMult = player-configured multiplier (difficulty × evap rate setting)
-        local settingsEvapMult = self.evapMultiplier or 1.0
+        -- sfEvapMod        = per-field organic matter modifier from FS25_SoilFertilizer (if present)
+        --                    High OM (>5%) lowers evap; poor OM (<1%) raises it. Default 1.0.
+        local sfEvapMod = sfHasEvap and sfInteg:getFieldEvapMod(fieldId) or 1.0
         local evapLoss = SoilMoistureSystem.BASE_EVAP_RATE
             * evapMultiplier
             * soilParams.evapMod
             * settingsEvapMult
+            * sfEvapMod
 
         -- Rain gain (modulated by soil absorption)
         local rainGain  = rainAmount * soilParams.rainAbsorb
@@ -170,7 +180,10 @@ function SoilMoistureSystem:hourlyUpdate(weather)
         -- Critical threshold check (12-hour cooldown per field to avoid spam).
         -- Use getCriticalMoisture() so the player's settings value is honoured;
         -- falls back to the class constant if applySettings() hasn't run yet.
-        if data.moisture <= self:getCriticalMoisture() then
+        -- SoilFertilizer pH modifier raises the threshold for acid/alkaline fields
+        -- (crops become moisture-stressed at a higher moisture level when pH is poor).
+        local sfStressMod = sfHasStress and sfInteg:getFieldStressMod(fieldId) or 0.0
+        if data.moisture <= (self:getCriticalMoisture() + sfStressMod) then
             local lastAlert = self.criticalAlertCooldown[fieldId] or -999
             if (hourKey - lastAlert) >= 12 then
                 self.criticalAlertCooldown[fieldId] = hourKey

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -222,5 +222,12 @@
     <text name="helpLine_cs_i1_about_text"      text="Erstellt von TisonK. Fügt eine realistische Bodenfeuchtesimulation, saisonalen Pflanzenstress und Bewässerungsinfrastrukturverwaltung zu Farming Simulator 25 hinzu. Entwickelt, um das Feldmanagement strategischer zu gestalten — jedes Feld, jede Saison, jede Entscheidung zählt."/>
     <text name="helpLine_cs_i1_community_title" text="Community &amp; Support"/>
     <text name="helpLine_cs_i1_community_text"  text="Diesen Mod findest du im Farming Simulator ModHub. Für Fragen, Fehlerberichte und Updates besuche die Mod-Seite im ModHub oder das GitHub-Repository. Schau in die Community-Foren, um Tipps mit anderen Spielern zu teilen."/>
+
+    <!-- ========== OPTIONALE MOD-INTEGRATIONEN ========== -->
+    <text name="cs_cp_vehicle_on_field"  text="CoursePlay: %d Fahrzeug arbeitet auf diesem Feld"/>
+    <text name="cs_cp_vehicles_on_field" text="CoursePlay: %d Fahrzeuge arbeiten auf diesem Feld"/>
+    <text name="cs_ad_water_hint"    text="AutoDrive: %d Wasserpunkt(e) verfügbar — Wasserroute einrichten"/>
+    <text name="cs_ad_destinations"  text="AutoDrive: %d Ziel(e) konfiguriert"/>
+
     </texts>
 </l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -222,5 +222,14 @@
     <text name="helpLine_cs_i1_about_text"      text="Created by TisonK. Adds realistic soil moisture simulation, seasonal crop stress accumulation, and irrigation infrastructure management to Farming Simulator 25. Designed to make crop management more strategic — every field, every season, every decision counts."/>
     <text name="helpLine_cs_i1_community_title" text="Community &amp; Support"/>
     <text name="helpLine_cs_i1_community_text"  text="Find this mod on Github and KingMods. For questions, bug reports, and updates please visit the github repository."/>
+
+    <!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->
+    <!-- CoursePlay context appended to stress alerts -->
+    <text name="cs_cp_vehicle_on_field"  text="CoursePlay: %d vehicle working this field"/>
+    <text name="cs_cp_vehicles_on_field" text="CoursePlay: %d vehicles working this field"/>
+    <!-- AutoDrive context appended to CRITICAL alerts -->
+    <text name="cs_ad_water_hint"    text="AutoDrive: %d water destination(s) available — consider a hauling route"/>
+    <text name="cs_ad_destinations"  text="AutoDrive: %d destination(s) configured"/>
+
     </texts>
 </l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -222,5 +222,12 @@
     <text name="helpLine_cs_i1_about_text"      text="Créé par TisonK. Ajoute une simulation réaliste de l'humidité du sol, du stress saisonnier des cultures et de la gestion de l'infrastructure d'irrigation à Farming Simulator 25. Conçu pour rendre la gestion des cultures plus stratégique — chaque champ, chaque saison, chaque décision compte."/>
     <text name="helpLine_cs_i1_community_title" text="Communauté &amp; Support"/>
     <text name="helpLine_cs_i1_community_text"  text="Retrouvez ce mod sur le ModHub de Farming Simulator. Pour les questions, rapports de bugs et mises à jour, visitez la page du mod sur le ModHub ou le dépôt GitHub. Rejoignez les forums communautaires pour partager des conseils avec d'autres joueurs."/>
+
+    <!-- ========== INTÉGRATIONS MODS OPTIONNELLES ========== -->
+    <text name="cs_cp_vehicle_on_field"  text="CoursePlay : %d véhicule sur cette parcelle"/>
+    <text name="cs_cp_vehicles_on_field" text="CoursePlay : %d véhicules sur cette parcelle"/>
+    <text name="cs_ad_water_hint"    text="AutoDrive : %d point(s) d'eau disponible(s) — créez une route d'approvisionnement"/>
+    <text name="cs_ad_destinations"  text="AutoDrive : %d destination(s) configurée(s)"/>
+
     </texts>
 </l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -222,5 +222,12 @@
     <text name="helpLine_cs_i1_about_text"      text="Creato da TisonK. Aggiunge una simulazione realistica dell'umidità del suolo, stress stagionale delle colture e gestione dell'infrastruttura di irrigazione a Farming Simulator 25. Progettato per rendere la gestione delle colture più strategica — ogni campo, ogni stagione, ogni decisione conta."/>
     <text name="helpLine_cs_i1_community_title" text="Comunità &amp; Supporto"/>
     <text name="helpLine_cs_i1_community_text"  text="Trova questa mod sull'ModHub di Farming Simulator. Per domande, segnalazioni di bug e aggiornamenti, visita la pagina della mod sull'ModHub o il repository GitHub. Unisciti ai forum della community per condividere consigli con altri giocatori."/>
+
+    <!-- ========== INTEGRAZIONI MOD OPZIONALI ========== -->
+    <text name="cs_cp_vehicle_on_field"  text="CoursePlay: %d veicolo su questo campo"/>
+    <text name="cs_cp_vehicles_on_field" text="CoursePlay: %d veicoli su questo campo"/>
+    <text name="cs_ad_water_hint"    text="AutoDrive: %d punto/i d'acqua disponibile/i — imposta un percorso di trasporto"/>
+    <text name="cs_ad_destinations"  text="AutoDrive: %d destinazione/i configurata/e"/>
+
     </texts>
 </l10n>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -222,5 +222,12 @@
     <text name="helpLine_cs_i1_about_text"      text="Gemaakt door TisonK. Voegt realistische bodemvochtsimulatie, seizoensgebonden gewasstress en beheer van irrigatie-infrastructuur toe aan Farming Simulator 25. Ontworpen om gewasbeheer strategischer te maken — elk veld, elk seizoen, elke beslissing telt."/>
     <text name="helpLine_cs_i1_community_title" text="Community &amp; Support"/>
     <text name="helpLine_cs_i1_community_text"  text="Vind deze mod op de Farming Simulator ModHub. Voor vragen, bugrapporten en updates, bezoek de modpagina op ModHub of de GitHub-repository. Sluit je aan bij de communityforums om tips te delen met andere spelers."/>
+
+    <!-- ========== OPTIONELE MOD-INTEGRATIES ========== -->
+    <text name="cs_cp_vehicle_on_field"  text="CoursePlay: %d voertuig actief op dit perceel"/>
+    <text name="cs_cp_vehicles_on_field" text="CoursePlay: %d voertuigen actief op dit perceel"/>
+    <text name="cs_ad_water_hint"    text="AutoDrive: %d waterbestemming(en) beschikbaar — stel een transportroute in"/>
+    <text name="cs_ad_destinations"  text="AutoDrive: %d bestemming(en) geconfigureerd"/>
+
     </texts>
 </l10n>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -222,5 +222,12 @@
     <text name="helpLine_cs_i1_about_text"      text="Stworzony przez TisonK. Dodaje realistyczną symulację wilgotności gleby, sezonowy stres upraw i zarządzanie infrastrukturą nawadniania do Farming Simulator 25. Zaprojektowany, aby zarządzanie uprawami było bardziej strategiczne — każde pole, każdy sezon, każda decyzja ma znaczenie."/>
     <text name="helpLine_cs_i1_community_title" text="Społeczność &amp; pomoc"/>
     <text name="helpLine_cs_i1_community_text"  text="Znajdź ten mod w Farming Simulator ModHub. W przypadku pytań, zgłoszeń błędów i aktualizacji odwiedź stronę moda w ModHub lub repozytorium GitHub. Dołącz do forów społecznościowych, aby dzielić się wskazówkami z innymi graczami."/>
+
+    <!-- ========== OPCJONALNE INTEGRACJE MODÓW ========== -->
+    <text name="cs_cp_vehicle_on_field"  text="CoursePlay: %d pojazd pracuje na tym polu"/>
+    <text name="cs_cp_vehicles_on_field" text="CoursePlay: %d pojazdy pracują na tym polu"/>
+    <text name="cs_ad_water_hint"    text="AutoDrive: %d punkt(y) wodny dostępny — skonfiguruj trasę transportu wody"/>
+    <text name="cs_ad_destinations"  text="AutoDrive: %d cel(e) skonfigurowany/e"/>
+
     </texts>
 </l10n>


### PR DESCRIPTION
## Summary

- **SoilFertilizerIntegration** (`g_SoilFertilityManager`): reads per-field pH and organic matter from the sibling mod. pH shifts each field's critical moisture threshold; organic matter adjusts the per-field evaporation multiplier. Cache refreshed every 4 in-game hours. Silently no-ops when mod absent.

- **CoursePlayIntegration** (`g_Courseplay` — confirmed capital P from FS25 source): detects active CP vehicles on stressed fields via confirmed `vehicle:getIsCpActive()` specialization method + world position matching. Appends a brief context line to stress alerts. Read-only — never starts or redirects CP jobs.

- **AutoDriveIntegration** (`AutoDrive` — no `g_` prefix, confirmed from FS25 ExternalInterface.lua): calls `AutoDrive:GetAvailableDestinations()` and filters for water-related destination names. Appends a hauling route hint to CRITICAL drought alerts. Cache TTL: 6 in-game hours.

## Research findings (confirmed from primary source)

| Mod | Global | Source |
|-----|--------|--------|
| CoursePlay | `g_Courseplay` (capital P) | Courseplay/Courseplay_FS25 |
| AutoDrive | `AutoDrive` (no `g_`) | Stephan-S/FS25_AutoDrive ExternalInterface.lua |
| SoilFertilizer | `g_SoilFertilityManager` | Local source read |
| FS25 Seasons | **Does not exist** | RealismusModding has no FS25 repo |
| GlobalCompany | **FS19 only** | Ls-Modcompany GitHub |

## Test plan

- [ ] Load without any optional mods → `csStatus` shows all integrations as `false`
- [ ] Load with SoilFertilizer → `csStatus` shows `SoilFertilizer: true`; sandy fields with low OM should evaporate slightly faster than before
- [ ] Load with CoursePlay → context line appears on WARNING/CRITICAL alerts when a CP vehicle is on the same field
- [ ] Load with AutoDrive → CRITICAL alert on a drought field appends destination hint when destinations are configured
- [ ] Log shows `[CropStress] FS25_SoilFertilizer detected` / `CoursePlay detected` / `AutoDrive detected` as appropriate