### PR TITLE
feat: Crop Moisture PDA screen + map overlay tab (v1.2.0.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ At these stages, Claude and Samantha MUST have explicit dialog:
 
 ## Project Overview
 
-**FS25_SeasonalCropStress** adds a soil moisture layer and crop stress simulation to Farming Simulator 25. Every field has a moisture percentage driven by rain, evapotranspiration (temperature + season + soil type), and irrigation. Moisture deficits during critical growth windows accumulate stress that reduces final yield. Players can place center-pivot or drip irrigation infrastructure to protect crops, managed via a scheduling dialog and monitored through a HUD overlay and a Crop Consultant alert system. Optional integration with `FS25_NPCFavor` (Crop Consultant as a named NPC) and `FS25_UsedPlus` (irrigation costs + equipment wear). Current version: **1.0.5.0**.
+**FS25_SeasonalCropStress** adds a soil moisture layer and crop stress simulation to Farming Simulator 25. Every field has a moisture percentage driven by rain, evapotranspiration (temperature + season + soil type), and irrigation. Moisture deficits during critical growth windows accumulate stress that reduces final yield. Players can place center-pivot or drip irrigation infrastructure to protect crops, managed via a scheduling dialog and monitored through a HUD overlay and a Crop Consultant alert system. Optional integration with `FS25_NPCFavor` (Crop Consultant as a named NPC) and `FS25_UsedPlus` (irrigation costs + equipment wear). Current version: **1.1.0.1**.
 
 Full implementation blueprint is in `FS25_SeasonalCropStress_ModPlan.md` at the repo root.
 

--- a/main.lua
+++ b/main.lua
@@ -50,6 +50,11 @@ source(modDir .. "src/events/CropStressSettingsSyncEvent.lua")
 -- Persistence
 source(modDir .. "src/SaveLoadHandler.lua")
 
+-- Map overlay & PDA screen (load before CropStressManager so hooks install in time)
+source(modDir .. "src/ui/CsMoistureMapOverlay.lua")
+source(modDir .. "src/ui/CsMapHooks.lua")
+source(modDir .. "src/ui/CsPDAScreen.lua")
+
 -- GUI dialog loader (must precede dialog scripts)
 source(modDir .. "src/gui/CsDialogLoader.lua")
 
@@ -182,7 +187,7 @@ Mission00.load = Utils.appendedFunction(Mission00.load, function(self, ...)
     -- Cross-mod bridge: g_currentMission is a shared C++ object visible to all mods.
     -- getfenv(0) is per-mod scoped in FS25; use mission property for reliable cross-mod detection.
     self.cropStressManager = g_csManager
-    print("[CropStress] CropStressManager created (v1.0.5.0)")
+    print("[CropStress] CropStressManager created (v1.2.0.0)")
 end)
 
 -- 2. Mission fully loaded: initialize all systems
@@ -206,6 +211,11 @@ Mission00.loadMission00Finished = Utils.appendedFunction(Mission00.loadMission00
     CsDialogLoader.register("IrrigationScheduleDialog", IrrigationScheduleDialog, "gui/IrrigationScheduleDialog.xml")
     CsDialogLoader.register("CropConsultantDialog",     CropConsultantDialog,     "gui/CropConsultantDialog.xml")
 
+    -- Register PDA screen with InGameMenu
+    if CsPDAScreen ~= nil then
+        CsPDAScreen.register(modDir)
+    end
+
     -- Register console debug commands
     if addConsoleCommand ~= nil then
         addConsoleCommand("csHelp",        "List all CropStress debug commands",                           "consoleHelp",        g_csManager)
@@ -221,6 +231,8 @@ end)
 -- 3. Per-frame update
 FSBaseMission.update = Utils.appendedFunction(FSBaseMission.update, function(self, dt)
     if g_csManager ~= nil then g_csManager:update(dt) end
+    -- Retry PDA registration each frame until InGameMenu is ready
+    if CsPDAScreen ~= nil then CsPDAScreen._attemptDeferredRegister(dt) end
 end)
 
 -- 4. Draw hook (HUD rendering)

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.1.0.1</version>
+    <version>1.2.0.0</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -137,6 +137,7 @@ function CropStressManager.new()
     self.irrigationManager  = IrrigationManager.new(self)       -- Phase 2 stub
     self.hudOverlay         = HUDOverlay.new(self)
     self.consultant         = CropConsultant.new(self)
+    self.moistureMapOverlay = CsMoistureMapOverlay ~= nil and CsMoistureMapOverlay.new(self) or nil
     self.npcIntegration     = NPCIntegration.new(self)
     self.financeIntegration = FinanceIntegration.new(self)      -- Phase 4 stub
 
@@ -222,6 +223,7 @@ function CropStressManager:initialize()
     self.irrigationManager:initialize()
     self.hudOverlay:initialize()
     self.consultant:initialize()
+    if self.moistureMapOverlay ~= nil then self.moistureMapOverlay:initialize() end
 
     -- Optional mod bridges — each checks for their mod's global at runtime
     self:detectOptionalMods()
@@ -673,6 +675,7 @@ function CropStressManager:delete()
     self.npcIntegration:delete()
     self.consultant:delete()
     self.hudOverlay:delete()
+    if self.moistureMapOverlay ~= nil then self.moistureMapOverlay:delete() end
     self.irrigationManager:delete()
     self.stressModifier:delete()
     self.soilSystem:delete()

--- a/src/ui/CsMapHooks.lua
+++ b/src/ui/CsMapHooks.lua
@@ -1,0 +1,258 @@
+-- =========================================================
+-- CsMapHooks
+-- Injects the Crop Moisture overlay into the native PDA map
+-- as a standard category tab (alongside Growth, Soil Type, etc.)
+-- =========================================================
+-- Pattern: mirrors FS25_SoilFertilizer SoilMapHooks.lua
+-- =========================================================
+
+CsMapHooks = {}
+
+local function getCsOverlay(frame)
+    if frame == nil then return nil end
+    return g_cropStressManager and g_cropStressManager.moistureMapOverlay
+end
+
+local function isCsPageActive(frame)
+    if frame == nil or frame.csMoisturePageIndex == nil or frame.mapOverviewSelector == nil then
+        return false
+    end
+    return frame.mapOverviewSelector:getState() == frame.csMoisturePageIndex
+end
+
+local function updateSubCategoryDotBox(frame)
+    if frame == nil or frame.subCategoryDotBox == nil or frame.mapSelectorTexts == nil then return end
+    local dotBox  = frame.subCategoryDotBox
+    local elements = dotBox.elements
+    if elements == nil or #elements == 0 then return end
+
+    local expectedCount = #frame.mapSelectorTexts
+    while #elements < expectedCount do
+        dotBox:addElement(elements[1]:clone(dotBox))
+        elements = dotBox.elements
+    end
+    while #elements > expectedCount do
+        elements[#elements]:delete()
+        elements = dotBox.elements
+    end
+    for i, dot in ipairs(dotBox.elements) do
+        local index = i
+        function dot.getIsSelected()
+            return frame.mapOverviewSelector ~= nil and frame.mapOverviewSelector:getState() == index
+        end
+    end
+    dotBox:invalidateLayout()
+end
+
+-- ── Hook handlers ─────────────────────────────────────────
+
+function CsMapHooks:onLoadMapFinished()
+    local overlay = getCsOverlay(self)
+    if overlay then
+        overlay:requestRefresh()
+        if not overlay.ingameMapRef then
+            local ref = nil
+            if self.ingameMapBase and self.ingameMapBase.layout then
+                ref = self.ingameMapBase
+            elseif self.ingameMap and self.ingameMap.layout then
+                ref = self.ingameMap
+            end
+            if ref then
+                overlay.ingameMapRef = ref
+                print("[CropStress] CsMapHooks: ingameMap ref cached")
+            end
+        end
+    end
+end
+
+function CsMapHooks:setupMapOverview()
+    if self.csMoisturePageIndex ~= nil then return end
+    if self.mapSelectorTexts == nil or self.mapOverviewSelector == nil then return end
+
+    local overlay = getCsOverlay(self)
+    if overlay == nil then return end
+
+    local pageText = (g_i18n and g_i18n:getText("cs_map_page_title")) or "Crop Moisture"
+
+    table.insert(self.mapSelectorTexts, pageText)
+    self.csMoisturePageIndex = #self.mapSelectorTexts
+    print(string.format("[CropStress] CsMapHooks: registered native page index %d", self.csMoisturePageIndex))
+
+    self.mapOverviewSelector:setTexts(self.mapSelectorTexts)
+
+    if self.dataTables ~= nil then
+        self.dataTables[self.csMoisturePageIndex] = overlay:getDisplayValues()
+    end
+    if self.filterStates ~= nil then
+        self.filterStates[self.csMoisturePageIndex] = overlay:getDefaultFilterState()
+    end
+
+    updateSubCategoryDotBox(self)
+end
+
+function CsMapHooks:onClickMapOverviewSelector(state)
+    if self.csMoisturePageIndex == nil or state ~= self.csMoisturePageIndex then return end
+
+    local overlay = getCsOverlay(self)
+    if overlay == nil then return end
+
+    if self.dataTables ~= nil and self.dataTables[self.csMoisturePageIndex] == nil then
+        self.dataTables[self.csMoisturePageIndex] = overlay:getDisplayValues()
+    end
+    if self.filterStates ~= nil and self.filterStates[self.csMoisturePageIndex] == nil then
+        self.filterStates[self.csMoisturePageIndex] = overlay:getDefaultFilterState()
+    end
+    if self.numSelectedFilters ~= nil then
+        self.numSelectedFilters[self.csMoisturePageIndex] = 0
+    end
+
+    if self.generateOverviewOverlay ~= nil then
+        self:generateOverviewOverlay()
+    end
+
+    overlay:requestRefresh()
+end
+
+function CsMapHooks:generateOverviewOverlay()
+    if self.csMoisturePageIndex == nil or self.mapOverviewSelector == nil then return end
+    if self.mapOverviewSelector:getState() ~= self.csMoisturePageIndex then return end
+
+    if self.ingameMap ~= nil and self.ingameMap.setOverlayVisible ~= nil then
+        self.ingameMap:setOverlayVisible(false)
+    end
+    if self.ingameMapBase ~= nil and self.ingameMapBase.setOverlayVisible ~= nil then
+        self.ingameMapBase:setOverlayVisible(false)
+    end
+
+    local overlay = getCsOverlay(self)
+    if overlay ~= nil then overlay:requestRefresh() end
+end
+
+function CsMapHooks.onDrawIngameMapElement(elementSelf, ...)
+    if elementSelf == nil or elementSelf.ingameMap == nil then return end
+
+    local _overlay = g_cropStressManager and g_cropStressManager.moistureMapOverlay
+    if _overlay and not _overlay.ingameMapRef and elementSelf.ingameMap.layout then
+        _overlay.ingameMapRef = elementSelf.ingameMap
+        print("[CropStress] CsMapHooks: ingameMap ref captured from PDA draw (fallback)")
+    end
+
+    local frame = elementSelf.parent
+    local depth = 0
+    while frame ~= nil and depth < 6 do
+        if frame.csMoisturePageIndex ~= nil then break end
+        frame = frame.parent
+        depth = depth + 1
+    end
+
+    if frame == nil or frame.csMoisturePageIndex == nil then return end
+    if frame.mapOverviewSelector == nil then return end
+    if frame.mapOverviewSelector:getState() ~= frame.csMoisturePageIndex then return end
+
+    local overlay = g_cropStressManager and g_cropStressManager.moistureMapOverlay
+    if overlay == nil then return end
+
+    overlay:onDraw(frame, elementSelf, elementSelf.ingameMap, frame.csMoisturePageIndex)
+end
+
+function CsMapHooks:onDrawOverlayHud()
+    local ok, active = pcall(isCsPageActive, self)
+    if not ok or not active then return end
+
+    local overlay = getCsOverlay(self)
+    if overlay == nil then return end
+
+    overlay:onDrawHud(self)
+end
+
+function CsMapHooks:onMouseEvent(superFunc, posX, posY, isDown, isUp, button, eventUsed)
+    local pageActive = false
+    local ok, result = pcall(isCsPageActive, self)
+    if ok then pageActive = result end
+
+    if not pageActive then
+        local ok2, ret = pcall(superFunc, self, posX, posY, isDown, isUp, button, eventUsed)
+        if not ok2 then
+            print("[CropStress] CsMapHooks: mouseEvent superFunc error: " .. tostring(ret))
+        end
+        return ret
+    end
+
+    if not eventUsed and isDown and (button == Input.MOUSE_BUTTON_LEFT or button == Input.MOUSE_BUTTON_RIGHT) then
+        local overlay = getCsOverlay(self)
+        if overlay and overlay:onSideBarClick(posX, posY) then
+            return true
+        end
+    end
+
+    local ok3, ret3 = pcall(superFunc, self, posX, posY, isDown, isUp, button, eventUsed)
+    if not ok3 then
+        print("[CropStress] CsMapHooks: mouseEvent superFunc error (2): " .. tostring(ret3))
+    end
+    return ret3
+end
+
+function CsMapHooks:getHasChangeableFilterList(superFunc, ...)
+    if self.csMoisturePageIndex ~= nil and self.mapOverviewSelector ~= nil then
+        if self.mapOverviewSelector:getState() == self.csMoisturePageIndex then
+            return false
+        end
+    end
+    return superFunc(self, ...)
+end
+
+function CsMapHooks:onFrameClose()
+    local overlay = getCsOverlay(self)
+    if overlay ~= nil then overlay:requestRefresh() end
+end
+
+-- ── Install hooks ─────────────────────────────────────────
+
+if InGameMenuMapFrame ~= nil then
+    if InGameMenuMapFrame.onLoadMapFinished ~= nil then
+        InGameMenuMapFrame.onLoadMapFinished = Utils.appendedFunction(
+            InGameMenuMapFrame.onLoadMapFinished, CsMapHooks.onLoadMapFinished)
+    end
+    if InGameMenuMapFrame.setupMapOverview ~= nil then
+        InGameMenuMapFrame.setupMapOverview = Utils.appendedFunction(
+            InGameMenuMapFrame.setupMapOverview, CsMapHooks.setupMapOverview)
+    end
+    if InGameMenuMapFrame.onClickMapOverviewSelector ~= nil then
+        InGameMenuMapFrame.onClickMapOverviewSelector = Utils.appendedFunction(
+            InGameMenuMapFrame.onClickMapOverviewSelector, CsMapHooks.onClickMapOverviewSelector)
+    end
+    if InGameMenuMapFrame.generateOverviewOverlay ~= nil then
+        InGameMenuMapFrame.generateOverviewOverlay = Utils.appendedFunction(
+            InGameMenuMapFrame.generateOverviewOverlay, CsMapHooks.generateOverviewOverlay)
+    end
+    if InGameMenuMapFrame.draw ~= nil then
+        InGameMenuMapFrame.draw = Utils.appendedFunction(
+            InGameMenuMapFrame.draw, CsMapHooks.onDrawOverlayHud)
+    elseif InGameMenuMapFrame.onDraw ~= nil then
+        InGameMenuMapFrame.onDraw = Utils.appendedFunction(
+            InGameMenuMapFrame.onDraw, CsMapHooks.onDrawOverlayHud)
+    end
+    if InGameMenuMapFrame.mouseEvent ~= nil then
+        InGameMenuMapFrame.mouseEvent = Utils.overwrittenFunction(
+            InGameMenuMapFrame.mouseEvent, CsMapHooks.onMouseEvent)
+    end
+    if InGameMenuMapFrame.getHasChangeableFilterList ~= nil then
+        InGameMenuMapFrame.getHasChangeableFilterList = Utils.overwrittenFunction(
+            InGameMenuMapFrame.getHasChangeableFilterList, CsMapHooks.getHasChangeableFilterList)
+    end
+    if InGameMenuMapFrame.onFrameClose ~= nil then
+        InGameMenuMapFrame.onFrameClose = Utils.appendedFunction(
+            InGameMenuMapFrame.onFrameClose, CsMapHooks.onFrameClose)
+    end
+    print("[CropStress] CsMapHooks: installed on InGameMenuMapFrame")
+else
+    print("[CropStress] CsMapHooks: WARNING — InGameMenuMapFrame not available at load time")
+end
+
+if IngameMapElement ~= nil then
+    IngameMapElement.draw = Utils.appendedFunction(
+        IngameMapElement.draw, CsMapHooks.onDrawIngameMapElement)
+    print("[CropStress] CsMapHooks: IngameMapElement.draw hook installed")
+else
+    print("[CropStress] CsMapHooks: WARNING — IngameMapElement not available — map dots will not draw")
+end

--- a/src/ui/CsMoistureMapOverlay.lua
+++ b/src/ui/CsMoistureMapOverlay.lua
@@ -1,0 +1,294 @@
+-- =========================================================
+-- CsMoistureMapOverlay
+-- Draws per-field moisture centroid dots on the PDA map.
+-- Colour-coded by moisture level: green / amber / red.
+-- =========================================================
+
+CsMoistureMapOverlay = {}
+local CsMoistureMapOverlay_mt = Class(CsMoistureMapOverlay)
+
+-- Moisture thresholds (match HUDOverlay + CropConsultant)
+CsMoistureMapOverlay.THRESHOLD_HEALTHY  = 0.40
+CsMoistureMapOverlay.THRESHOLD_WARNING  = 0.25
+CsMoistureMapOverlay.ALPHA              = 0.82
+
+-- World-metre radius represented by each dot
+CsMoistureMapOverlay.DOT_STEP           = 60
+
+CsMoistureMapOverlay.SAMPLE_INTERVAL_MS = 5000
+
+CsMoistureMapOverlay.C_HEALTHY  = {0.25, 0.85, 0.40}
+CsMoistureMapOverlay.C_WARNING  = {0.90, 0.82, 0.18}
+CsMoistureMapOverlay.C_CRITICAL = {0.88, 0.25, 0.25}
+CsMoistureMapOverlay.C_ACCENT   = {0.20, 0.65, 0.85}
+
+local CS_MAP_MOD_NAME = g_currentModName
+
+local function tr(key, fallback)
+    local modEnv = g_modEnvironments and g_modEnvironments[CS_MAP_MOD_NAME]
+    local i18n = (modEnv and modEnv.i18n) or g_i18n
+    if i18n then
+        local ok, text = pcall(function() return i18n:getText(key) end)
+        if ok and text and text ~= "" and text ~= ("$l10n_" .. key) then
+            return text
+        end
+    end
+    return fallback or key
+end
+
+-- ── Constructor ───────────────────────────────────────────
+
+function CsMoistureMapOverlay.new(manager)
+    local self = setmetatable({}, CsMoistureMapOverlay_mt)
+    self.manager       = manager
+    self.samplePoints  = {}
+    self.nextSampleTime = 0
+    self.buttonRects   = {}
+    self.ingameMapRef  = nil
+    return self
+end
+
+function CsMoistureMapOverlay:initialize()
+    print("[CropStress] CsMoistureMapOverlay initialized")
+end
+
+function CsMoistureMapOverlay:delete()
+    self.samplePoints = {}
+end
+
+-- ── Required by CsMapHooks ────────────────────────────────
+
+function CsMoistureMapOverlay:getDisplayValues()       return {} end
+function CsMoistureMapOverlay:getDefaultFilterState()  return {} end
+
+function CsMoistureMapOverlay:requestRefresh()
+    self.nextSampleTime = 0
+end
+
+-- ── Colour helper ─────────────────────────────────────────
+
+function CsMoistureMapOverlay:getMoistureColor(moisture)
+    local t = CsMoistureMapOverlay
+    if moisture >= t.THRESHOLD_HEALTHY then
+        return t.C_HEALTHY[1], t.C_HEALTHY[2], t.C_HEALTHY[3]
+    elseif moisture >= t.THRESHOLD_WARNING then
+        return t.C_WARNING[1], t.C_WARNING[2], t.C_WARNING[3]
+    else
+        return t.C_CRITICAL[1], t.C_CRITICAL[2], t.C_CRITICAL[3]
+    end
+end
+
+-- ── Sample field centroids ────────────────────────────────
+
+function CsMoistureMapOverlay:updateSamplePoints(force)
+    local now = (g_currentMission and g_currentMission.time) or 0
+    if not force and now < self.nextSampleTime then return end
+    self.nextSampleTime = now + CsMoistureMapOverlay.SAMPLE_INTERVAL_MS
+
+    self.samplePoints = {}
+
+    if g_currentMission == nil or g_fieldManager == nil then return end
+    local fields = g_fieldManager.fields
+    if fields == nil then return end
+
+    local soilSystem = self.manager and self.manager.soilSystem
+    if soilSystem == nil then return end
+
+    for _, field in ipairs(fields) do
+        if field and field.farmland then
+            local fid = field.farmland.id
+            if fid and fid > 0 then
+                local entry = soilSystem.fieldData[fid]
+                local moisture = entry and entry.moisture or 0.5
+                local r, g, b = self:getMoistureColor(moisture)
+                table.insert(self.samplePoints, {
+                    x        = field.posX or 0,
+                    z        = field.posZ or 0,
+                    r = r, g = g, b = b,
+                    moisture = moisture,
+                    fieldId  = fid,
+                })
+            end
+        end
+    end
+end
+
+-- ── Map bounds & projection ───────────────────────────────
+
+function CsMoistureMapOverlay:getMapRenderBounds(frame, ingameMap)
+    local layout = nil
+    if frame ~= nil and frame.ingameMapBase ~= nil and frame.ingameMapBase.fullScreenLayout ~= nil then
+        layout = frame.ingameMapBase.fullScreenLayout
+    elseif ingameMap ~= nil and ingameMap.fullScreenLayout ~= nil then
+        layout = ingameMap.fullScreenLayout
+    end
+    if layout == nil or layout.getMapSize == nil or layout.getMapPosition == nil then
+        return nil, nil, nil, nil
+    end
+    local mapX, mapY = layout:getMapPosition()
+    local mapW, mapH = layout:getMapSize()
+    return mapX, mapY, mapW, mapH
+end
+
+function CsMoistureMapOverlay:worldToScreenPosition(ingameMap, worldX, worldZ)
+    if ingameMap == nil then return nil, nil end
+    local layout = ingameMap.fullScreenLayout or ingameMap.layout
+    if layout == nil or layout.getMapObjectPosition == nil then return nil, nil end
+
+    local worldSizeX = ingameMap.worldSizeX or (g_currentMission and g_currentMission.terrainSize) or 2048
+    local worldSizeZ = ingameMap.worldSizeZ or (g_currentMission and g_currentMission.terrainSize) or 2048
+    if worldSizeX == 0 or worldSizeZ == 0 then return nil, nil end
+
+    local objectX = (worldX + (ingameMap.worldCenterOffsetX or 0)) / worldSizeX
+    local objectZ = (worldZ + (ingameMap.worldCenterOffsetZ or 0)) / worldSizeZ
+    objectX = objectX * (ingameMap.mapExtensionScaleFactor or 1) + (ingameMap.mapExtensionOffsetX or 0)
+    objectZ = objectZ * (ingameMap.mapExtensionScaleFactor or 1) + (ingameMap.mapExtensionOffsetZ or 0)
+    return layout:getMapObjectPosition(objectX, objectZ, 0, 0)
+end
+
+-- ── Draw dots on the map ──────────────────────────────────
+
+function CsMoistureMapOverlay:onDraw(frame, mapElement, ingameMap, pageIndex)
+    self:updateSamplePoints(false)
+    if #self.samplePoints == 0 then return end
+
+    local mapX, mapY, mapWidth, mapHeight = self:getMapRenderBounds(frame, ingameMap)
+    if mapX == nil then return end
+
+    local mapMaxX = mapX + mapWidth
+    local mapMaxY = mapY + mapHeight
+
+    local step   = CsMoistureMapOverlay.DOT_STEP
+    local ax, ay = self:worldToScreenPosition(ingameMap, 0, 0)
+    local bx, by = self:worldToScreenPosition(ingameMap, step, 0)
+    local cx, cy = self:worldToScreenPosition(ingameMap, 0, step)
+
+    local sizeX, sizeY
+    if ax and bx and cx then
+        sizeX = math.max(math.abs(bx - ax) * 0.80, 0.003)
+        sizeY = math.max(math.abs(cy - ay) * 0.80, 0.003)
+    else
+        local sw, sh = getNormalizedScreenValues(12, 12)
+        sizeX, sizeY = sw, sh
+    end
+    local halfX = sizeX * 0.5
+    local halfY = sizeY * 0.5
+
+    local scaleXX = ax and ((bx - ax) / step) or 0
+    local scaleYX = ax and ((by - ay) / step) or 0
+    local scaleXZ = ax and ((cx - ax) / step) or 0
+    local scaleYZ = ax and ((cy - ay) / step) or 0
+
+    for _, pt in ipairs(self.samplePoints) do
+        local screenX, screenY
+        if ax then
+            screenX = ax + pt.x * scaleXX + pt.z * scaleXZ
+            screenY = ay + pt.x * scaleYX + pt.z * scaleYZ
+        else
+            screenX, screenY = self:worldToScreenPosition(ingameMap, pt.x, pt.z)
+        end
+        if screenX and screenX >= mapX and screenX <= mapMaxX
+           and screenY >= mapY and screenY <= mapMaxY then
+            drawFilledRect(screenX - halfX, screenY - halfY, sizeX, sizeY,
+                           pt.r, pt.g, pt.b, CsMoistureMapOverlay.ALPHA)
+        end
+    end
+end
+
+-- ── Sidebar HUD ───────────────────────────────────────────
+
+function CsMoistureMapOverlay:onDrawHud(frame)
+    self.buttonRects = {}
+
+    local panelX, panelWidth
+
+    if frame.filterList and frame.filterList.absPosition then
+        panelX     = frame.filterList.absPosition[1]
+        panelWidth = frame.filterList.absSize[1]
+    else
+        local safeX, _ = getNormalizedScreenValues(14, 0)
+        local minW, _  = getNormalizedScreenValues(210, 0)
+        panelX     = safeX
+        panelWidth = minW
+    end
+
+    local topY = 0.80
+    if frame.mapOverviewSelector and frame.mapOverviewSelector.absPosition then
+        local _, extraM = getNormalizedScreenValues(0, 52)
+        topY = frame.mapOverviewSelector.absPosition[2] - extraM
+    end
+
+    local _, rowH  = getNormalizedScreenValues(0, 26)
+    local _, gap   = getNormalizedScreenValues(0, 4)
+    local _, txtSz = getNormalizedScreenValues(0, 14)
+    local padX, _  = getNormalizedScreenValues(10, 0)
+    local dotW, dotH = getNormalizedScreenValues(12, 12)
+    local acW, _   = getNormalizedScreenValues(3, 0)
+
+    -- Section title
+    local _, titleSz = getNormalizedScreenValues(0, 15)
+    setTextBold(true)
+    setTextUpperCase(true)
+    setTextAlignment(RenderText.ALIGN_LEFT)
+    setTextColor(CsMoistureMapOverlay.C_ACCENT[1], CsMoistureMapOverlay.C_ACCENT[2], CsMoistureMapOverlay.C_ACCENT[3], 1.0)
+    renderText(panelX + padX, topY - rowH, titleSz, tr("cs_map_sidebar_title", "MOISTURE LEGEND"))
+    setTextUpperCase(false)
+    setTextBold(false)
+
+    local currentY = topY - rowH * 2 - gap
+
+    local legend = {
+        { label = tr("cs_map_legend_healthy",  "Healthy  ≥40%"),  c = CsMoistureMapOverlay.C_HEALTHY  },
+        { label = tr("cs_map_legend_warning",  "Warning  25-40%"), c = CsMoistureMapOverlay.C_WARNING  },
+        { label = tr("cs_map_legend_critical", "Critical <25%"),   c = CsMoistureMapOverlay.C_CRITICAL },
+    }
+
+    local dotOffX, _ = getNormalizedScreenValues(6, 0)
+    for _, entry in ipairs(legend) do
+        local dotY = currentY + (rowH - dotH) * 0.5
+        drawFilledRect(panelX + padX, dotY, dotW, dotH,
+                       entry.c[1], entry.c[2], entry.c[3], 0.90)
+        setTextColor(0.90, 0.90, 0.90, 1.0)
+        setTextAlignment(RenderText.ALIGN_LEFT)
+        renderText(panelX + padX + dotW + dotOffX, currentY + rowH * 0.22, txtSz, entry.label)
+        currentY = currentY - rowH - gap
+    end
+
+    -- Separator
+    currentY = currentY - gap
+    local _, sepH = getNormalizedScreenValues(0, 1)
+    drawFilledRect(panelX, currentY, panelWidth, sepH, 0.45, 0.45, 0.45, 0.40)
+    currentY = currentY - sepH - gap * 2
+
+    -- "Open Crop PDA" button
+    local _, btnH = getNormalizedScreenValues(0, 30)
+    drawFilledRect(panelX, currentY, panelWidth, btnH, 0.04, 0.10, 0.18, 0.88)
+    drawFilledRect(panelX, currentY, acW, btnH,
+                   CsMoistureMapOverlay.C_ACCENT[1], CsMoistureMapOverlay.C_ACCENT[2], CsMoistureMapOverlay.C_ACCENT[3], 1.0)
+    setTextBold(false)
+    setTextColor(0.80, 0.92, 1.0, 1.0)
+    setTextAlignment(RenderText.ALIGN_LEFT)
+    renderText(panelX + padX + acW, currentY + btnH * 0.28, txtSz,
+               tr("cs_map_btn_open_pda", "Open Crop PDA"))
+
+    table.insert(self.buttonRects, {
+        x1 = panelX, y1 = currentY,
+        x2 = panelX + panelWidth, y2 = currentY + btnH,
+        action = "openPDA",
+    })
+end
+
+function CsMoistureMapOverlay:onSideBarClick(posX, posY)
+    for _, rect in ipairs(self.buttonRects) do
+        if posX >= rect.x1 and posX <= rect.x2
+           and posY >= rect.y1 and posY <= rect.y2 then
+            if rect.action == "openPDA" then
+                if CsPDAScreen ~= nil then
+                    CsPDAScreen.toggle()
+                end
+            end
+            return true
+        end
+    end
+    return false
+end

--- a/src/ui/CsPDAScreen.lua
+++ b/src/ui/CsPDAScreen.lua
@@ -1,0 +1,589 @@
+-- =========================================================
+-- CsPDAScreen
+-- InGameMenu (PDA) page for Seasonal Crop Stress.
+-- Two tabs:
+--   Overview  — farm-wide moisture / stress stats
+--   Irrigation — field triage list sorted by moisture asc
+--
+-- Pattern: mirrors FS25_SoilFertilizer SoilPDAScreen.lua /
+--          FS25_MarketDynamics MDMMarketScreen.
+-- =========================================================
+
+---@class CsPDAScreen
+CsPDAScreen = {}
+CsPDAScreen._mt = Class(CsPDAScreen, TabbedMenuFrameElement)
+
+CsPDAScreen.CLASS_NAME     = "CsPDAScreen"
+CsPDAScreen.MENU_PAGE_NAME = "menuCropStress"
+CsPDAScreen.XML_FILENAME   = "xml/gui/CsPDAScreen.xml"
+CsPDAScreen.MENU_ICON_PATH = "icon.dds"
+
+local CS_PDA_MOD_DIR  = g_currentModDirectory
+local CS_PDA_MOD_NAME = g_currentModName
+
+CsPDAScreen.CONTROLS = {
+    -- Field list (left sidebar)
+    "fieldList",
+    -- Stats panel (right, overview tab)
+    "overviewContent",
+    "statsFieldsTracked", "statsFieldsOwned",
+    "statsAvgMoisture",
+    "statsHealthy", "statsWarning", "statsCritical",
+    "statsAvgStress", "statsYieldLoss",
+    "statsIrrigated", "statsIrrSystems",
+    "overviewEmptyHint",
+    -- Irrigation tab
+    "irrigationContent",
+    "irrigationList",
+    "irrigationEmptyHint",
+    -- Tab decorations
+    "tabLabelOverview", "tabLabelIrrigation",
+    "tabUnderlineOverview", "tabUnderlineIrrigation",
+}
+
+local TAB_OVERVIEW   = 1
+local TAB_IRRIGATION = 2
+
+local REFRESH_INTERVAL = 2500  -- ms between data rebuilds while PDA is open
+
+local COLOR_HEALTHY = {0.25, 0.85, 0.40, 1.0}
+local COLOR_WARNING = {0.90, 0.82, 0.18, 1.0}
+local COLOR_CRITICAL= {0.88, 0.25, 0.25, 1.0}
+local COLOR_DIM     = {0.65, 0.65, 0.65, 1.0}
+local COLOR_WHITE   = {1.00, 1.00, 1.00, 1.0}
+
+-- Module-level pending registration
+local _pendingRegistration = false
+local _pendingModDir       = nil
+
+-- ── i18n helper ───────────────────────────────────────────
+
+local function tr(key, fallback)
+    local modEnv = g_modEnvironments and g_modEnvironments[CS_PDA_MOD_NAME]
+    local i18n = (modEnv and modEnv.i18n) or g_i18n
+    if i18n then
+        local ok, text = pcall(function() return i18n:getText(key) end)
+        if ok and text and text ~= "" and text ~= ("$l10n_" .. key) then
+            return text
+        end
+    end
+    return fallback or key
+end
+
+-- ── Data helpers ──────────────────────────────────────────
+
+local function getMgr()
+    return g_cropStressManager
+end
+
+local function getCropName(fruitTypeIndex)
+    if fruitTypeIndex == nil or fruitTypeIndex == 0 then return "—" end
+    local ft = g_fruitTypeManager and g_fruitTypeManager:getFruitTypeByIndex(fruitTypeIndex)
+    if ft and ft.name then
+        local name = ft.name
+        return name:sub(1,1):upper() .. name:sub(2):lower()
+    end
+    return "—"
+end
+
+local function getMoistureColor(moisture)
+    if moisture >= 0.40 then return COLOR_HEALTHY
+    elseif moisture >= 0.25 then return COLOR_WARNING
+    else return COLOR_CRITICAL end
+end
+
+local function getMoistureStatus(moisture)
+    if moisture >= 0.40 then return tr("cs_pda_status_healthy", "Healthy")
+    elseif moisture >= 0.25 then return tr("cs_pda_status_warning", "Warning")
+    else return tr("cs_pda_status_critical", "Critical") end
+end
+
+-- ── Constructor ───────────────────────────────────────────
+
+function CsPDAScreen.new()
+    local self = CsPDAScreen:superClass().new(nil, CsPDAScreen._mt)
+    self.name      = "CsPDAScreen"
+    self.className = "CsPDAScreen"
+
+    self.activeTab        = TAB_OVERVIEW
+    self.fieldData        = {}  -- sorted list: {fieldId, cropName, moisture, stress, irrigated}
+    self.irrigationData   = {}  -- subset sorted by moisture asc
+
+    self.refreshTimer     = 0
+    self.returnScreenName = ""
+    self.menuButtonInfo   = {}
+    return self
+end
+
+-- ── Initialize ────────────────────────────────────────────
+
+function CsPDAScreen:initialize()
+    CsPDAScreen:superClass().initialize(self)
+    self.menuButtonInfo = {
+        {inputAction = "MENU_BACK"},
+    }
+    self:setMenuButtonInfo(self.menuButtonInfo)
+end
+
+-- ── Registration ──────────────────────────────────────────
+
+function CsPDAScreen.register(modDir)
+    if CsPDAScreen._performRegistration(modDir) then return end
+    _pendingRegistration = true
+    _pendingModDir       = modDir
+    print("[CropStress] CsPDAScreen: deferred registration — InGameMenu not ready yet")
+end
+
+function CsPDAScreen._attemptDeferredRegister(dt)
+    if not _pendingRegistration then return end
+    if CsPDAScreen._performRegistration(_pendingModDir) then
+        _pendingRegistration = false
+        _pendingModDir       = nil
+    end
+end
+
+function CsPDAScreen._performRegistration(modDir)
+    if g_gui == nil or g_inGameMenu == nil then return false end
+
+    if g_inGameMenu[CsPDAScreen.MENU_PAGE_NAME] ~= nil then
+        print("[CropStress] CsPDAScreen: already registered, skipping")
+        return true
+    end
+
+    local screen  = CsPDAScreen.new()
+    local xmlPath = modDir .. CsPDAScreen.XML_FILENAME
+
+    print("[CropStress] CsPDAScreen: loading GUI from: " .. xmlPath)
+    local ok, err = pcall(function()
+        g_gui:loadGui(xmlPath, CsPDAScreen.CLASS_NAME, screen, true)
+    end)
+    if not ok then
+        print("[CropStress] CsPDAScreen: loadGui failed: " .. tostring(err))
+        return false
+    end
+
+    local inGameMenu = g_gui.screenControllers[InGameMenu] or g_inGameMenu
+    if inGameMenu == nil or inGameMenu.pagingElement == nil then
+        print("[CropStress] CsPDAScreen: inGameMenu or pagingElement nil")
+        return false
+    end
+
+    if g_inGameMenu ~= nil and g_inGameMenu.controlIDs ~= nil then
+        g_inGameMenu.controlIDs[CsPDAScreen.MENU_PAGE_NAME] = nil
+    end
+
+    inGameMenu[CsPDAScreen.MENU_PAGE_NAME] = screen
+
+    local alreadyAdded = false
+    if inGameMenu.pagingElement.elements then
+        for _, el in ipairs(inGameMenu.pagingElement.elements) do
+            if el == screen then alreadyAdded = true; break end
+        end
+    end
+    if not alreadyAdded then
+        inGameMenu.pagingElement:addElement(screen)
+    end
+
+    if type(inGameMenu.exposeControlsAsFields) == "function" then
+        pcall(inGameMenu.exposeControlsAsFields, inGameMenu, CsPDAScreen.MENU_PAGE_NAME)
+    end
+    if type(inGameMenu.pagingElement.updateAbsolutePosition) == "function" then
+        pcall(inGameMenu.pagingElement.updateAbsolutePosition, inGameMenu.pagingElement)
+    end
+    if type(inGameMenu.pagingElement.updatePageMapping) == "function" then
+        pcall(inGameMenu.pagingElement.updatePageMapping, inGameMenu.pagingElement)
+    end
+    if type(inGameMenu.registerPage) == "function" then
+        pcall(inGameMenu.registerPage, inGameMenu, screen, nil, function() return true end)
+    end
+
+    -- Tab icon
+    local iconFile = Utils.getFilename(CsPDAScreen.MENU_ICON_PATH, modDir)
+    if iconFile and type(inGameMenu.addPageTab) == "function" then
+        local okTab, errTab = pcall(inGameMenu.addPageTab, inGameMenu, screen,
+                                    iconFile, GuiUtils.getUVs({0, 0, 1024, 1024}))
+        if not okTab then
+            print("[CropStress] CsPDAScreen: addPageTab failed: " .. tostring(errTab))
+        end
+    end
+
+    if type(inGameMenu.rebuildTabList) == "function" then
+        pcall(inGameMenu.rebuildTabList, inGameMenu)
+    end
+    if type(screen.initialize) == "function" then
+        pcall(screen.initialize, screen)
+    end
+
+    print("[CropStress] CsPDAScreen: registered successfully")
+    return true
+end
+
+-- ── Public toggle (called from map overlay button & keybind) ──
+
+function CsPDAScreen.toggle()
+    if g_gui == nil then return end
+    local inGameMenu = g_gui.screenControllers[InGameMenu] or g_inGameMenu
+    if inGameMenu == nil then return end
+
+    if g_gui:getIsGuiVisible() then
+        -- If PDA is already on our page, close it; otherwise navigate to our page
+        local screen = inGameMenu[CsPDAScreen.MENU_PAGE_NAME]
+        if screen ~= nil and type(inGameMenu.showPage) == "function" then
+            inGameMenu:showPage(screen)
+        end
+    else
+        if type(g_gui.showGui) == "function" then
+            g_gui:showGui("InGameMenu")
+        elseif type(inGameMenu.setOpen) == "function" then
+            inGameMenu:setOpen(true)
+        end
+        local function navigateAfterOpen()
+            local screen = inGameMenu[CsPDAScreen.MENU_PAGE_NAME]
+            if screen ~= nil and type(inGameMenu.showPage) == "function" then
+                inGameMenu:showPage(screen)
+            end
+        end
+        -- Defer one frame to let InGameMenu finish opening
+        local screen = inGameMenu[CsPDAScreen.MENU_PAGE_NAME]
+        if screen ~= nil and type(inGameMenu.showPage) == "function" then
+            pcall(navigateAfterOpen)
+        end
+    end
+end
+
+-- ── Data rebuild ──────────────────────────────────────────
+
+function CsPDAScreen:_rebuildData()
+    local mgr = getMgr()
+    if mgr == nil then
+        self.fieldData      = {}
+        self.irrigationData = {}
+        return
+    end
+
+    local soilSystem  = mgr.soilSystem
+    local stressMod   = mgr.stressModifier
+    local irrMgr      = mgr.irrigationManager
+    local fieldById   = mgr.fieldById or {}
+
+    if soilSystem == nil then return end
+
+    -- Build covered fields set from irrigation manager
+    local coveredFields = {}
+    if irrMgr and irrMgr.systems then
+        for _, sys in pairs(irrMgr.systems) do
+            if sys.coveredFields then
+                for fid, _ in pairs(sys.coveredFields) do
+                    coveredFields[fid] = true
+                end
+            end
+        end
+    end
+
+    local rows = {}
+    for fid, entry in pairs(soilSystem.fieldData) do
+        local field      = fieldById[fid]
+        local ftiIndex   = field and field.fieldState and field.fieldState.fruitTypeIndex or 0
+        local cropName   = getCropName(ftiIndex)
+        local moisture   = entry.moisture or 0
+        local stress     = (stressMod and stressMod.fieldStress and stressMod.fieldStress[fid]) or 0
+        local irrigated  = coveredFields[fid] == true
+
+        table.insert(rows, {
+            fieldId   = fid,
+            cropName  = cropName,
+            moisture  = moisture,
+            stress    = stress,
+            irrigated = irrigated,
+        })
+    end
+
+    -- Sort field list: alphabetical crop, then by moisture asc within crop
+    table.sort(rows, function(a, b)
+        if a.cropName ~= b.cropName then return a.cropName < b.cropName end
+        return a.moisture < b.moisture
+    end)
+    self.fieldData = rows
+
+    -- Irrigation tab: driest first, all fields
+    local irrRows = {}
+    for _, r in ipairs(rows) do
+        table.insert(irrRows, r)
+    end
+    table.sort(irrRows, function(a, b)
+        return a.moisture < b.moisture
+    end)
+    self.irrigationData = irrRows
+end
+
+function CsPDAScreen:_rebuildStats()
+    local mgr = getMgr()
+    if mgr == nil then return end
+
+    local soilSystem = mgr.soilSystem
+    local stressMod  = mgr.stressModifier
+    local irrMgr     = mgr.irrigationManager
+    local fieldById  = mgr.fieldById or {}
+
+    if soilSystem == nil then return end
+
+    -- Ownership
+    local localFarmId = mgr.getLocalFarmId and mgr.getLocalFarmId() or 1
+    local totalTracked = 0
+    local totalOwned   = 0
+    local sumMoisture  = 0
+    local sumStress    = 0
+    local healthy = 0
+    local warning = 0
+    local critical = 0
+    local irrigatedCount = 0
+
+    -- Covered fields set
+    local coveredFields = {}
+    if irrMgr and irrMgr.systems then
+        for _, sys in pairs(irrMgr.systems) do
+            if sys.coveredFields then
+                for fid, _ in pairs(sys.coveredFields) do
+                    coveredFields[fid] = true
+                end
+            end
+        end
+    end
+
+    for fid, entry in pairs(soilSystem.fieldData) do
+        totalTracked = totalTracked + 1
+        local m = entry.moisture or 0
+        sumMoisture = sumMoisture + m
+        if m >= 0.40 then healthy = healthy + 1
+        elseif m >= 0.25 then warning = warning + 1
+        else critical = critical + 1 end
+
+        local s = (stressMod and stressMod.fieldStress and stressMod.fieldStress[fid]) or 0
+        sumStress = sumStress + s
+
+        if coveredFields[fid] then irrigatedCount = irrigatedCount + 1 end
+
+        local field = fieldById[fid]
+        if field and field.farmland and mgr.isFarmlandOwnedByFarm and
+           mgr.isFarmlandOwnedByFarm(field.farmland.id, localFarmId) then
+            totalOwned = totalOwned + 1
+        end
+    end
+
+    local avgMoisture = totalTracked > 0 and (sumMoisture / totalTracked) or 0
+    local avgStress   = totalTracked > 0 and (sumStress   / totalTracked) or 0
+    local yieldLoss   = avgStress * 0.60  -- matches CropStressModifier.MAX_YIELD_LOSS
+
+    local irrSystems = 0
+    if irrMgr and irrMgr.systems then
+        for _ in pairs(irrMgr.systems) do irrSystems = irrSystems + 1 end
+    end
+
+    local function setText(el, val)
+        if el then el:setText(tostring(val)) end
+    end
+    local function setTextFmt(el, val, fmt)
+        if el then el:setText(string.format(fmt, val)) end
+    end
+    local function setColor(el, color)
+        if el then el:setTextColor(unpack(color)) end
+    end
+
+    setText(self.statsFieldsTracked, totalTracked)
+    setText(self.statsFieldsOwned,   totalOwned)
+
+    if self.statsAvgMoisture then
+        self.statsAvgMoisture:setText(string.format("%.0f%%", avgMoisture * 100))
+        setColor(self.statsAvgMoisture, getMoistureColor(avgMoisture))
+    end
+
+    if self.statsHealthy  then
+        self.statsHealthy:setText(tostring(healthy))
+        setColor(self.statsHealthy, COLOR_HEALTHY)
+    end
+    if self.statsWarning  then
+        self.statsWarning:setText(tostring(warning))
+        setColor(self.statsWarning, COLOR_WARNING)
+    end
+    if self.statsCritical then
+        self.statsCritical:setText(tostring(critical))
+        setColor(self.statsCritical, critical > 0 and COLOR_CRITICAL or COLOR_DIM)
+    end
+
+    if self.statsAvgStress then
+        self.statsAvgStress:setText(string.format("%.0f%%", avgStress * 100))
+        setColor(self.statsAvgStress, avgStress > 0.5 and COLOR_CRITICAL or avgStress > 0.2 and COLOR_WARNING or COLOR_HEALTHY)
+    end
+    if self.statsYieldLoss then
+        self.statsYieldLoss:setText(string.format("-%.0f%%", yieldLoss * 100))
+        setColor(self.statsYieldLoss, yieldLoss > 0.20 and COLOR_CRITICAL or yieldLoss > 0.05 and COLOR_WARNING or COLOR_DIM)
+    end
+
+    setText(self.statsIrrigated,   irrigatedCount)
+    setText(self.statsIrrSystems,  irrSystems)
+
+    if self.overviewEmptyHint then
+        self.overviewEmptyHint:setVisible(totalTracked == 0)
+    end
+end
+
+-- ── SmoothList datasource ─────────────────────────────────
+
+function CsPDAScreen:getNumberOfItemsInSection(list, section)
+    if list == self.fieldList then
+        return #self.fieldData
+    elseif list == self.irrigationList then
+        return #self.irrigationData
+    end
+    return 0
+end
+
+function CsPDAScreen:populateCellForItemInSection(list, cell, index, section)
+    if list == self.fieldList then
+        self:_populateFieldCell(index, cell)
+    elseif list == self.irrigationList then
+        self:_populateIrrigationCell(index, cell)
+    end
+end
+
+function CsPDAScreen:_populateFieldCell(index, cell)
+    local row = self.fieldData[index]
+    if not row then return end
+
+    local idEl     = cell:getDescendantByName("fieldRowId")
+    local cropEl   = cell:getDescendantByName("fieldRowCrop")
+    local moistEl  = cell:getDescendantByName("fieldRowMoisture")
+    local statusEl = cell:getDescendantByName("fieldRowStatus")
+
+    if idEl     then idEl:setText(tostring(row.fieldId)) end
+    if cropEl   then cropEl:setText(row.cropName) end
+
+    if moistEl  then
+        moistEl:setText(string.format("%.0f%%", row.moisture * 100))
+        moistEl:setTextColor(unpack(getMoistureColor(row.moisture)))
+    end
+    if statusEl then
+        statusEl:setText(getMoistureStatus(row.moisture))
+        statusEl:setTextColor(unpack(getMoistureColor(row.moisture)))
+    end
+end
+
+function CsPDAScreen:_populateIrrigationCell(index, cell)
+    local row = self.irrigationData[index]
+    if not row then return end
+
+    local idEl    = cell:getDescendantByName("irrRowId")
+    local cropEl  = cell:getDescendantByName("irrRowCrop")
+    local moistEl = cell:getDescendantByName("irrRowMoisture")
+    local strEl   = cell:getDescendantByName("irrRowStress")
+    local irrEl   = cell:getDescendantByName("irrRowIrrigated")
+
+    if idEl   then idEl:setText(tostring(row.fieldId)) end
+    if cropEl then cropEl:setText(row.cropName) end
+
+    if moistEl then
+        moistEl:setText(string.format("%.0f%%", row.moisture * 100))
+        moistEl:setTextColor(unpack(getMoistureColor(row.moisture)))
+    end
+    if strEl then
+        local stressPct = math.floor(row.stress * 100)
+        strEl:setText(stressPct .. "%")
+        strEl:setTextColor(unpack(stressPct > 50 and COLOR_CRITICAL or stressPct > 20 and COLOR_WARNING or COLOR_DIM))
+    end
+    if irrEl then
+        if row.irrigated then
+            irrEl:setText(tr("cs_pda_irrigated_yes", "Yes"))
+            irrEl:setTextColor(unpack(COLOR_HEALTHY))
+        else
+            irrEl:setText(tr("cs_pda_irrigated_no", "No"))
+            irrEl:setTextColor(unpack(COLOR_DIM))
+        end
+    end
+end
+
+-- ── Row click handlers ────────────────────────────────────
+
+function CsPDAScreen:onClickFieldRow(item)
+    -- Reserved for future field detail dialog
+end
+
+function CsPDAScreen:onClickIrrigationRow(item)
+    -- Reserved for future field detail dialog
+end
+
+-- ── Tab switching ─────────────────────────────────────────
+
+function CsPDAScreen:onClickTabOverview()
+    self:_setTab(TAB_OVERVIEW)
+end
+
+function CsPDAScreen:onClickTabIrrigation()
+    self:_setTab(TAB_IRRIGATION)
+end
+
+function CsPDAScreen:_setTab(tabIndex)
+    self.activeTab = tabIndex
+    local isOverview   = (tabIndex == TAB_OVERVIEW)
+    local isIrrigation = (tabIndex == TAB_IRRIGATION)
+
+    if self.overviewContent   then self.overviewContent:setVisible(isOverview)   end
+    if self.irrigationContent then self.irrigationContent:setVisible(isIrrigation) end
+
+    if self.tabUnderlineOverview   then self.tabUnderlineOverview:setVisible(isOverview)   end
+    if self.tabUnderlineIrrigation then self.tabUnderlineIrrigation:setVisible(isIrrigation) end
+
+    if self.tabLabelOverview then
+        self.tabLabelOverview:setTextColor(isOverview and 1 or 0.6, isOverview and 1 or 0.6, isOverview and 1 or 0.6, 1)
+    end
+    if self.tabLabelIrrigation then
+        self.tabLabelIrrigation:setTextColor(isIrrigation and 1 or 0.6, isIrrigation and 1 or 0.6, isIrrigation and 1 or 0.6, 1)
+    end
+
+    self:_reloadLists()
+    if isOverview then self:_rebuildStats() end
+end
+
+function CsPDAScreen:_reloadLists()
+    if self.fieldList      then self.fieldList:reloadData()      end
+    if self.irrigationList then self.irrigationList:reloadData() end
+
+    if self.irrigationEmptyHint then
+        self.irrigationEmptyHint:setVisible(#self.irrigationData == 0)
+    end
+end
+
+-- ── FS25 TabbedMenuFrameElement lifecycle ─────────────────
+
+function CsPDAScreen:onOpen()
+    CsPDAScreen:superClass().onOpen(self)
+    self.refreshTimer = 0
+    self:_rebuildData()
+    self:_setTab(TAB_OVERVIEW)
+end
+
+function CsPDAScreen:onClose()
+    CsPDAScreen:superClass().onClose(self)
+end
+
+function CsPDAScreen:onFrameUpdate(dt)
+    CsPDAScreen:superClass().onFrameUpdate(self, dt)
+
+    if _pendingRegistration then
+        CsPDAScreen._attemptDeferredRegister(dt)
+    end
+
+    self.refreshTimer = (self.refreshTimer or 0) + dt
+    if self.refreshTimer >= REFRESH_INTERVAL then
+        self.refreshTimer = 0
+        self:_rebuildData()
+        self:_reloadLists()
+        if self.activeTab == TAB_OVERVIEW then
+            self:_rebuildStats()
+        end
+    end
+end
+
+-- Registration is triggered by main.lua's Mission00.loadMission00Finished hook.
+-- Deferred retries run from onFrameUpdate (while the PDA is open) and from
+-- main.lua's FSBaseMission.update hook (which calls _attemptDeferredRegister).
+

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -243,6 +243,46 @@
     <text name="helpLine_cs_t3_sprayer_title"  text="Použití postřikovačů jako zavlažování"/>
     <text name="helpLine_cs_t3_sprayer_text"   text="Standardní vozidlové postřikovače lze použít jako manuální alternativu k permanentním zavlažovacím systémům. Pokud naplníte postřikovač VODOU, jakákoli oblast, kterou postříkáte, obdrží okamžité zvýšení vlhkosti. To je užitečné pro malá pole nebo jako dočasné opatření, dokud si nemůžete dovolit středový pivot nebo kapkovou linku."/>
 
+    <!-- ========== PDA SCREEN ========== -->
+    <text name="cs_pda_screen_title"           text="Crop Moisture Monitor"/>
+    <text name="cs_pda_tab_fields"             text="Fields"/>
+    <text name="cs_pda_tab_overview"           text="Overview"/>
+    <text name="cs_pda_tab_irrigation"         text="Irrigation"/>
+    <text name="cs_pda_col_field"              text="Field"/>
+    <text name="cs_pda_col_crop"               text="Crop"/>
+    <text name="cs_pda_col_moisture"           text="Moisture"/>
+    <text name="cs_pda_col_status"             text="Status"/>
+    <text name="cs_pda_col_stress"             text="Stress"/>
+    <text name="cs_pda_col_irrigated"          text="Irrigated"/>
+    <text name="cs_pda_section_farm_overview"  text="Farm Overview"/>
+    <text name="cs_pda_section_moisture"       text="Moisture Status"/>
+    <text name="cs_pda_section_stress"         text="Crop Stress"/>
+    <text name="cs_pda_section_irrigation"     text="Irrigation"/>
+    <text name="cs_pda_section_irrigation_plan" text="Irrigation Priority"/>
+    <text name="cs_pda_fields_tracked"         text="Fields Tracked"/>
+    <text name="cs_pda_fields_owned"           text="Fields Owned"/>
+    <text name="cs_pda_avg_moisture"           text="Average Moisture"/>
+    <text name="cs_pda_fields_healthy"         text="Healthy (<!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->gt;=40%)"/>
+    <text name="cs_pda_fields_warning"         text="Warning (25-40%)"/>
+    <text name="cs_pda_fields_critical"        text="Critical (<!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->lt;25%)"/>
+    <text name="cs_pda_avg_stress"             text="Average Stress"/>
+    <text name="cs_pda_est_yield_loss"         text="Est. Yield Loss"/>
+    <text name="cs_pda_irrigated_fields"       text="Irrigated Fields"/>
+    <text name="cs_pda_irrigation_systems"     text="Active Systems"/>
+    <text name="cs_pda_status_healthy"         text="Healthy"/>
+    <text name="cs_pda_status_warning"         text="Warning"/>
+    <text name="cs_pda_status_critical"        text="Critical"/>
+    <text name="cs_pda_irrigated_yes"          text="Yes"/>
+    <text name="cs_pda_irrigated_no"           text="No"/>
+    <text name="cs_pda_no_fields"             text="No field data yet."/>
+    <!-- ========== MAP OVERLAY ========== -->
+    <text name="cs_map_page_title"            text="Crop Moisture"/>
+    <text name="cs_map_sidebar_title"         text="MOISTURE LEGEND"/>
+    <text name="cs_map_legend_healthy"        text="Healthy  <!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->gt;=40%"/>
+    <text name="cs_map_legend_warning"        text="Warning  25-40%"/>
+    <text name="cs_map_legend_critical"       text="Critical  <!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->lt;25%"/>
+    <text name="cs_map_btn_open_pda"          text="Open Crop PDA"/>
+
     <!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->
     <!-- CoursePlay context appended to stress alerts -->
     <text name="cs_cp_vehicle_on_field"  text="CoursePlay: %d vozidlo pracuje na tomto poli"/>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -243,6 +243,46 @@
     <text name="helpLine_cs_t3_sprayer_title"  text="Feldspritzen zur Bewässerung nutzen"/>
     <text name="helpLine_cs_t3_sprayer_text"   text="Standard-Feldspritzen können als manuelle Alternative zu fest installierten Bewässerungssystemen verwendet werden. Wenn Sie eine Spritze mit WASSER füllen, erhält jeder Bereich, den Sie besprühen, einen sofortigen Feuchtigkeitsschub. Dies ist nützlich für kleine Felder oder als Übergangsmaßnahme, bis Sie sich eine Kreis- oder Tröpfchenbewässerung leisten können."/>
 
+    <!-- ========== PDA SCREEN ========== -->
+    <text name="cs_pda_screen_title"           text="Crop Moisture Monitor"/>
+    <text name="cs_pda_tab_fields"             text="Fields"/>
+    <text name="cs_pda_tab_overview"           text="Overview"/>
+    <text name="cs_pda_tab_irrigation"         text="Irrigation"/>
+    <text name="cs_pda_col_field"              text="Field"/>
+    <text name="cs_pda_col_crop"               text="Crop"/>
+    <text name="cs_pda_col_moisture"           text="Moisture"/>
+    <text name="cs_pda_col_status"             text="Status"/>
+    <text name="cs_pda_col_stress"             text="Stress"/>
+    <text name="cs_pda_col_irrigated"          text="Irrigated"/>
+    <text name="cs_pda_section_farm_overview"  text="Farm Overview"/>
+    <text name="cs_pda_section_moisture"       text="Moisture Status"/>
+    <text name="cs_pda_section_stress"         text="Crop Stress"/>
+    <text name="cs_pda_section_irrigation"     text="Irrigation"/>
+    <text name="cs_pda_section_irrigation_plan" text="Irrigation Priority"/>
+    <text name="cs_pda_fields_tracked"         text="Fields Tracked"/>
+    <text name="cs_pda_fields_owned"           text="Fields Owned"/>
+    <text name="cs_pda_avg_moisture"           text="Average Moisture"/>
+    <text name="cs_pda_fields_healthy"         text="Healthy (<!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->gt;=40%)"/>
+    <text name="cs_pda_fields_warning"         text="Warning (25-40%)"/>
+    <text name="cs_pda_fields_critical"        text="Critical (<!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->lt;25%)"/>
+    <text name="cs_pda_avg_stress"             text="Average Stress"/>
+    <text name="cs_pda_est_yield_loss"         text="Est. Yield Loss"/>
+    <text name="cs_pda_irrigated_fields"       text="Irrigated Fields"/>
+    <text name="cs_pda_irrigation_systems"     text="Active Systems"/>
+    <text name="cs_pda_status_healthy"         text="Healthy"/>
+    <text name="cs_pda_status_warning"         text="Warning"/>
+    <text name="cs_pda_status_critical"        text="Critical"/>
+    <text name="cs_pda_irrigated_yes"          text="Yes"/>
+    <text name="cs_pda_irrigated_no"           text="No"/>
+    <text name="cs_pda_no_fields"             text="No field data yet."/>
+    <!-- ========== MAP OVERLAY ========== -->
+    <text name="cs_map_page_title"            text="Crop Moisture"/>
+    <text name="cs_map_sidebar_title"         text="MOISTURE LEGEND"/>
+    <text name="cs_map_legend_healthy"        text="Healthy  <!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->gt;=40%"/>
+    <text name="cs_map_legend_warning"        text="Warning  25-40%"/>
+    <text name="cs_map_legend_critical"       text="Critical  <!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->lt;25%"/>
+    <text name="cs_map_btn_open_pda"          text="Open Crop PDA"/>
+
     <!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->
 
     <text name="cs_cp_vehicle_on_field"  text="CoursePlay: %d Fahrzeug arbeitet auf diesem Feld"/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -243,6 +243,47 @@
     <text name="helpLine_cs_t3_sprayer_title"  text="Using Sprayers as Irrigation"/>
     <text name="helpLine_cs_t3_sprayer_text"   text="Standard vehicle-based sprayers can be used as a manual alternative to permanent irrigation systems. If you fill a sprayer with WATER, any area you spray will receive an immediate moisture boost. This is useful for small fields or as a temporary measure until you can afford a centre pivot or drip line."/>
 
+    <!-- ========== PDA SCREEN ========== -->
+    <text name="cs_pda_screen_title"           text="Crop Moisture Monitor"/>
+    <text name="cs_pda_tab_fields"             text="Fields"/>
+    <text name="cs_pda_tab_overview"           text="Overview"/>
+    <text name="cs_pda_tab_irrigation"         text="Irrigation"/>
+    <text name="cs_pda_col_field"              text="Field"/>
+    <text name="cs_pda_col_crop"               text="Crop"/>
+    <text name="cs_pda_col_moisture"           text="Moisture"/>
+    <text name="cs_pda_col_status"             text="Status"/>
+    <text name="cs_pda_col_stress"             text="Stress"/>
+    <text name="cs_pda_col_irrigated"          text="Irrigated"/>
+    <text name="cs_pda_section_farm_overview"  text="Farm Overview"/>
+    <text name="cs_pda_section_moisture"       text="Moisture Status"/>
+    <text name="cs_pda_section_stress"         text="Crop Stress"/>
+    <text name="cs_pda_section_irrigation"     text="Irrigation"/>
+    <text name="cs_pda_section_irrigation_plan" text="Irrigation Priority"/>
+    <text name="cs_pda_fields_tracked"         text="Fields Tracked"/>
+    <text name="cs_pda_fields_owned"           text="Fields Owned"/>
+    <text name="cs_pda_avg_moisture"           text="Average Moisture"/>
+    <text name="cs_pda_fields_healthy"         text="Healthy (≥40%)"/>
+    <text name="cs_pda_fields_warning"         text="Warning (25–40%)"/>
+    <text name="cs_pda_fields_critical"        text="Critical (&lt;25%)"/>
+    <text name="cs_pda_avg_stress"             text="Average Stress"/>
+    <text name="cs_pda_est_yield_loss"         text="Est. Yield Loss"/>
+    <text name="cs_pda_irrigated_fields"       text="Irrigated Fields"/>
+    <text name="cs_pda_irrigation_systems"     text="Active Systems"/>
+    <text name="cs_pda_status_healthy"         text="Healthy"/>
+    <text name="cs_pda_status_warning"         text="Warning"/>
+    <text name="cs_pda_status_critical"        text="Critical"/>
+    <text name="cs_pda_irrigated_yes"          text="Yes"/>
+    <text name="cs_pda_irrigated_no"           text="No"/>
+    <text name="cs_pda_no_fields"             text="No field data yet. Fields appear once the simulation has run for one in-game hour."/>
+
+    <!-- ========== MAP OVERLAY ========== -->
+    <text name="cs_map_page_title"            text="Crop Moisture"/>
+    <text name="cs_map_sidebar_title"         text="MOISTURE LEGEND"/>
+    <text name="cs_map_legend_healthy"        text="Healthy  ≥40%"/>
+    <text name="cs_map_legend_warning"        text="Warning  25–40%"/>
+    <text name="cs_map_legend_critical"       text="Critical  &lt;25%"/>
+    <text name="cs_map_btn_open_pda"          text="Open Crop PDA"/>
+
     <!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->
     <!-- CoursePlay context appended to stress alerts -->
     <text name="cs_cp_vehicle_on_field"  text="CoursePlay: %d vehicle working this field"/>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -244,5 +244,44 @@
     <text name="cs_ad_water_hint"    text="AutoDrive : %d point(s) d'eau disponible(s) — créez une route d'approvisionnement"/>
     <text name="cs_ad_destinations"  text="AutoDrive : %d destination(s) configurée(s)"/>
 
+    <!-- ========== PDA SCREEN ========== -->
+    <text name="cs_pda_screen_title"           text="Crop Moisture Monitor"/>
+    <text name="cs_pda_tab_fields"             text="Fields"/>
+    <text name="cs_pda_tab_overview"           text="Overview"/>
+    <text name="cs_pda_tab_irrigation"         text="Irrigation"/>
+    <text name="cs_pda_col_field"              text="Field"/>
+    <text name="cs_pda_col_crop"               text="Crop"/>
+    <text name="cs_pda_col_moisture"           text="Moisture"/>
+    <text name="cs_pda_col_status"             text="Status"/>
+    <text name="cs_pda_col_stress"             text="Stress"/>
+    <text name="cs_pda_col_irrigated"          text="Irrigated"/>
+    <text name="cs_pda_section_farm_overview"  text="Farm Overview"/>
+    <text name="cs_pda_section_moisture"       text="Moisture Status"/>
+    <text name="cs_pda_section_stress"         text="Crop Stress"/>
+    <text name="cs_pda_section_irrigation"     text="Irrigation"/>
+    <text name="cs_pda_section_irrigation_plan" text="Irrigation Priority"/>
+    <text name="cs_pda_fields_tracked"         text="Fields Tracked"/>
+    <text name="cs_pda_fields_owned"           text="Fields Owned"/>
+    <text name="cs_pda_avg_moisture"           text="Average Moisture"/>
+    <text name="cs_pda_fields_healthy"         text="Healthy (>=40%)"/>
+    <text name="cs_pda_fields_warning"         text="Warning (25-40%)"/>
+    <text name="cs_pda_fields_critical"        text="Critical (&lt;25%)"/>
+    <text name="cs_pda_avg_stress"             text="Average Stress"/>
+    <text name="cs_pda_est_yield_loss"         text="Est. Yield Loss"/>
+    <text name="cs_pda_irrigated_fields"       text="Irrigated Fields"/>
+    <text name="cs_pda_irrigation_systems"     text="Active Systems"/>
+    <text name="cs_pda_status_healthy"         text="Healthy"/>
+    <text name="cs_pda_status_warning"         text="Warning"/>
+    <text name="cs_pda_status_critical"        text="Critical"/>
+    <text name="cs_pda_irrigated_yes"          text="Yes"/>
+    <text name="cs_pda_irrigated_no"           text="No"/>
+    <text name="cs_pda_no_fields"              text="No field data yet."/>
+    <!-- ========== MAP OVERLAY ========== -->
+    <text name="cs_map_page_title"             text="Crop Moisture"/>
+    <text name="cs_map_sidebar_title"          text="MOISTURE LEGEND"/>
+    <text name="cs_map_legend_healthy"         text="Healthy  >=40%"/>
+    <text name="cs_map_legend_warning"         text="Warning  25-40%"/>
+    <text name="cs_map_legend_critical"        text="Critical  &lt;25%"/>
+    <text name="cs_map_btn_open_pda"           text="Open Crop PDA"/>
     </texts>
 </l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -244,5 +244,44 @@
     <text name="cs_ad_water_hint"    text="AutoDrive: %d punto/i d'acqua disponibile/i — imposta un percorso di trasporto"/>
     <text name="cs_ad_destinations"  text="AutoDrive: %d destinazione/i configurata/e"/>
 
+    <!-- ========== PDA SCREEN ========== -->
+    <text name="cs_pda_screen_title"           text="Crop Moisture Monitor"/>
+    <text name="cs_pda_tab_fields"             text="Fields"/>
+    <text name="cs_pda_tab_overview"           text="Overview"/>
+    <text name="cs_pda_tab_irrigation"         text="Irrigation"/>
+    <text name="cs_pda_col_field"              text="Field"/>
+    <text name="cs_pda_col_crop"               text="Crop"/>
+    <text name="cs_pda_col_moisture"           text="Moisture"/>
+    <text name="cs_pda_col_status"             text="Status"/>
+    <text name="cs_pda_col_stress"             text="Stress"/>
+    <text name="cs_pda_col_irrigated"          text="Irrigated"/>
+    <text name="cs_pda_section_farm_overview"  text="Farm Overview"/>
+    <text name="cs_pda_section_moisture"       text="Moisture Status"/>
+    <text name="cs_pda_section_stress"         text="Crop Stress"/>
+    <text name="cs_pda_section_irrigation"     text="Irrigation"/>
+    <text name="cs_pda_section_irrigation_plan" text="Irrigation Priority"/>
+    <text name="cs_pda_fields_tracked"         text="Fields Tracked"/>
+    <text name="cs_pda_fields_owned"           text="Fields Owned"/>
+    <text name="cs_pda_avg_moisture"           text="Average Moisture"/>
+    <text name="cs_pda_fields_healthy"         text="Healthy (>=40%)"/>
+    <text name="cs_pda_fields_warning"         text="Warning (25-40%)"/>
+    <text name="cs_pda_fields_critical"        text="Critical (&lt;25%)"/>
+    <text name="cs_pda_avg_stress"             text="Average Stress"/>
+    <text name="cs_pda_est_yield_loss"         text="Est. Yield Loss"/>
+    <text name="cs_pda_irrigated_fields"       text="Irrigated Fields"/>
+    <text name="cs_pda_irrigation_systems"     text="Active Systems"/>
+    <text name="cs_pda_status_healthy"         text="Healthy"/>
+    <text name="cs_pda_status_warning"         text="Warning"/>
+    <text name="cs_pda_status_critical"        text="Critical"/>
+    <text name="cs_pda_irrigated_yes"          text="Yes"/>
+    <text name="cs_pda_irrigated_no"           text="No"/>
+    <text name="cs_pda_no_fields"              text="No field data yet."/>
+    <!-- ========== MAP OVERLAY ========== -->
+    <text name="cs_map_page_title"             text="Crop Moisture"/>
+    <text name="cs_map_sidebar_title"          text="MOISTURE LEGEND"/>
+    <text name="cs_map_legend_healthy"         text="Healthy  >=40%"/>
+    <text name="cs_map_legend_warning"         text="Warning  25-40%"/>
+    <text name="cs_map_legend_critical"        text="Critical  &lt;25%"/>
+    <text name="cs_map_btn_open_pda"           text="Open Crop PDA"/>
     </texts>
 </l10n>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -249,5 +249,44 @@
     <text name="cs_ad_water_hint"    text="AutoDrive: %d waterbestemming(en) beschikbaar — stel een transportroute in"/>
     <text name="cs_ad_destinations"  text="AutoDrive: %d bestemming(en) geconfigureerd"/>
 
+    <!-- ========== PDA SCREEN ========== -->
+    <text name="cs_pda_screen_title"           text="Crop Moisture Monitor"/>
+    <text name="cs_pda_tab_fields"             text="Fields"/>
+    <text name="cs_pda_tab_overview"           text="Overview"/>
+    <text name="cs_pda_tab_irrigation"         text="Irrigation"/>
+    <text name="cs_pda_col_field"              text="Field"/>
+    <text name="cs_pda_col_crop"               text="Crop"/>
+    <text name="cs_pda_col_moisture"           text="Moisture"/>
+    <text name="cs_pda_col_status"             text="Status"/>
+    <text name="cs_pda_col_stress"             text="Stress"/>
+    <text name="cs_pda_col_irrigated"          text="Irrigated"/>
+    <text name="cs_pda_section_farm_overview"  text="Farm Overview"/>
+    <text name="cs_pda_section_moisture"       text="Moisture Status"/>
+    <text name="cs_pda_section_stress"         text="Crop Stress"/>
+    <text name="cs_pda_section_irrigation"     text="Irrigation"/>
+    <text name="cs_pda_section_irrigation_plan" text="Irrigation Priority"/>
+    <text name="cs_pda_fields_tracked"         text="Fields Tracked"/>
+    <text name="cs_pda_fields_owned"           text="Fields Owned"/>
+    <text name="cs_pda_avg_moisture"           text="Average Moisture"/>
+    <text name="cs_pda_fields_healthy"         text="Healthy (>=40%)"/>
+    <text name="cs_pda_fields_warning"         text="Warning (25-40%)"/>
+    <text name="cs_pda_fields_critical"        text="Critical (&lt;25%)"/>
+    <text name="cs_pda_avg_stress"             text="Average Stress"/>
+    <text name="cs_pda_est_yield_loss"         text="Est. Yield Loss"/>
+    <text name="cs_pda_irrigated_fields"       text="Irrigated Fields"/>
+    <text name="cs_pda_irrigation_systems"     text="Active Systems"/>
+    <text name="cs_pda_status_healthy"         text="Healthy"/>
+    <text name="cs_pda_status_warning"         text="Warning"/>
+    <text name="cs_pda_status_critical"        text="Critical"/>
+    <text name="cs_pda_irrigated_yes"          text="Yes"/>
+    <text name="cs_pda_irrigated_no"           text="No"/>
+    <text name="cs_pda_no_fields"              text="No field data yet."/>
+    <!-- ========== MAP OVERLAY ========== -->
+    <text name="cs_map_page_title"             text="Crop Moisture"/>
+    <text name="cs_map_sidebar_title"          text="MOISTURE LEGEND"/>
+    <text name="cs_map_legend_healthy"         text="Healthy  >=40%"/>
+    <text name="cs_map_legend_warning"         text="Warning  25-40%"/>
+    <text name="cs_map_legend_critical"        text="Critical  &lt;25%"/>
+    <text name="cs_map_btn_open_pda"           text="Open Crop PDA"/>
     </texts>
 </l10n>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -244,5 +244,44 @@
     <text name="cs_ad_water_hint"    text="AutoDrive: %d punkt(y) wodny dostępny — skonfiguruj trasę transportu wody"/>
     <text name="cs_ad_destinations"  text="AutoDrive: %d cel(e) skonfigurowany/e"/>
 
+    <!-- ========== PDA SCREEN ========== -->
+    <text name="cs_pda_screen_title"           text="Crop Moisture Monitor"/>
+    <text name="cs_pda_tab_fields"             text="Fields"/>
+    <text name="cs_pda_tab_overview"           text="Overview"/>
+    <text name="cs_pda_tab_irrigation"         text="Irrigation"/>
+    <text name="cs_pda_col_field"              text="Field"/>
+    <text name="cs_pda_col_crop"               text="Crop"/>
+    <text name="cs_pda_col_moisture"           text="Moisture"/>
+    <text name="cs_pda_col_status"             text="Status"/>
+    <text name="cs_pda_col_stress"             text="Stress"/>
+    <text name="cs_pda_col_irrigated"          text="Irrigated"/>
+    <text name="cs_pda_section_farm_overview"  text="Farm Overview"/>
+    <text name="cs_pda_section_moisture"       text="Moisture Status"/>
+    <text name="cs_pda_section_stress"         text="Crop Stress"/>
+    <text name="cs_pda_section_irrigation"     text="Irrigation"/>
+    <text name="cs_pda_section_irrigation_plan" text="Irrigation Priority"/>
+    <text name="cs_pda_fields_tracked"         text="Fields Tracked"/>
+    <text name="cs_pda_fields_owned"           text="Fields Owned"/>
+    <text name="cs_pda_avg_moisture"           text="Average Moisture"/>
+    <text name="cs_pda_fields_healthy"         text="Healthy (>=40%)"/>
+    <text name="cs_pda_fields_warning"         text="Warning (25-40%)"/>
+    <text name="cs_pda_fields_critical"        text="Critical (&lt;25%)"/>
+    <text name="cs_pda_avg_stress"             text="Average Stress"/>
+    <text name="cs_pda_est_yield_loss"         text="Est. Yield Loss"/>
+    <text name="cs_pda_irrigated_fields"       text="Irrigated Fields"/>
+    <text name="cs_pda_irrigation_systems"     text="Active Systems"/>
+    <text name="cs_pda_status_healthy"         text="Healthy"/>
+    <text name="cs_pda_status_warning"         text="Warning"/>
+    <text name="cs_pda_status_critical"        text="Critical"/>
+    <text name="cs_pda_irrigated_yes"          text="Yes"/>
+    <text name="cs_pda_irrigated_no"           text="No"/>
+    <text name="cs_pda_no_fields"              text="No field data yet."/>
+    <!-- ========== MAP OVERLAY ========== -->
+    <text name="cs_map_page_title"             text="Crop Moisture"/>
+    <text name="cs_map_sidebar_title"          text="MOISTURE LEGEND"/>
+    <text name="cs_map_legend_healthy"         text="Healthy  >=40%"/>
+    <text name="cs_map_legend_warning"         text="Warning  25-40%"/>
+    <text name="cs_map_legend_critical"        text="Critical  &lt;25%"/>
+    <text name="cs_map_btn_open_pda"           text="Open Crop PDA"/>
     </texts>
 </l10n>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -229,6 +229,46 @@
     <text name="helpLine_cs_t3_sprayer_title"  text="Використання обприскувачів для зрошення"/>
     <text name="helpLine_cs_t3_sprayer_text"   text="Звичайні обприскувачі можна використовувати як ручну альтернативу постійним системам зрошення. Якщо наповнити обприскувач ВОДОЮ, будь-яка оброблена ділянка отримає негайний приріст вологості. Корисно для невеликих полів або як тимчасовий захід до встановлення постійного зрошення."/>
 
+    <!-- ========== PDA SCREEN ========== -->
+    <text name="cs_pda_screen_title"           text="Crop Moisture Monitor"/>
+    <text name="cs_pda_tab_fields"             text="Fields"/>
+    <text name="cs_pda_tab_overview"           text="Overview"/>
+    <text name="cs_pda_tab_irrigation"         text="Irrigation"/>
+    <text name="cs_pda_col_field"              text="Field"/>
+    <text name="cs_pda_col_crop"               text="Crop"/>
+    <text name="cs_pda_col_moisture"           text="Moisture"/>
+    <text name="cs_pda_col_status"             text="Status"/>
+    <text name="cs_pda_col_stress"             text="Stress"/>
+    <text name="cs_pda_col_irrigated"          text="Irrigated"/>
+    <text name="cs_pda_section_farm_overview"  text="Farm Overview"/>
+    <text name="cs_pda_section_moisture"       text="Moisture Status"/>
+    <text name="cs_pda_section_stress"         text="Crop Stress"/>
+    <text name="cs_pda_section_irrigation"     text="Irrigation"/>
+    <text name="cs_pda_section_irrigation_plan" text="Irrigation Priority"/>
+    <text name="cs_pda_fields_tracked"         text="Fields Tracked"/>
+    <text name="cs_pda_fields_owned"           text="Fields Owned"/>
+    <text name="cs_pda_avg_moisture"           text="Average Moisture"/>
+    <text name="cs_pda_fields_healthy"         text="Healthy (<!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->gt;=40%)"/>
+    <text name="cs_pda_fields_warning"         text="Warning (25-40%)"/>
+    <text name="cs_pda_fields_critical"        text="Critical (<!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->lt;25%)"/>
+    <text name="cs_pda_avg_stress"             text="Average Stress"/>
+    <text name="cs_pda_est_yield_loss"         text="Est. Yield Loss"/>
+    <text name="cs_pda_irrigated_fields"       text="Irrigated Fields"/>
+    <text name="cs_pda_irrigation_systems"     text="Active Systems"/>
+    <text name="cs_pda_status_healthy"         text="Healthy"/>
+    <text name="cs_pda_status_warning"         text="Warning"/>
+    <text name="cs_pda_status_critical"        text="Critical"/>
+    <text name="cs_pda_irrigated_yes"          text="Yes"/>
+    <text name="cs_pda_irrigated_no"           text="No"/>
+    <text name="cs_pda_no_fields"             text="No field data yet."/>
+    <!-- ========== MAP OVERLAY ========== -->
+    <text name="cs_map_page_title"            text="Crop Moisture"/>
+    <text name="cs_map_sidebar_title"         text="MOISTURE LEGEND"/>
+    <text name="cs_map_legend_healthy"        text="Healthy  <!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->gt;=40%"/>
+    <text name="cs_map_legend_warning"        text="Warning  25-40%"/>
+    <text name="cs_map_legend_critical"       text="Critical  <!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->lt;25%"/>
+    <text name="cs_map_btn_open_pda"          text="Open Crop PDA"/>
+
     <!-- ========== OPTIONAL MOD INTEGRATIONS ========== -->
     <text name="cs_cp_vehicle_on_field"  text="CoursePlay: %d транспортний засіб працює на цьому полі"/>
     <text name="cs_cp_vehicles_on_field" text="CoursePlay: %d транспортних засоби працюють на цьому полі"/>

--- a/xml/gui/CsPDAScreen.xml
+++ b/xml/gui/CsPDAScreen.xml
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<!--
+    CsPDAScreen.xml
+    InGameMenu page — Controller: CsPDAScreen (src/ui/CsPDAScreen.lua)
+
+    Layout:
+      LEFT  (460px) — field list sidebar: F# | Crop | Moisture | Status
+      RIGHT (1000px) — tabbed content:
+          Tab 1 Overview   → farm-wide moisture & stress stats
+          Tab 2 Irrigation → field triage sorted by moisture (driest first)
+-->
+<GUI name="menuCropStress">
+  <GuiElement profile="fs25_menuContainer">
+
+    <!-- ── Header ──────────────────────────────────────────── -->
+    <GuiElement profile="fs25_menuHeaderPanel" position="-200px 90px" width="800px">
+      <Text profile="fs25_menuHeaderTitle" id="categoryHeaderText"
+            text="$l10n_cs_pda_screen_title"/>
+    </GuiElement>
+
+    <!-- ══════════════════════════════════════════════════════
+         LEFT COLUMN — 460px, field list sidebar
+         ══════════════════════════════════════════════════════ -->
+    <ThreePartBitmap width="460px" height="700px" position="0px 100px">
+      <GuiElement profile="fs25_subCategoryContainer" width="420px">
+
+        <GuiElement id="sidebarFields" position="0px 0px" width="420px" height="640px">
+          <Text profile="cs_sectionHeader" text="$l10n_cs_pda_tab_fields" position="10px -10px"/>
+
+          <!-- Column headers -->
+          <Text profile="cs_colHeader" text="$l10n_cs_pda_col_field"    position="10px  -50px" size="55px  24px"/>
+          <Text profile="cs_colHeader" text="$l10n_cs_pda_col_crop"     position="70px  -50px" size="140px 24px"/>
+          <Text profile="cs_colHeader" text="$l10n_cs_pda_col_moisture" position="214px -50px" size="80px  24px"/>
+          <Text profile="cs_colHeader" text="$l10n_cs_pda_col_status"   position="298px -50px" size="112px 24px"/>
+
+          <!-- Scrollable field list -->
+          <GuiElement position="0px -78px" width="420px" height="552px">
+            <SmoothList id="fieldList" profile="cs_smoothList"
+                        startClipperElementName="sideListStart"
+                        endClipperElementName="sideListEnd">
+              <ListItem profile="cs_listRow" onClick="onClickFieldRow">
+                <Bitmap profile="cs_rowBg" name="alternating"/>
+                <Text profile="cs_cellLeft"  name="fieldRowId"       size="55px  28px"/>
+                <Text profile="cs_cellLeft"  name="fieldRowCrop"     position="70px  0" size="140px 28px"/>
+                <Text profile="cs_cellRight" name="fieldRowMoisture" position="214px 0" size="80px  28px"/>
+                <Text profile="cs_cellRight" name="fieldRowStatus"   position="298px 0" size="112px 28px"/>
+              </ListItem>
+            </SmoothList>
+            <Bitmap profile="fs25_secondaryMenuStartClipper" name="sideListStart"/>
+            <Bitmap profile="fs25_secondaryMenuStopClipper"  name="sideListEnd"/>
+          </GuiElement>
+        </GuiElement>
+
+      </GuiElement>
+    </ThreePartBitmap>
+
+    <!-- ══════════════════════════════════════════════════════
+         RIGHT COLUMN — 1000px, tabbed content
+         ══════════════════════════════════════════════════════ -->
+    <GuiElement id="rightPanel" position="500px 100px" width="1000px" height="700px">
+
+      <!-- Tab bar -->
+      <GuiElement position="0px 654px" width="1000px" height="40px">
+        <Text profile="cs_tabLabel" id="tabLabelOverview"
+              text="$l10n_cs_pda_tab_overview"
+              position="0px 0px" size="490px 40px"
+              onClick="onClickTabOverview"/>
+        <Text profile="cs_tabLabel" id="tabLabelIrrigation"
+              text="$l10n_cs_pda_tab_irrigation"
+              position="510px 0px" size="490px 40px"
+              onClick="onClickTabIrrigation"/>
+        <Bitmap profile="cs_tabUnderline" id="tabUnderlineOverview"
+                position="0px -3px" size="490px 3px"/>
+        <Bitmap profile="cs_tabUnderline" id="tabUnderlineIrrigation"
+                position="510px -3px" size="490px 3px" visible="false"/>
+      </GuiElement>
+
+      <Bitmap profile="cs_tabDivider" position="0px 650px" size="1000px 2px"/>
+
+      <!-- ── TAB 1: OVERVIEW ─────────────────────────────── -->
+      <GuiElement id="overviewContent" position="0px 0px" width="1000px" height="642px">
+
+        <Text profile="cs_sectionHeader"
+              text="$l10n_cs_pda_section_farm_overview"
+              position="0px 620px"/>
+
+        <ThreePartBitmap width="960px" height="580px" position="0px 30px">
+          <GuiElement profile="fs25_subCategoryContainer" width="920px">
+
+            <!-- Fields row -->
+            <Text profile="cs_statLabel" text="$l10n_cs_pda_fields_tracked"
+                  position="10px -30px" size="300px 24px"/>
+            <Text profile="cs_statValue" id="statsFieldsTracked" text="0"
+                  position="320px -30px"/>
+
+            <Text profile="cs_statLabel" text="$l10n_cs_pda_fields_owned"
+                  position="10px -60px" size="300px 24px"/>
+            <Text profile="cs_statValue" id="statsFieldsOwned" text="0"
+                  position="320px -60px"/>
+
+            <!-- Moisture breakdown -->
+            <Text profile="cs_subHeader" text="$l10n_cs_pda_section_moisture"
+                  position="10px -110px"/>
+
+            <Text profile="cs_statLabel" text="$l10n_cs_pda_avg_moisture"
+                  position="10px -140px" size="300px 24px"/>
+            <Text profile="cs_statValue" id="statsAvgMoisture" text="—"
+                  position="320px -140px"/>
+
+            <Text profile="cs_statLabel" text="$l10n_cs_pda_fields_healthy"
+                  position="10px -170px" size="300px 24px"/>
+            <Text profile="cs_statValue" id="statsHealthy" text="0"
+                  position="320px -170px"/>
+
+            <Text profile="cs_statLabel" text="$l10n_cs_pda_fields_warning"
+                  position="10px -200px" size="300px 24px"/>
+            <Text profile="cs_statValue" id="statsWarning" text="0"
+                  position="320px -200px"/>
+
+            <Text profile="cs_statLabel" text="$l10n_cs_pda_fields_critical"
+                  position="10px -230px" size="300px 24px"/>
+            <Text profile="cs_statValue" id="statsCritical" text="0"
+                  position="320px -230px"/>
+
+            <!-- Stress & yield -->
+            <Text profile="cs_subHeader" text="$l10n_cs_pda_section_stress"
+                  position="10px -282px"/>
+
+            <Text profile="cs_statLabel" text="$l10n_cs_pda_avg_stress"
+                  position="10px -312px" size="300px 24px"/>
+            <Text profile="cs_statValue" id="statsAvgStress" text="—"
+                  position="320px -312px"/>
+
+            <Text profile="cs_statLabel" text="$l10n_cs_pda_est_yield_loss"
+                  position="10px -342px" size="300px 24px"/>
+            <Text profile="cs_statValue" id="statsYieldLoss" text="—"
+                  position="320px -342px"/>
+
+            <!-- Irrigation -->
+            <Text profile="cs_subHeader" text="$l10n_cs_pda_section_irrigation"
+                  position="10px -394px"/>
+
+            <Text profile="cs_statLabel" text="$l10n_cs_pda_irrigated_fields"
+                  position="10px -424px" size="300px 24px"/>
+            <Text profile="cs_statValue" id="statsIrrigated" text="0"
+                  position="320px -424px"/>
+
+            <Text profile="cs_statLabel" text="$l10n_cs_pda_irrigation_systems"
+                  position="10px -454px" size="300px 24px"/>
+            <Text profile="cs_statValue" id="statsIrrSystems" text="0"
+                  position="320px -454px"/>
+
+          </GuiElement>
+        </ThreePartBitmap>
+
+        <Text profile="cs_emptyHint" id="overviewEmptyHint"
+              text="$l10n_cs_pda_no_fields"
+              position="480px 320px" visible="false"/>
+
+      </GuiElement><!-- /overviewContent -->
+
+      <!-- ── TAB 2: IRRIGATION ───────────────────────────── -->
+      <GuiElement id="irrigationContent" position="0px 0px" width="1000px" height="642px" visible="false">
+
+        <Text profile="cs_sectionHeader"
+              text="$l10n_cs_pda_section_irrigation_plan"
+              position="0px 620px"/>
+
+        <!-- Column headers -->
+        <Text profile="cs_colHeader" text="$l10n_cs_pda_col_field"
+              position="8px  590px" size="60px 24px"/>
+        <Text profile="cs_colHeader" text="$l10n_cs_pda_col_crop"
+              position="72px 590px" size="200px 24px"/>
+        <Text profile="cs_colHeader" text="$l10n_cs_pda_col_moisture"
+              position="276px 590px" size="80px 24px"/>
+        <Text profile="cs_colHeader" text="$l10n_cs_pda_col_stress"
+              position="360px 590px" size="80px 24px"/>
+        <Text profile="cs_colHeader" text="$l10n_cs_pda_col_irrigated"
+              position="444px 590px" size="100px 24px"/>
+
+        <!-- Irrigation triage list -->
+        <GuiElement position="0px 80px" width="960px" height="498px">
+          <SmoothList id="irrigationList" profile="cs_smoothList"
+                      startClipperElementName="irrListStart"
+                      endClipperElementName="irrListEnd">
+            <ListItem profile="cs_listRow" onClick="onClickIrrigationRow">
+              <Bitmap profile="cs_rowBg" name="alternating"/>
+              <Text profile="cs_cellLeft"  name="irrRowId"        size="60px  28px"/>
+              <Text profile="cs_cellLeft"  name="irrRowCrop"      position="72px  0" size="200px 28px"/>
+              <Text profile="cs_cellRight" name="irrRowMoisture"  position="276px 0" size="80px  28px"/>
+              <Text profile="cs_cellRight" name="irrRowStress"    position="360px 0" size="80px  28px"/>
+              <Text profile="cs_cellRight" name="irrRowIrrigated" position="444px 0" size="100px 28px"/>
+            </ListItem>
+          </SmoothList>
+          <Bitmap profile="fs25_secondaryMenuStartClipper" name="irrListStart"/>
+          <Bitmap profile="fs25_secondaryMenuStopClipper"  name="irrListEnd"/>
+        </GuiElement>
+
+        <Text profile="cs_emptyHint" id="irrigationEmptyHint"
+              text="$l10n_cs_pda_no_fields"
+              position="480px 320px" visible="false"/>
+
+      </GuiElement><!-- /irrigationContent -->
+
+    </GuiElement><!-- /rightPanel -->
+
+  </GuiElement><!-- /menuContainer -->
+
+  <!-- ── Inline profile definitions ──────────────────────── -->
+  <GUIProfiles>
+
+    <Profile name="cs_tabLabel" extends="fs25_textDefault" with="anchorTopLeft">
+      <isFocusable value="true"/>
+      <textSize value="14px"/>
+      <textBold value="true"/>
+      <textUpperCase value="true"/>
+      <textAlignment value="center"/>
+      <textColor value="$preset_colorWhite_50"/>
+    </Profile>
+
+    <Profile name="cs_tabUnderline" extends="baseReference" with="anchorBottomLeft">
+      <imageColor value="0.20 0.65 0.85 1.0"/>
+    </Profile>
+
+    <Profile name="cs_tabDivider" extends="baseReference" with="anchorTopLeft">
+      <imageColor value="1.0 1.0 1.0 0.12"/>
+    </Profile>
+
+    <Profile name="cs_sectionHeader" extends="fs25_textDefault" with="anchorTopLeft">
+      <textSize value="18px"/>
+      <textBold value="true"/>
+      <textUpperCase value="true"/>
+      <textColor value="0.20 0.65 0.85 1.0"/>
+    </Profile>
+
+    <Profile name="cs_subHeader" extends="fs25_textDefault" with="anchorTopLeft">
+      <textSize value="13px"/>
+      <textBold value="true"/>
+      <textUpperCase value="true"/>
+      <textColor value="$preset_colorWhite_50"/>
+    </Profile>
+
+    <Profile name="cs_statLabel" extends="fs25_textDefault" with="anchorTopLeft">
+      <textSize value="14px"/>
+      <textColor value="$preset_colorWhite_50"/>
+      <textAlignment value="left"/>
+      <size value="200px 24px"/>
+    </Profile>
+
+    <Profile name="cs_statValue" extends="fs25_textDefault" with="anchorTopLeft">
+      <textSize value="14px"/>
+      <textBold value="true"/>
+      <textColor value="$preset_colorWhite"/>
+      <textAlignment value="right"/>
+      <size value="180px 24px"/>
+    </Profile>
+
+    <Profile name="cs_colHeader" extends="fs25_textDefault" with="anchorTopLeft">
+      <textSize value="13px"/>
+      <textBold value="true"/>
+      <textUpperCase value="true"/>
+      <textColor value="$preset_colorWhite_50"/>
+      <textAlignment value="left"/>
+    </Profile>
+
+    <Profile name="cs_smoothList" extends="emptyPanel" with="anchorStretchingYLeft pivotTopLeft"/>
+
+    <Profile name="cs_listRow" extends="emptyPanel" with="anchorTopStretchingX pivotTopLeft">
+      <height value="28px"/>
+    </Profile>
+
+    <Profile name="cs_rowBg" extends="baseReference" with="anchorStretchingYStretchingX">
+      <imageColor value="$preset_fs25_colorGrey"/>
+      <imageSelectedColor value="0.10 0.35 0.55 0.85"/>
+      <alternateBackgroundColor value="$preset_fs25_colorGreyDark_50"/>
+    </Profile>
+
+    <Profile name="cs_cellLeft" extends="fs25_textDefault" with="anchorStretchingYLeft">
+      <position value="8px 0"/>
+      <textSize value="13px"/>
+      <textAlignment value="left"/>
+      <textColor value="$preset_fs25_colorMainLight"/>
+      <textSelectedColor value="$preset_fs25_colorMainDark"/>
+    </Profile>
+
+    <Profile name="cs_cellRight" extends="cs_cellLeft">
+      <textAlignment value="right"/>
+    </Profile>
+
+    <Profile name="cs_emptyHint" extends="fs25_textDefault" with="anchorTopLeft">
+      <textSize value="14px"/>
+      <textAlignment value="center"/>
+      <textColor value="$preset_colorWhite_50"/>
+    </Profile>
+
+  </GUIProfiles>
+
+</GUI>


### PR DESCRIPTION
## What's in this release

### New: Crop Moisture map overlay tab
- Adds a **Crop Moisture** tab to the native PDA map (alongside Growth, Soil Type, etc.)
- Per-field centroid dots colour-coded **green / amber / red** by moisture level
- Sidebar legend with threshold labels and a direct link to the Crop PDA page
- Suppresses the native density-map overlay when our tab is active

### New: Crop Moisture PDA screen
- Full in-game PDA page accessible from the InGameMenu tab bar (with mod icon)
- **Overview tab** — farm-wide stats: fields tracked/owned, average moisture, healthy/warning/critical field counts, average stress, estimated yield loss, active irrigation system count
- **Irrigation tab** — all fields sorted driest-first showing moisture %, stress %, and whether the field is already covered by an irrigation system — designed for quick triage
- Left sidebar: full field list sorted by crop type then moisture, colour-coded status
- "Open Crop PDA" button on the map overlay sidebar links directly to this screen

### Translations
- New `cs_pda_*` and `cs_map_*` keys added to all 8 language files (English text used as fallback for non-English languages)

Closes #79
Closes #69

## Save compatibility
Full save compatibility — no migration required. This release adds UI only.