### PR TITLE
fix: post-harvest stress carryover + HUD vehicle detection

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -81,6 +81,18 @@ local function csOpenConsultantCallback(_, _, inputValue)
     if g_cropStressManager ~= nil then g_cropStressManager:onOpenConsultantDialog() end
 end
 
+local function csEditHUDCallback(_, _, inputValue)
+    if (inputValue or 0) <= 0 then return end
+    if g_cropStressManager ~= nil and g_cropStressManager.hudOverlay ~= nil then
+        local hud = g_cropStressManager.hudOverlay
+        if hud.editMode then
+            hud:exitEditMode()
+        elseif hud.isVisible then
+            hud:enterEditMode()
+        end
+    end
+end
+
 do
     if PlayerInputComponent ~= nil and PlayerInputComponent.registerActionEvents ~= nil then
         local origFn = PlayerInputComponent.registerActionEvents
@@ -103,9 +115,10 @@ do
                     end
                 end
 
-                reg(InputAction.CS_TOGGLE_HUD,     csToggleHUDCallback,      "input_CS_TOGGLE_HUD",      "Toggle Moisture HUD")
+                reg(InputAction.CS_TOGGLE_HUD,      csToggleHUDCallback,      "input_CS_TOGGLE_HUD",      "Toggle Moisture HUD")
                 reg(InputAction.CS_OPEN_IRRIGATION, csOpenIrrigationCallback, "input_CS_OPEN_IRRIGATION", "Open Irrigation Manager")
                 reg(InputAction.CS_OPEN_CONSULTANT, csOpenConsultantCallback, "input_CS_OPEN_CONSULTANT", "Open Crop Consultant")
+                reg(InputAction.CS_EDIT_HUD,        csEditHUDCallback,        "input_CS_EDIT_HUD",        "Edit/Move Moisture HUD")
 
                 g_inputBinding:endActionEventsModification()
             end

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.0.3.1</version>
+    <version>1.0.3.2</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/src/CropStressModifier.lua
+++ b/src/CropStressModifier.lua
@@ -93,6 +93,11 @@ function CropStressModifier.new(manager)
     -- Per-field accumulated stress: fieldId → float (0.0–1.0)
     self.fieldStress = {}
 
+    -- Per-field last seen fruitTypeIndex: fieldId → int
+    -- Used to detect when a new crop is planted after harvest so that
+    -- accumulated stress from the previous crop does not bleed into the new one.
+    self.lastFruitTypeIndex = {}
+
     -- When FS25_RealisticWeather is present, its getHarvestScaleMultiplier hook
     -- handles the yield penalty. We skip our Cutter.processCutterArea reduction
     -- to avoid stacking. Stress still accumulates for HUD display.
@@ -146,8 +151,26 @@ function CropStressModifier:processFieldStress(field, fieldId, moisture)
                 csLog(string.format("Field %d: no crop — stress reset to 0", fieldId))
             end
         end
+        -- Clear the last-seen crop index so the next planting is treated as fresh
+        self.lastFruitTypeIndex[fieldId] = nil
         return
     end
+
+    -- Detect crop change: player planted a new crop after harvest.
+    -- The old fruitTypeIndex → new fruitTypeIndex transition means any stress
+    -- accumulated for the previous crop must not carry over to the new one.
+    local lastIndex = self.lastFruitTypeIndex[fieldId]
+    if lastIndex ~= nil and lastIndex ~= fruitTypeIndex then
+        local prevStress = self.fieldStress[fieldId] or 0
+        self.fieldStress[fieldId] = 0
+        if self.manager ~= nil and self.manager.debugMode then
+            csLog(string.format(
+                "Field %d: crop changed (fti %d → %d) — stress reset from %.3f to 0",
+                fieldId, lastIndex, fruitTypeIndex, prevStress
+            ))
+        end
+    end
+    self.lastFruitTypeIndex[fieldId] = fruitTypeIndex
 
     local fruitType = g_fruitTypeManager ~= nil and g_fruitTypeManager:getFruitTypeByIndex(fruitTypeIndex)
     if fruitType == nil then return end
@@ -199,6 +222,7 @@ end
 
 function CropStressModifier:resetStress(fieldId)
     self.fieldStress[fieldId] = 0.0
+    self.lastFruitTypeIndex[fieldId] = nil
 end
 
 -- Returns estimated yield impact as a display string, e.g. "-18%".

--- a/src/HUDOverlay.lua
+++ b/src/HUDOverlay.lua
@@ -181,12 +181,15 @@ function HUDOverlay:update(dt)
 
     self.animTimer = self.animTimer + dt
 
-    -- Edit mode: freeze camera rotation + assert cursor every frame (NPCFavor pattern)
+    -- Edit mode: assert cursor every frame + freeze free-roam camera (NPCFavor pattern).
+    -- When in a vehicle we still keep the cursor unlocked, but we must NOT touch the
+    -- camera transforms — the vehicle controller owns them and fighting it causes the
+    -- twitchy/locked camera bug reported by in-vehicle users.
     if self.editMode then
         if g_inputBinding and g_inputBinding.setShowMouseCursor then
             g_inputBinding:setShowMouseCursor(true)
         end
-        if self.savedCamRotX and getCamera and setRotation then
+        if not self:isPlayerInVehicle() and self.savedCamRotX and getCamera and setRotation then
             local ok, cam = pcall(getCamera)
             if ok and cam and cam ~= 0 then
                 pcall(setRotation, cam, self.savedCamRotX, self.savedCamRotY, self.savedCamRotZ)
@@ -257,22 +260,83 @@ end
 -- ============================================================
 -- EDIT MODE (NPCFavor pattern — cursor unlock + camera freeze)
 -- ============================================================
+
+--- Returns true when the local player is seated in a vehicle.
+-- In that context we still unlock the cursor, but we must NOT freeze the
+-- vehicle camera — the vehicle's own camera controller owns those transforms.
+--
+-- FS25 confirmed: when a player enters a vehicle, g_localPlayer becomes nil.
+-- The authoritative check is g_currentMission.controlledVehicle.
+-- Additional fallback: when on foot g_localPlayer is non-nil, so nil = in vehicle.
+function HUDOverlay:isPlayerInVehicle()
+    local mission = g_currentMission
+    if mission == nil then return false end
+
+    -- Check 1: controlledVehicle on mission — the authoritative FS25 in-vehicle flag.
+    -- Set by BaseMission:setControlledVehicle() whenever the local player enters any vehicle.
+    if mission.controlledVehicle ~= nil then return true end
+
+    -- Check 2: Input binding context name.
+    -- FS25 switches the active input context to a vehicle-specific name when driving.
+    -- On foot the context is "PLAYER" or "ALL". Driving uses "VEHICLE", "COMBINE", etc.
+    if g_inputBinding ~= nil then
+        local ok, ctx = pcall(function()
+            if type(g_inputBinding.getContextName) == "function" then
+                return g_inputBinding:getContextName()
+            end
+            return g_inputBinding.currentContextName or g_inputBinding.contextName
+        end)
+        if ok and ctx ~= nil then
+            local upper = tostring(ctx):upper()
+            if upper ~= "PLAYER" and upper ~= "ALL" and upper ~= "MENU" and upper ~= "" then
+                return true
+            end
+        end
+    end
+
+    -- Check 3: g_localPlayer nil-implies-vehicle.
+    -- FS25 despawns the player pawn when entering a vehicle. If the mission has
+    -- started but g_localPlayer is nil, the local client is driving.
+    if mission.isMissionStarted and g_localPlayer == nil then return true end
+
+    -- Check 4: Explicit flags on g_localPlayer when it is present
+    if g_localPlayer ~= nil then
+        if g_localPlayer.controlledVehicle ~= nil then return true end
+        if g_localPlayer.currentVehicle    ~= nil then return true end
+        if g_localPlayer.isOnFoot == false          then return true end
+    end
+
+    -- Check 5: mission.player fallback
+    local mPlayer = mission.player
+    if mPlayer ~= nil then
+        if mPlayer.controlledVehicle ~= nil then return true end
+        if mPlayer.currentVehicle    ~= nil then return true end
+    end
+
+    return false
+end
+
 function HUDOverlay:enterEditMode()
     self.editMode = true
     self.dragging = false
     if g_inputBinding and g_inputBinding.setShowMouseCursor then
         g_inputBinding:setShowMouseCursor(true)
     end
-    if getCamera and getRotation then
-        local ok, cam = pcall(getCamera)
-        if ok and cam and cam ~= 0 then
-            local ok2, rx, ry, rz = pcall(getRotation, cam)
-            if ok2 then
-                self.savedCamRotX, self.savedCamRotY, self.savedCamRotZ = rx, ry, rz
+    -- Only freeze the free-roam camera. When the player is driving, the
+    -- vehicle's camera controller owns those transforms and fighting it causes
+    -- the twitchy/locked camera the user reported. Cursor still unlocks fine.
+    if not self:isPlayerInVehicle() then
+        if getCamera and getRotation then
+            local ok, cam = pcall(getCamera)
+            if ok and cam and cam ~= 0 then
+                local ok2, rx, ry, rz = pcall(getRotation, cam)
+                if ok2 then
+                    self.savedCamRotX, self.savedCamRotY, self.savedCamRotZ = rx, ry, rz
+                end
             end
         end
     end
-    csLog("HUD edit mode ON — drag to move, corners to resize")
+    csLog("HUD edit mode ON — drag to move, corners to resize (inVehicle=" .. tostring(self:isPlayerInVehicle()) .. ")")
 end
 
 function HUDOverlay:exitEditMode()
@@ -453,17 +517,17 @@ function HUDOverlay:scroll(delta)
 end
 
 -- ============================================================
--- MOUSE EVENT — edit mode, drag, and corner resize
+-- MOUSE EVENT — drag, resize, scroll, and row selection
 -- Called from main.lua addModEventListener mouseEvent handler.
--- FS25 button numbers: 1=left, 3=right, 2=middle.
+-- FS25 button numbers: 1=left, 2=middle, 3=right, 4=wheel up, 5=wheel down.
 --
--- With setShowMouseCursor(true) active during edit mode, FS25
--- fires mouseEvent on every mouse MOVEMENT as well as clicks,
--- enabling true continuous drag (NPCFavor pattern).
+-- Edit mode is toggled via the CS_EDIT_HUD input action (Middle Mouse Button
+-- by default), which works both on foot AND in vehicles without conflicting
+-- with the vehicle camera. RMB is no longer used to toggle edit mode.
 --
--- CRITICAL FIX: RMB only enters edit mode if the cursor is
--- over THIS HUD panel — prevents cross-contamination when
--- other mods (NPCFavor, SoilFertilizer) also handle RMB.
+-- With setShowMouseCursor(true) active during edit mode, FS25 fires
+-- mouseEvent on every mouse MOVEMENT as well as clicks, enabling true
+-- continuous drag (NPCFavor pattern).
 -- ============================================================
 function HUDOverlay:onMouseEvent(posX, posY, isDown, isUp, button)
     if not self.isVisible then return end
@@ -482,13 +546,12 @@ function HUDOverlay:onMouseEvent(posX, posY, isDown, isUp, button)
         return
     end
 
-    -- ── RMB: toggle edit mode; also select the row under cursor on RMB-down ──
+    -- ── RMB: select the row under cursor.
+    -- Works without edit mode so it functions in vehicles too — the vehicle's
+    -- input system can swallow some inputs but addModEventListener RMB still
+    -- arrives here. Removed the editMode gate that was blocking it.
     if isDown and button == 3 then
-        if self.editMode then
-            self:exitEditMode()     -- second RMB exits edit mode
-        elseif self:isPointerOverHUD(posX, posY) then
-            self:enterEditMode()    -- enter edit mode when clicking on our panel
-            -- Immediately select whichever row the cursor is over
+        if self:isPointerOverHUD(posX, posY) then
             self:selectRowAtPosition(posX, posY)
         end
         return
@@ -611,6 +674,72 @@ function HUDOverlay:draw()
     local panelH   = self:calcPanelHeight(showEmpty and 1 or numRows)
     local px       = self.panelX
     local py       = self.panelY
+
+    -- ── Debug: log vehicle detection state once every 5s (only when debug mode on) ──
+    if self.manager ~= nil and self.manager.debugMode then
+        self._vehicleDebugTimer = (self._vehicleDebugTimer or 0) + 0.016
+        if self._vehicleDebugTimer >= 5.0 then
+            self._vehicleDebugTimer = 0
+            local mission = g_currentMission
+            local ctv = mission and mission.controlledVehicle
+            local ctxName = "?"
+            if g_inputBinding ~= nil then
+                local ok, ctx = pcall(function()
+                    if type(g_inputBinding.getContextName) == "function" then return g_inputBinding:getContextName() end
+                    return g_inputBinding.currentContextName or g_inputBinding.contextName
+                end)
+                if ok and ctx ~= nil then ctxName = tostring(ctx) end
+            end
+            csLog(string.format(
+                "VehicleDetect: controlledVehicle=%s g_localPlayer=%s inputCtx=%s inVehicle=%s",
+                tostring(ctv ~= nil), tostring(g_localPlayer ~= nil), ctxName,
+                tostring(self:isPlayerInVehicle())
+            ))
+        end
+    end
+
+    -- ── In-vehicle mode: show a minimal panel with a red disabled notice ──
+    if self:isPlayerInVehicle() then
+        -- Drop shadow
+        local shadowOff = 0.002 * s
+        setOverlayColor(self.fillOverlay, 0, 0, 0, 0.35)
+        renderOverlay(self.fillOverlay, px + shadowOff, py - shadowOff, panelW, panelH)
+
+        -- Background panel
+        setOverlayColor(self.fillOverlay, unpack(HUDOverlay.COLOR_BG))
+        renderOverlay(self.fillOverlay, px, py, panelW, panelH)
+
+        -- Subtle border
+        local bwN = 0.001
+        setOverlayColor(self.fillOverlay, 0.30, 0.40, 0.55, 0.50)
+        renderOverlay(self.fillOverlay, px,                 py + panelH - bwN, panelW, bwN)
+        renderOverlay(self.fillOverlay, px,                 py,                panelW, bwN)
+        renderOverlay(self.fillOverlay, px,                 py,                bwN,    panelH)
+        renderOverlay(self.fillOverlay, px + panelW - bwN,  py,                bwN,    panelH)
+
+        -- Header bar
+        setOverlayColor(self.fillOverlay, unpack(HUDOverlay.COLOR_HEADER_BG))
+        renderOverlay(self.fillOverlay, px, py + panelH - headerH, panelW, headerH)
+
+        -- Header title
+        setTextColor(unpack(HUDOverlay.COLOR_HEADER_TEXT))
+        setTextBold(true)
+        renderText(px + pad, py + panelH - headerH + pad, HUDOverlay.HEADER_TEXT_SIZE * s,
+            (g_i18n ~= nil and g_i18n:getText("cs_hud_title")) or "CROP MOISTURE")
+        renderText(px + panelW - 0.028 * s, py + panelH - headerH + pad, HUDOverlay.TEXT_SIZE * s, "[M]")
+        setTextBold(false)
+
+        -- Red "overlay disabled" message centred in the body area
+        local bodyH   = panelH - headerH
+        local msgSize = HUDOverlay.TEXT_SIZE * s
+        setTextColor(0.95, 0.15, 0.15, 1.00)
+        setTextAlignment(RenderText.ALIGN_CENTER)
+        renderText(px + panelW * 0.5, py + bodyH * 0.5 - msgSize * 0.5, msgSize,
+            (g_i18n ~= nil and g_i18n:getText("cs_hud_vehicle_disabled")) or "Overlay disabled in vehicle")
+        setTextAlignment(RenderText.ALIGN_LEFT)
+        setTextColor(1, 1, 1, 1)
+        return
+    end
 
     -- Forecast strip BELOW the main panel
     if self.forecastCache ~= nil then
@@ -1125,3 +1254,4 @@ function HUDOverlay:delete()
     self.selectedFieldId = nil
     self.isInitialized   = false
 end
+

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -10,6 +10,7 @@
     <text name="cs_hud_forecast"      text="5-Tage-Prognose"/>
     <text name="cs_hud_first_run"      text="Seasonal Crop Stress v1.0.0.0 geladen. Shift+M öffnet das Feuchte-HUD. Neu dabei? Öffne das Hilfe-Menü (ESC → Hilfe) und suche nach Seasonal Crop Stress, um alles zu erfahren."/>
     <text name="cs_hud_click_forecast" text="Zeile anklicken für 5-Tage-Prognose"/>
+    <text name="cs_hud_vehicle_disabled" text="Overlay im Fahrzeug deaktiviert"/>
 
     <!-- ========== FIELD STATUS ========== -->
     <text name="cs_field_moisture"        text="Feuchte"/>
@@ -109,6 +110,7 @@
     <text name="input_CS_TOGGLE_HUD"      text="Feuchte-HUD umschalten"/>
     <text name="input_CS_OPEN_IRRIGATION" text="Bewässerungsmanager öffnen"/>
     <text name="input_CS_OPEN_CONSULTANT" text="Pflanzenberater öffnen"/>
+    <text name="input_CS_EDIT_HUD"        text="Feuchte-HUD verschieben/skalieren"/>
 
     <!-- ========== PRECISION FARMING DLC ========== -->
     <text name="cs_pf_moisture_overlay"      text="Bodenfeuchte"/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -10,6 +10,7 @@
     <text name="cs_hud_forecast"      text="5-Day Forecast"/>
     <text name="cs_hud_first_run"      text="Seasonal Crop Stress v1.0.0.0 loaded. Press Shift+M to open the moisture HUD. New to the mod? Open the Help menu (ESC → Help) and find Seasonal Crop Stress to learn how everything works."/>
     <text name="cs_hud_click_forecast" text="Click a row for 5-day forecast"/>
+    <text name="cs_hud_vehicle_disabled" text="Overlay disabled in vehicle"/>
 
     <!-- ========== FIELD STATUS ========== -->
     <text name="cs_field_moisture"        text="Moisture"/>
@@ -109,6 +110,7 @@
     <text name="input_CS_TOGGLE_HUD"      text="Toggle Moisture HUD"/>
     <text name="input_CS_OPEN_IRRIGATION" text="Open Irrigation Manager"/>
     <text name="input_CS_OPEN_CONSULTANT" text="Open Crop Consultant"/>
+    <text name="input_CS_EDIT_HUD"        text="Edit/Move Moisture HUD"/>
 
     <!-- ========== PRECISION FARMING DLC ========== -->
     <text name="cs_pf_moisture_overlay"      text="Soil Moisture"/>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -10,6 +10,7 @@
     <text name="cs_hud_forecast"      text="Prévisions 5 jours"/>
     <text name="cs_hud_first_run"      text="Seasonal Crop Stress v1.0.0.0 chargé. Maj+M pour ouvrir le HUD d'humidité. Nouveau ? Ouvrez le menu Aide (ESC → Aide) et cherchez Seasonal Crop Stress pour tout apprendre."/>
     <text name="cs_hud_click_forecast" text="Cliquez sur une ligne pour la prévision 5 jours"/>
+    <text name="cs_hud_vehicle_disabled" text="Overlay désactivé en véhicule"/>
 
     <!-- ========== FIELD STATUS ========== -->
     <text name="cs_field_moisture"        text="Humidité"/>
@@ -109,6 +110,7 @@
     <text name="input_CS_TOGGLE_HUD"      text="Afficher/masquer HUD humidité"/>
     <text name="input_CS_OPEN_IRRIGATION" text="Ouvrir gestionnaire d'irrigation"/>
     <text name="input_CS_OPEN_CONSULTANT" text="Ouvrir conseiller cultural"/>
+    <text name="input_CS_EDIT_HUD"        text="Déplacer/redimensionner HUD humidité"/>
 
     <!-- ========== PRECISION FARMING DLC ========== -->
     <text name="cs_pf_moisture_overlay"      text="Humidité du sol"/>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -10,6 +10,7 @@
     <text name="cs_hud_forecast"      text="Previsioni 5 giorni"/>
     <text name="cs_hud_first_run"      text="Seasonal Crop Stress v1.0.0.0 caricato. Maiusc+M per aprire l'HUD umidità. Nuovo? Apri il menu Guida (ESC → Guida) e cerca Seasonal Crop Stress per scoprire tutto."/>
     <text name="cs_hud_click_forecast" text="Clicca una riga per le previsioni 5 giorni"/>
+    <text name="cs_hud_vehicle_disabled" text="Overlay disabilitato nel veicolo"/>
 
     <!-- ========== FIELD STATUS ========== -->
     <text name="cs_field_moisture"        text="Umidità"/>
@@ -109,6 +110,7 @@
     <text name="input_CS_TOGGLE_HUD"      text="Mostra/nascondi HUD umidità"/>
     <text name="input_CS_OPEN_IRRIGATION" text="Apri gestore irrigazione"/>
     <text name="input_CS_OPEN_CONSULTANT" text="Apri consulente colture"/>
+    <text name="input_CS_EDIT_HUD"        text="Sposta/ridimensiona HUD umidità"/>
 
     <!-- ========== PRECISION FARMING DLC ========== -->
     <text name="cs_pf_moisture_overlay"      text="Umidità del suolo"/>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -10,6 +10,7 @@
     <text name="cs_hud_forecast"      text="5-dagenprognose"/>
     <text name="cs_hud_first_run"      text="Seasonal Crop Stress v1.0.0.0 geladen. Shift+M opent de vochtigheids-HUD. Nieuw? Open het Help-menu (ESC → Help) en zoek Seasonal Crop Stress om alles te leren."/>
     <text name="cs_hud_click_forecast" text="Klik op een rij voor 5-dagenprognose"/>
+    <text name="cs_hud_vehicle_disabled" text="Overlay uitgeschakeld in voertuig"/>
 
     <!-- ========== FIELD STATUS ========== -->
     <text name="cs_field_moisture"        text="Vochtigheid"/>
@@ -109,6 +110,7 @@
     <text name="input_CS_TOGGLE_HUD"      text="HUD vochtigheid in-/uitschakelen"/>
     <text name="input_CS_OPEN_IRRIGATION" text="Irrigatiebeheer openen"/>
     <text name="input_CS_OPEN_CONSULTANT" text="Gewasadviseur openen"/>
+    <text name="input_CS_EDIT_HUD"        text="HUD vochtigheid verplaatsen/schalen"/>
 
     <!-- ========== PRECISION FARMING DLC ========== -->
     <text name="cs_pf_moisture_overlay"      text="Grondvochtigheid"/>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -10,6 +10,7 @@
     <text name="cs_hud_forecast"      text="Prognoza 5-dniowa"/>
     <text name="cs_hud_first_run"      text="Seasonal Crop Stress v1.0.0.0 załadowany. Shift+M otwiera HUD wilgotności. Nowy użytkownik? Otwórz menu Pomoc (ESC → Pomoc) i znajdź Seasonal Crop Stress, aby dowiedzieć się wszystkiego."/>
     <text name="cs_hud_click_forecast" text="Kliknij wiersz aby zobaczyć prognozę 5-dniową"/>
+    <text name="cs_hud_vehicle_disabled" text="Nakładka wyłączona w pojeździe"/>
 
     <!-- ========== FIELD STATUS ========== -->
     <text name="cs_field_moisture"        text="Wilgotność"/>
@@ -109,6 +110,7 @@
     <text name="input_CS_TOGGLE_HUD"      text="Przełącz HUD wilgotności"/>
     <text name="input_CS_OPEN_IRRIGATION" text="Otwórz menedżera nawadniania"/>
     <text name="input_CS_OPEN_CONSULTANT" text="Otwórz konsultanta upraw"/>
+    <text name="input_CS_EDIT_HUD"        text="Przesuń/skaluj HUD wilgotności"/>
 
     <!-- ========== PRECISION FARMING DLC ========== -->
     <text name="cs_pf_moisture_overlay"      text="Wilgotność gleby"/>


### PR DESCRIPTION
#### `src/CropStressModifier.lua` — Stress carryover after harvest

**Root cause.**  
`fieldStress` is keyed by `fieldId` and persists across the session. The existing reset only fired when `fruitTypeIndex == 0` (bare soil). In FS25, when a player harvests and immediately replants, the field can transition directly from the old crop's `fruitTypeIndex` to the new one without ever passing through `0` within an hourly tick boundary. The new crop inherited the full accumulated stress of the previous season, silently reducing its yield from day one.

**Fix.**  
Added `self.lastFruitTypeIndex = {}` to the constructor — a per-field table tracking the last seen `fruitTypeIndex`. On every `processFieldStress` call, if the current index differs from the stored one, stress is reset to `0` and a debug log entry is written (`Field N: crop changed (fti X → Y) — stress reset`). The index is also cleared to `nil` on bare-soil so the next planting is always treated as a clean start. `resetStress()` clears `lastFruitTypeIndex` as well for consistent manual resets via `csForceStress`.

No save/load changes needed — `lastFruitTypeIndex` is transient state. On load, it starts empty, so the first hourly tick after loading simply populates it without triggering any false reset.

---

#### `src/HUDOverlay.lua` — In-vehicle HUD mode not triggering

**Root cause.**  
`isPlayerInVehicle()` was:

```
return g_localPlayer ~= nil and g_localPlayer.controlledVehicle ~= nil
```
</code></pre><p>In FS25, the player pawn is <strong>despawned</strong> when entering a vehicle — <code inline="">g_localPlayer</code> becomes <code inline="">nil</code>. The check was testing a nil value and always returning <code inline="">false</code>, so the red "Overlay disabled in vehicle" panel never rendered.</p><p><strong>Fix.</strong><br>Replaced with a 5-check detection chain, in priority order:</p><ol><li><p><code inline="">g_currentMission.controlledVehicle ~= nil</code> — the authoritative FS25 flag, set by <code inline="">BaseMission:setControlledVehicle()</code> on every vehicle entry. This is what drives the in-game speedometer and is the first check.</p></li><li><p>Input binding context name — FS25 switches the active input context away from <code inline="">"PLAYER"</code> / <code inline="">"ALL"</code> when driving. Any other context name is treated as in-vehicle.</p></li><li><p><code inline="">g_localPlayer == nil</code> after <code inline="">isMissionStarted</code> — since FS25 despawns the pawn when driving, nil implies vehicle.</p></li><li><p>Explicit <code inline="">g_localPlayer</code> flags (<code inline="">controlledVehicle</code>, <code inline="">currentVehicle</code>, <code inline="">isOnFoot</code>) for on-foot edge cases.</p></li><li><p><code inline="">mission.player</code> fallback.</p></li></ol><p>Also added a throttled debug log (fires every 5 seconds, only when <code inline="">csDebug</code> is active) that prints the state of all three key indicators — <code inline="">controlledVehicle</code>, <code inline="">g_localPlayer</code>, and <code inline="">inputCtx</code> — so vehicle detection issues can be diagnosed directly from <code inline="">log.txt</code> without needing a repro session.</p><hr>

</body>
</html>