### PR TITLE
docs: Public release polish — README, Discord, CC BY-NC-ND 4.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thanks for your interest in contributing. This document covers everything you ne
 
 Read `CLAUDE.md` — it is the authoritative reference for this project's architecture, known FS25 Lua constraints, and code patterns. Anything in that file takes precedence over general Lua or modding conventions you may know from other projects.
 
-Read `DEVELOPMENT.md` for environment setup, build steps, and how to run the mod locally.
+Build with `bash build.sh --deploy` to compile and deploy to your local mods folder. Check `log.txt` after loading — look for `[CropStress]` prefixed lines to confirm the mod loaded correctly.
 
 ---
 
@@ -26,7 +26,7 @@ Filter for lines tagged `[CropStress]`. Include everything from the first `[Crop
 
 ## Requesting Features
 
-Use the **Feature Request** issue template. Before submitting, check the roadmap in `README.md` — your idea may already be planned.
+Use the **Feature Request** issue template. Before submitting, search open issues and discussions — your idea may already be tracked.
 
 Keep feature requests scoped. A request for "improve irrigation" will be closed. A request for "allow drip line coverage to be adjusted after placement" is actionable.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,41 +1,45 @@
-Copyright (c) 2026 TisonK (TheCodingDad-TisonK). All Rights Reserved.
+Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International
 
-DEFINITIONS
+FS25_SeasonalCropStress
+Copyright (c) 2026 TisonK (Tison Kuster). All rights reserved.
 
-"Mod" refers to FS25_SeasonalCropStress and all files contained in this repository,
-including Lua source code, XML configuration, i3d assets, translations, and artwork.
+This work is licensed under the Creative Commons
+Attribution-NonCommercial-NoDerivatives 4.0 International License.
 
-"Author" refers to the original copyright holder, Tison Kuster.
+You are free to:
+  - Share: copy and redistribute this mod in its original, unmodified form
+    for non-commercial purposes, with proper attribution.
 
-PERMISSIONS
+Under the following terms:
+  - Attribution: You must give appropriate credit to TisonK as the original
+    author, provide a link to this license, and indicate if any changes were
+    made. You may not suggest the licensor endorses you or your use.
+  - NonCommercial: You may not use this mod or any part of it for commercial
+    purposes. Uploading to monetized platforms or behind paywalls is prohibited.
+  - NoDerivatives: If you remix, transform, or build upon this mod, you may
+    not distribute the modified version. Contributions submitted as pull
+    requests to the original repository are explicitly permitted and encouraged.
 
-You MAY:
-  - Install and play this mod in Farming Simulator 25 for personal use.
-  - Fork this repository and modify it privately for your own non-distributed use.
-  - Submit pull requests to contribute improvements back to the original repository.
-  - Study the source code for learning purposes.
-
-RESTRICTIONS
-
-You MAY NOT, without explicit written permission from the Author:
-  - Redistribute this mod or any modified version of it on any platform
-    (ModHub, Farming Simulator mod sites, Steam Workshop, file hosting services, etc.).
-  - Upload this mod or any derivative work under a different name or authorship.
-  - Use assets from this mod (code, models, textures, icons) in another mod or project.
-  - Sell, sublicense, or commercially exploit this mod or any part of it.
-  - Remove or alter this license notice or any attribution credits.
+No additional restrictions: You may not apply legal terms or technological
+measures that legally restrict others from doing anything the license permits.
 
 CONTRIBUTIONS
 
 By submitting a pull request or otherwise contributing code or assets to this
-repository, you agree that your contribution is made under the same terms as this
-license and that the Author retains full copyright over the combined work.
+repository, you grant TisonK a perpetual, irrevocable, royalty-free license
+to use, modify, and include your contribution in this project. The author
+retains full copyright over the combined work. Your contribution does not
+transfer ownership of the project or grant you any rights beyond those
+described in this license.
 
 DISCLAIMER
 
-THIS MOD IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.
-THE AUTHOR IS NOT RESPONSIBLE FOR ANY DAMAGE TO SAVE FILES, GAME INSTALLATIONS,
-OR OTHER SOFTWARE RESULTING FROM THE USE OF THIS MOD.
+This mod is provided "as is" without warranty of any kind, express or implied.
+The author is not responsible for any damage to save files, game installations,
+or other software resulting from the use of this mod.
 
-For permissions beyond the scope of this license, contact the Author via the
-GitHub repository at https://github.com/TheCodingDad-TisonK/FS25_SeasonalCropStress.
+Full license text: https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode
+Human-readable summary: https://creativecommons.org/licenses/by-nc-nd/4.0/
+
+For permissions beyond the scope of this license, contact the author via
+GitHub: https://github.com/TheCodingDad-TisonK/FS25_SeasonalCropStress

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Downloads](https://img.shields.io/github/downloads/TheCodingDad-TisonK/FS25_SeasonalCropStress/total?style=for-the-badge&logo=github&color=4caf50&logoColor=white)](https://github.com/TheCodingDad-TisonK/FS25_SeasonalCropStress/releases)
 [![Release](https://img.shields.io/github/v/release/TheCodingDad-TisonK/FS25_SeasonalCropStress?style=for-the-badge&logo=tag&color=76c442&logoColor=white)](https://github.com/TheCodingDad-TisonK/FS25_SeasonalCropStress/releases/latest)
-[![License](https://img.shields.io/badge/license-All%20Rights%20Reserved-red?style=for-the-badge&logo=shield&logoColor=white)](#license)
+[![License](https://img.shields.io/badge/license-CC%20BY--NC--ND%204.0-lightgrey?style=for-the-badge&logo=creativecommons&logoColor=white)](https://creativecommons.org/licenses/by-nc-nd/4.0/)
 
 <br>
 
@@ -214,12 +214,13 @@ Found a bug? [Open an issue](https://github.com/TheCodingDad-TisonK/FS25_Seasona
 
 ## 📝 License
 
-> [!CAUTION]
-> Redistribution, modification, or reupload without explicit written permission is **not permitted**.
+This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/)**.
+
+You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
 **Author:** TisonK · **Version:** 1.0.0.0
 
-© TisonK — All Rights Reserved. Personal use only. See [LICENSE](LICENSE) for full terms.
+© 2026 TisonK — See [LICENSE](LICENSE) for full terms.
 
 ---
 


### PR DESCRIPTION
## Summary

- Full README rewrite for public release — player-facing only, no dev/phase content, ModPlan removed
- Added Discord community link ([FS25 Modding Community](https://discord.gg/Th2pnq36)) below hero section
- Switched license from custom All Rights Reserved to **CC BY-NC-ND 4.0** — internationally recognized, contributions via PR explicitly permitted
- Fixed stale CONTRIBUTING.md references (removed DEVELOPMENT.md link and obsolete roadmap mention)

## Test plan
- [ ] README renders correctly on GitHub (badges, tables, callouts, Discord link)
- [ ] License badge links to Creative Commons
- [ ] No broken links in CONTRIBUTING.md
- [ ] LICENSE file reflects CC BY-NC-ND 4.0 terms