### PR TITLE
feat: Issue triage automation + remove DEVELOPMENT.md

### DIFF
--- a/.github/workflows/issue-author-responded.yml
+++ b/.github/workflows/issue-author-responded.yml
@@ -1,0 +1,52 @@
+name: Issue — Author Responded
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  track-response:
+    runs-on: ubuntu-latest
+    # Only run on issue comments (not PR comments)
+    if: github.event.issue.pull_request == null
+    permissions:
+      issues: write
+
+    steps:
+      - name: Update label when author replies
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue   = context.payload.issue;
+            const comment = context.payload.comment;
+
+            // Only react to comments from the issue author
+            if (comment.user.login !== issue.user.login) return;
+
+            // Only act if the waiting-on-author label is present
+            const labels = issue.labels.map(l => l.name);
+            if (!labels.includes('waiting-on-author')) return;
+
+            // Remove waiting-on-author
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                name: 'waiting-on-author'
+              });
+            } catch (e) {
+              // Label may have already been removed — that's fine
+            }
+
+            // Add in-progress
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['in-progress']
+              });
+            } catch (e) {
+              core.warning(`Could not add in-progress label: ${e.message}`);
+            }

--- a/.github/workflows/issue-timeout.yml
+++ b/.github/workflows/issue-timeout.yml
@@ -1,0 +1,111 @@
+name: Issue — Auto-close on No Response
+
+on:
+  schedule:
+    # Runs every 6 hours — checks for issues open > 24h with no author reply
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+    # Allow manual trigger for testing
+
+jobs:
+  close-unresponded:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Close issues with no author response after 24h
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const now       = Date.now();
+            const twentyFourHours = 24 * 60 * 60 * 1000;
+
+            // Fetch all open issues with the waiting-on-author label
+            const issues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                state: 'open',
+                labels: 'waiting-on-author',
+                per_page: 100
+              }
+            );
+
+            for (const issue of issues) {
+              // Skip pull requests
+              if (issue.pull_request) continue;
+
+              const openedAt = new Date(issue.created_at).getTime();
+              const age      = now - openedAt;
+
+              // Only act on issues older than 24 hours
+              if (age < twentyFourHours) continue;
+
+              const author = issue.user.login;
+
+              // Check comments — if the author has replied since the issue opened, skip
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100
+              });
+
+              const authorReplied = comments.data.some(c =>
+                c.user.login === author &&
+                // Exclude the opening comment (same user, but that's the issue body — comments only)
+                new Date(c.created_at).getTime() > openedAt
+              );
+
+              if (authorReplied) {
+                // Author did respond — remove waiting-on-author if still present, add in-progress
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo:  context.repo.repo,
+                    issue_number: issue.number,
+                    name: 'waiting-on-author'
+                  });
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo:  context.repo.repo,
+                    issue_number: issue.number,
+                    labels: ['in-progress']
+                  });
+                } catch (e) { /* already updated */ }
+                continue;
+              }
+
+              // No author reply within 24h — post closing comment and close
+              const closeBody = [
+                `Hey @${author} — this issue has been automatically closed because no additional information was received within **24 hours**.`,
+                ``,
+                `This is not a rejection. If you still have the problem, please **reopen this issue** and include:`,
+                ``,
+                `- The relevant \`[CropStress]\` lines from your \`log.txt\``,
+                `  - Location: \`Documents/My Games/FarmingSimulator2025/log.txt\``,
+                `- Your mod version (visible in the mod manager)`,
+                `- Steps to reproduce the issue`,
+                ``,
+                `Without a log snippet it is very difficult to investigate issues. We look forward to helping you once we have the details!`,
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: issue.number,
+                body: closeBody
+              });
+
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned'
+              });
+
+              core.info(`Closed issue #${issue.number} (${issue.title}) — no author response in 24h`);
+            }

--- a/.github/workflows/issue-welcome.yml
+++ b/.github/workflows/issue-welcome.yml
@@ -1,0 +1,83 @@
+name: Issue — Welcome & Label
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Create waiting-on-author label if missing
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'waiting-on-author',
+                color: 'e4e669',
+                description: 'Waiting for the issue author to provide more information'
+              });
+            } catch (e) {
+              // Label already exists — that's fine
+            }
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'in-progress',
+                color: '0075ca',
+                description: 'Being actively investigated'
+              });
+            } catch (e) {
+              // Label already exists — that's fine
+            }
+
+      - name: Add waiting-on-author label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['waiting-on-author']
+            });
+
+      - name: Post welcome comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const author = context.payload.issue.user.login;
+            const issueTitle = context.payload.issue.title;
+
+            const body = [
+              `Hey @${author}, thanks for opening this issue! 👋`,
+              ``,
+              `@TheCodingDad-TisonK has been notified and will take a look.`,
+              ``,
+              `**While you wait, please double-check the following:**`,
+              ``,
+              `- [ ] You are running **v1.0.0.0** of Seasonal Crop Stress (visible in the mod manager)`,
+              `- [ ] Your issue includes the relevant \`[CropStress]\` lines from \`log.txt\``,
+              `  - Log location: \`Documents/My Games/FarmingSimulator2025/log.txt\``,
+              `  - Search for \`[CropStress]\` — paste the relevant section in your issue`,
+              `- [ ] You have checked the in-game help (ESC → Help → Seasonal Crop Stress)`,
+              `- [ ] You have searched [existing issues](https://github.com/TheCodingDad-TisonK/FS25_SeasonalCropStress/issues) for a similar report`,
+              ``,
+              `> **Important:** If this issue is missing a log snippet, it may be closed without investigation. A log is almost always required to reproduce bugs.`,
+              ``,
+              `This issue is currently marked **waiting-on-author** — if any of the above information is missing, please add it and the label will be updated. If there is no response within **24 hours**, this issue will be closed automatically. You can always reopen it with the missing details.`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body
+            });


### PR DESCRIPTION
## GitHub Actions — Issue Triage

Three workflows to keep issues organized without manual effort:

**issue-welcome.yml** — fires on every new issue
- Posts a comment tagging `@TheCodingDad-TisonK`
- Reminds the reporter to include log snippet, version, and steps
- Adds `waiting-on-author` label (creates label automatically if missing)

**issue-author-responded.yml** — fires when a comment is posted
- Detects if the comment is from the issue author
- Swaps `waiting-on-author` → `in-progress`

**issue-timeout.yml** — runs on a schedule every 6 hours
- Finds all open issues with `waiting-on-author` label older than 24h
- Checks if the author has replied since opening
- If no reply: posts a friendly close comment tagging the author and closes with `not_planned`
- If they did reply but label wasn't swapped: corrects the labels

Also includes the `DEVELOPMENT.md` removal from the previous commit.