### PR TITLE
fix: MP dedicated server — stream irrigation spatial data to clients

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.0.5.0</version>
+    <version>1.0.6.0</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/placeables/dripIrrigationLine/dripLine.lua
+++ b/placeables/dripIrrigationLine/dripLine.lua
@@ -155,11 +155,27 @@ function DripIrrigationLine.onDelete(self)
 end
 
 function DripIrrigationLine.onReadStream(self, streamId, connection)
-    self.isActive = streamReadBool(streamId)
+    self.isActive     = streamReadBool(streamId)
+    self.startX       = streamReadFloat32(streamId)
+    self.startZ       = streamReadFloat32(streamId)
+    self.endX         = streamReadFloat32(streamId)
+    self.endZ         = streamReadFloat32(streamId)
+    self.coverageMinX = streamReadFloat32(streamId)
+    self.coverageMaxX = streamReadFloat32(streamId)
+    self.coverageMinZ = streamReadFloat32(streamId)
+    self.coverageMaxZ = streamReadFloat32(streamId)
 end
 
 function DripIrrigationLine.onWriteStream(self, streamId, connection)
-    streamWriteBool(streamId, self.isActive or false)
+    streamWriteBool(streamId,    self.isActive     or false)
+    streamWriteFloat32(streamId, self.startX       or 0)
+    streamWriteFloat32(streamId, self.startZ       or 0)
+    streamWriteFloat32(streamId, self.endX         or 0)
+    streamWriteFloat32(streamId, self.endZ         or 0)
+    streamWriteFloat32(streamId, self.coverageMinX or 0)
+    streamWriteFloat32(streamId, self.coverageMaxX or 0)
+    streamWriteFloat32(streamId, self.coverageMinZ or 0)
+    streamWriteFloat32(streamId, self.coverageMaxZ or 0)
 end
 
 -- ============================================================


### PR DESCRIPTION
## Summary

- `dripLine.lua` computed six spatial endpoint/coverage fields (`startX/Z`, `endX/Z`, `coverageMinX/MaxX/Z`) from `nodeId` world position and rotation at load time
- These fields were never streamed, so dedicated server clients computed their own values from potentially different node states — causing the irrigation manager to operate on mismatched bounding regions
- `onWriteStream` and `onReadStream` now stream all eight spatial fields alongside the existing `isActive` bool
- `centerPivot.lua` was not changed — its only node-derived value is the pivot center itself which is always the placeable root, handled natively by the engine
- Version bumped to 1.0.6.0

## Test plan

- [ ] Place a drip irrigation line in MP (listen server + 1 client)
- [ ] Verify both machines agree on the coverage region (field moisture applied to same area)
- [ ] Disconnect and reconnect a client — verify spatial fields are received correctly on rejoin
- [ ] Load on dedicated server — check log.txt for no stream read/write errors