### PR TITLE
chore: Use TisonK only in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International
 
 FS25_SeasonalCropStress
-Copyright (c) 2026 TisonK (Tison Kuster). All rights reserved.
+Copyright (c) 2026 TisonK. All rights reserved.
 
 This work is licensed under the Creative Commons
 Attribution-NonCommercial-NoDerivatives 4.0 International License.


### PR DESCRIPTION
## Summary

- Removes full name from LICENSE copyright line — author credit is TisonK only.