### PR TITLE
fix(l10n): add missing input_CS_OPEN_SETTINGS to all translation files

### DIFF
--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -110,6 +110,7 @@
     <text name="input_CS_TOGGLE_HUD"      text="Přepnout HUD vlhkosti"/>
     <text name="input_CS_OPEN_IRRIGATION" text="Otevřít správce zavlažování"/>
     <text name="input_CS_OPEN_CONSULTANT" text="Otevřít poradce pro plodiny"/>
+    <text name="input_CS_OPEN_SETTINGS"   text="Otevřít nastavení stresu plodin"/>
     <text name="input_CS_EDIT_HUD"        text="Upravit/Přesunout HUD vlhkosti"/>
 
     <!-- ========== PRECISION FARMING DLC ========== -->

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -110,6 +110,7 @@
     <text name="input_CS_TOGGLE_HUD"      text="Feuchte-HUD umschalten"/>
     <text name="input_CS_OPEN_IRRIGATION" text="Bewässerungsmanager öffnen"/>
     <text name="input_CS_OPEN_CONSULTANT" text="Pflanzenberater öffnen"/>
+    <text name="input_CS_OPEN_SETTINGS"   text="Feldstress-Einstellungen öffnen"/>
     <text name="input_CS_EDIT_HUD"        text="Feuchte-HUD verschieben/skalieren"/>
 
     <!-- ========== PRECISION FARMING DLC ========== -->

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -110,6 +110,7 @@
     <text name="input_CS_TOGGLE_HUD"      text="Toggle Moisture HUD"/>
     <text name="input_CS_OPEN_IRRIGATION" text="Open Irrigation Manager"/>
     <text name="input_CS_OPEN_CONSULTANT" text="Open Crop Consultant"/>
+    <text name="input_CS_OPEN_SETTINGS"   text="Open Crop Stress Settings"/>
     <text name="input_CS_EDIT_HUD"        text="Edit/Move Moisture HUD"/>
 
     <!-- ========== PRECISION FARMING DLC ========== -->

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -110,6 +110,7 @@
     <text name="input_CS_TOGGLE_HUD"      text="Afficher/masquer HUD humidité"/>
     <text name="input_CS_OPEN_IRRIGATION" text="Ouvrir gestionnaire d'irrigation"/>
     <text name="input_CS_OPEN_CONSULTANT" text="Ouvrir conseiller cultural"/>
+    <text name="input_CS_OPEN_SETTINGS"   text="Ouvrir paramètres stress cultural"/>
     <text name="input_CS_EDIT_HUD"        text="Déplacer/redimensionner HUD humidité"/>
 
     <!-- ========== PRECISION FARMING DLC ========== -->

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -110,6 +110,7 @@
     <text name="input_CS_TOGGLE_HUD"      text="Mostra/nascondi HUD umidità"/>
     <text name="input_CS_OPEN_IRRIGATION" text="Apri gestore irrigazione"/>
     <text name="input_CS_OPEN_CONSULTANT" text="Apri consulente colture"/>
+    <text name="input_CS_OPEN_SETTINGS"   text="Apri impostazioni stress colture"/>
     <text name="input_CS_EDIT_HUD"        text="Sposta/ridimensiona HUD umidità"/>
 
     <!-- ========== PRECISION FARMING DLC ========== -->

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -110,6 +110,7 @@
     <text name="input_CS_TOGGLE_HUD"      text="HUD vochtigheid in-/uitschakelen"/>
     <text name="input_CS_OPEN_IRRIGATION" text="Irrigatiebeheer openen"/>
     <text name="input_CS_OPEN_CONSULTANT" text="Gewasadviseur openen"/>
+    <text name="input_CS_OPEN_SETTINGS"   text="Gewasstresinstellingen openen"/>
     <text name="input_CS_EDIT_HUD"        text="HUD vochtigheid verplaatsen/schalen"/>
 
     <!-- ========== PRECISION FARMING DLC ========== -->

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -110,6 +110,7 @@
     <text name="input_CS_TOGGLE_HUD"      text="Przełącz HUD wilgotności"/>
     <text name="input_CS_OPEN_IRRIGATION" text="Otwórz menedżera nawadniania"/>
     <text name="input_CS_OPEN_CONSULTANT" text="Otwórz konsultanta upraw"/>
+    <text name="input_CS_OPEN_SETTINGS"   text="Otwórz ustawienia stresu upraw"/>
     <text name="input_CS_EDIT_HUD"        text="Przesuń/skaluj HUD wilgotności"/>
 
     <!-- ========== PRECISION FARMING DLC ========== -->

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -110,6 +110,7 @@
     <text name="input_CS_TOGGLE_HUD"      text="Перемкнути HUD вологості"/>
     <text name="input_CS_OPEN_IRRIGATION" text="Відкрити менеджер зрошення"/>
     <text name="input_CS_OPEN_CONSULTANT" text="Відкрити агрономічного консультанта"/>
+    <text name="input_CS_OPEN_SETTINGS"   text="Відкрити налаштування стресу культур"/>
     <text name="input_CS_EDIT_HUD"        text="Редагувати/переміщати HUD вологості"/>
 
     <!-- ========== PRECISION FARMING DLC ========== -->


### PR DESCRIPTION
## Summary
- Adds missing `input_CS_OPEN_SETTINGS` l10n key to all 8 translation files (en, de, fr, it, nl, pl, cz, uk)
- Eliminates the `Missing l10n 'input_CS_OPEN_SETTINGS'` warning logged on every game start for every player

## Root Cause
The `CS_OPEN_SETTINGS` input action was added to `main.lua` and `modDesc.xml` but its display label was never added to the translation files, causing the engine to log a missing key warning on load.

## Test Plan
- [ ] Load mod in-game, confirm no `Missing l10n 'input_CS_OPEN_SETTINGS'` warning in log
- [ ] Check ESC → Controls — "Open Crop Stress Settings" label shows correctly for the bound key (Shift+S)