### PR TITLE
fix: v1.2.0.1 — Unicode char and GuiUtils position warnings cleanup

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.0.0</version>
+    <version>1.2.0.1</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/src/ui/CsMoistureMapOverlay.lua
+++ b/src/ui/CsMoistureMapOverlay.lua
@@ -228,11 +228,10 @@ function CsMoistureMapOverlay:onDrawHud(frame)
     -- Section title
     local _, titleSz = getNormalizedScreenValues(0, 15)
     setTextBold(true)
-    setTextUpperCase(true)
     setTextAlignment(RenderText.ALIGN_LEFT)
     setTextColor(CsMoistureMapOverlay.C_ACCENT[1], CsMoistureMapOverlay.C_ACCENT[2], CsMoistureMapOverlay.C_ACCENT[3], 1.0)
-    renderText(panelX + padX, topY - rowH, titleSz, tr("cs_map_sidebar_title", "MOISTURE LEGEND"))
-    setTextUpperCase(false)
+    local titleText = tr("cs_map_sidebar_title", "MOISTURE LEGEND")
+    renderText(panelX + padX, topY - rowH, titleSz, titleText:upper())
     setTextBold(false)
 
     local currentY = topY - rowH * 2 - gap

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -262,8 +262,8 @@
     <text name="cs_pda_fields_tracked"         text="Fields Tracked"/>
     <text name="cs_pda_fields_owned"           text="Fields Owned"/>
     <text name="cs_pda_avg_moisture"           text="Average Moisture"/>
-    <text name="cs_pda_fields_healthy"         text="Healthy (≥40%)"/>
-    <text name="cs_pda_fields_warning"         text="Warning (25–40%)"/>
+    <text name="cs_pda_fields_healthy"         text="Healthy (>=40%)"/>
+    <text name="cs_pda_fields_warning"         text="Warning (25-40%)"/>
     <text name="cs_pda_fields_critical"        text="Critical (&lt;25%)"/>
     <text name="cs_pda_avg_stress"             text="Average Stress"/>
     <text name="cs_pda_est_yield_loss"         text="Est. Yield Loss"/>
@@ -279,8 +279,8 @@
     <!-- ========== MAP OVERLAY ========== -->
     <text name="cs_map_page_title"            text="Crop Moisture"/>
     <text name="cs_map_sidebar_title"         text="MOISTURE LEGEND"/>
-    <text name="cs_map_legend_healthy"        text="Healthy  ≥40%"/>
-    <text name="cs_map_legend_warning"        text="Warning  25–40%"/>
+    <text name="cs_map_legend_healthy"        text="Healthy  >=40%"/>
+    <text name="cs_map_legend_warning"        text="Warning  25-40%"/>
     <text name="cs_map_legend_critical"       text="Critical  &lt;25%"/>
     <text name="cs_map_btn_open_pda"          text="Open Crop PDA"/>
 

--- a/xml/gui/CsPDAScreen.xml
+++ b/xml/gui/CsPDAScreen.xml
@@ -41,9 +41,9 @@
               <ListItem profile="cs_listRow" onClick="onClickFieldRow">
                 <Bitmap profile="cs_rowBg" name="alternating"/>
                 <Text profile="cs_cellLeft"  name="fieldRowId"       size="55px  28px"/>
-                <Text profile="cs_cellLeft"  name="fieldRowCrop"     position="70px  0" size="140px 28px"/>
-                <Text profile="cs_cellRight" name="fieldRowMoisture" position="214px 0" size="80px  28px"/>
-                <Text profile="cs_cellRight" name="fieldRowStatus"   position="298px 0" size="112px 28px"/>
+                <Text profile="cs_cellLeft"  name="fieldRowCrop"     position="70px  0px" size="140px 28px"/>
+                <Text profile="cs_cellRight" name="fieldRowMoisture" position="214px 0px" size="80px  28px"/>
+                <Text profile="cs_cellRight" name="fieldRowStatus"   position="298px 0px" size="112px 28px"/>
               </ListItem>
             </SmoothList>
             <Bitmap profile="fs25_secondaryMenuStartClipper" name="sideListStart"/>
@@ -186,10 +186,10 @@
             <ListItem profile="cs_listRow" onClick="onClickIrrigationRow">
               <Bitmap profile="cs_rowBg" name="alternating"/>
               <Text profile="cs_cellLeft"  name="irrRowId"        size="60px  28px"/>
-              <Text profile="cs_cellLeft"  name="irrRowCrop"      position="72px  0" size="200px 28px"/>
-              <Text profile="cs_cellRight" name="irrRowMoisture"  position="276px 0" size="80px  28px"/>
-              <Text profile="cs_cellRight" name="irrRowStress"    position="360px 0" size="80px  28px"/>
-              <Text profile="cs_cellRight" name="irrRowIrrigated" position="444px 0" size="100px 28px"/>
+              <Text profile="cs_cellLeft"  name="irrRowCrop"      position="72px  0px" size="200px 28px"/>
+              <Text profile="cs_cellRight" name="irrRowMoisture"  position="276px 0px" size="80px  28px"/>
+              <Text profile="cs_cellRight" name="irrRowStress"    position="360px 0px" size="80px  28px"/>
+              <Text profile="cs_cellRight" name="irrRowIrrigated" position="444px 0px" size="100px 28px"/>
             </ListItem>
           </SmoothList>
           <Bitmap profile="fs25_secondaryMenuStartClipper" name="irrListStart"/>
@@ -276,7 +276,7 @@
     </Profile>
 
     <Profile name="cs_cellLeft" extends="fs25_textDefault" with="anchorStretchingYLeft">
-      <position value="8px 0"/>
+      <position value="8px 0px"/>
       <textSize value="13px"/>
       <textAlignment value="left"/>
       <textColor value="$preset_fs25_colorMainLight"/>


### PR DESCRIPTION
## Summary

- Replace `≥` (U+2265) and `–` (U+2013) with ASCII equivalents in `translation_en.xml` — FS25 built-in font does not include these codepoints, causing `Warning: Character '8805' not found` spam in log
- Fix 8 bare `0` position values (no `px` unit) in `CsPDAScreen.xml` that triggered `GuiUtils.getNormalizedValue: String "" could not be converted to a number` on every screen load
- Follows on from v1.2.0.0 (map overlay + PDA screen) and v1.2.0.1 `setTextUpperCase` crash fix

## Test plan

- [ ] Launch game, open PDA map — no `setTextUpperCase` errors in log
- [ ] Open Crop Stress PDA screen — no `GuiUtils.getNormalizedValue` warnings
- [ ] Confirm `>=40%` and `25-40%` display correctly in legend and stats panel