### PR TITLE
fix: multiplayer settings sync and permission denial feedback

### DIFF
--- a/src/events/CropStressSettingsSyncEvent.lua
+++ b/src/events/CropStressSettingsSyncEvent.lua
@@ -190,16 +190,23 @@ function CropStressSettingsSyncEvent:applySingleSetting(key, value, connection)
         -- Server: verify master rights before applying
         if not self:senderHasMasterRights(connection) then
             csLog("WARNING: Non-master player attempted to change settings, ignoring")
+            -- Send current server settings back so the client's UI reverts to actual state
+            if connection ~= nil then
+                CropStressSettingsSyncEvent.sendAllToConnection(connection)
+            end
             return
         end
-        
+
         -- Apply setting and validate
         g_cropStressManager.settings[key] = value
         g_cropStressManager.settings:validateSettings()
         g_cropStressManager:applySettings()
-        
+
         csLog("Setting applied: " .. key .. " = " .. tostring(value))
-        
+
+        -- Broadcast to all clients (including the sender) so everyone stays in sync
+        g_server:broadcastEvent(CropStressSettingsSyncEvent.newSingle(key, value), false)
+
     else
         -- Client: apply setting directly (already validated by server)
         g_cropStressManager.settings[key] = value


### PR DESCRIPTION
## Summary
- Server now broadcasts setting changes made by master clients to all connected players — previously only host-initiated changes were synced
- When a non-master player attempts to change a setting, the server sends current settings back to that client so their UI reverts to the actual state (silent rejection was the previous behaviour)

## Root Cause
Both bugs lived in `CropStressSettingsSyncEvent:applySingleSetting`. The broadcast call only existed in the UI callback path (host-only), not in the server-receives-from-client path. The rejection path simply returned with no feedback.

## Test plan
- [ ] Join as non-master client → try changing a setting → confirm UI reverts
- [ ] Join as master client → change a setting → confirm all other clients see the update
- [ ] Host changes a setting → confirm clients still sync correctly (regression check)