### PR TITLE
l18n(fr): native French translation from Seb/Squall39

### DIFF
--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -244,77 +244,77 @@
     <text name="cs_ad_water_hint"    text="AutoDrive : %d point(s) d'eau disponible(s) — créez une route d'approvisionnement"/>
     <text name="cs_ad_destinations"  text="AutoDrive : %d destination(s) configurée(s)"/>
 
-    <!-- ========== PDA SCREEN ========== -->
-    <text name="cs_pda_screen_title"           text="Crop Moisture Monitor"/>
-    <text name="cs_pda_tab_fields"             text="Fields"/>
-    <text name="cs_pda_tab_overview"           text="Overview"/>
-    <text name="cs_pda_tab_irrigation"         text="Irrigation"/>
-    <text name="cs_pda_col_field"              text="Field"/>
-    <text name="cs_pda_col_crop"               text="Crop"/>
-    <text name="cs_pda_col_moisture"           text="Moisture"/>
-    <text name="cs_pda_col_status"             text="Status"/>
-    <text name="cs_pda_col_stress"             text="Stress"/>
-    <text name="cs_pda_col_irrigated"          text="Irrigated"/>
-    <text name="cs_pda_section_farm_overview"  text="Farm Overview"/>
-    <text name="cs_pda_section_moisture"       text="Moisture Status"/>
-    <text name="cs_pda_section_stress"         text="Crop Stress"/>
-    <text name="cs_pda_section_irrigation"     text="Irrigation"/>
-    <text name="cs_pda_section_irrigation_plan" text="Irrigation Priority"/>
-    <text name="cs_pda_fields_tracked"         text="Fields Tracked"/>
-    <text name="cs_pda_fields_owned"           text="Fields Owned"/>
-    <text name="cs_pda_avg_moisture"           text="Average Moisture"/>
-    <text name="cs_pda_fields_healthy"         text="Healthy (>=40%)"/>
-    <text name="cs_pda_fields_warning"         text="Warning (25-40%)"/>
-    <text name="cs_pda_fields_critical"        text="Critical (&lt;25%)"/>
-    <text name="cs_pda_avg_stress"             text="Average Stress"/>
-    <text name="cs_pda_est_yield_loss"         text="Est. Yield Loss"/>
-    <text name="cs_pda_irrigated_fields"       text="Irrigated Fields"/>
-    <text name="cs_pda_irrigation_systems"     text="Active Systems"/>
-    <text name="cs_pda_status_healthy"         text="Healthy"/>
-    <text name="cs_pda_status_warning"         text="Warning"/>
-    <text name="cs_pda_status_critical"        text="Critical"/>
-    <text name="cs_pda_irrigated_yes"          text="Yes"/>
-    <text name="cs_pda_irrigated_no"           text="No"/>
-    <text name="cs_pda_no_fields"              text="No field data yet."/>
-    <!-- ========== MAP OVERLAY ========== -->
-    <text name="cs_map_page_title"             text="Crop Moisture"/>
-    <text name="cs_map_sidebar_title"          text="MOISTURE LEGEND"/>
-    <text name="cs_map_legend_healthy"         text="Healthy  >=40%"/>
-    <text name="cs_map_legend_warning"         text="Warning  25-40%"/>
-    <text name="cs_map_legend_critical"        text="Critical  &lt;25%"/>
-    <text name="cs_map_btn_open_pda"           text="Open Crop PDA"/>
+    <!-- ========== ÉCRAN PDA ========== -->
+    <text name="cs_pda_screen_title" text="Moniteur d'humidité des cultures"/>
+<text name="cs_pda_tab_fields" text="Champs"/>
+<text name="cs_pda_tab_overview" text="Vue d'ensemble"/>
+<text name="cs_pda_tab_irrigation" text="Irrigation"/>
+<text name="cs_pda_col_field" text="Champ"/>
+<text name="cs_pda_col_crop" text="Culture"/>
+<text name="cs_pda_col_moisture" text="Humidité"/>
+<text name="cs_pda_col_status" text="Statut"/>
+<text name="cs_pda_col_stress" text="Stress"/>
+<text name="cs_pda_col_irrigated" text="Irrigué"/>
+<text name="cs_pda_section_farm_overview" text="Vue d'ensemble de la ferme"/>
+<text name="cs_pda_section_moisture" text="État de l'humidité"/>
+<text name="cs_pda_section_stress" text="Stress des cultures"/>
+<text name="cs_pda_section_irrigation" text="Irrigation"/>
+<text name="cs_pda_section_irrigation_plan" text="Priorité d'irrigation"/>
+<text name="cs_pda_fields_tracked" text="Champs suivis"/>
+<text name="cs_pda_fields_owned" text="Champs possédés"/>
+<text name="cs_pda_avg_moisture" text="Humidité moyenne"/>
+<text name="cs_pda_fields_healthy" text="Sains (>=40%)"/>
+<text name="cs_pda_fields_warning" text="Alerte (25-40%)"/>
+<text name="cs_pda_fields_critical" text="Critique (&lt;25%)"/>
+<text name="cs_pda_avg_stress" text="Stress moyen"/>
+<text name="cs_pda_est_yield_loss" text="Perte de rendement estimée"/>
+<text name="cs_pda_irrigated_fields" text="Champs irrigués"/>
+<text name="cs_pda_irrigation_systems" text="Systèmes actifs"/>
+<text name="cs_pda_status_healthy" text="Sain"/>
+<text name="cs_pda_status_warning" text="Alerte"/>
+<text name="cs_pda_status_critical" text="Critique"/>
+<text name="cs_pda_irrigated_yes" text="Oui"/>
+<text name="cs_pda_irrigated_no" text="Non"/>
+<text name="cs_pda_no_fields" text="Aucune donnée de champ pour le moment."/>
+    <!-- ========== SUPERPOSITION CARTE ========== -->
+<text name="cs_map_page_title" text="Humidité des cultures"/>
+<text name="cs_map_sidebar_title" text="LÉGENDE D'HUMIDITÉ"/>
+<text name="cs_map_legend_healthy" text="Sain >=40%"/>
+<text name="cs_map_legend_warning" text="Alerte 25-40%"/>
+<text name="cs_map_legend_critical" text="Critique &lt;25%"/>
+<text name="cs_map_btn_open_pda" text="Ouvrir le PDA des cultures"/>
     
-    <!-- ========== HELP DIALOG ========== -->
-    <text name="cs_help_title"       text="Crop Moisture Monitor -- Help"/>
-    <text name="cs_help_ov_hdr"      text="How It Works"/>
-    <text name="cs_help_ov_1"        text="Tracks soil moisture for every field in the game."/>
-    <text name="cs_help_ov_2"        text="Rainfall raises moisture; heat and time reduce it."/>
-    <text name="cs_help_ov_3"        text="Use the filter button to focus on your own fields."/>
-    <text name="cs_help_status_hdr"  text="Moisture Levels"/>
-    <text name="cs_help_status_1"    text="Healthy  &gt;=40%   No action needed."/>
-    <text name="cs_help_status_2"    text="Warning  25-40%  Irrigate soon."/>
-    <text name="cs_help_status_3"    text="Critical &lt;25%   Irrigate now!"/>
-    <text name="cs_help_stress_hdr"  text="Crop Stress"/>
-    <text name="cs_help_stress_1"    text="Builds each hour moisture stays below 40% during growth."/>
-    <text name="cs_help_stress_2"    text="Up to 60% yield loss at max stress. Cannot be reversed."/>
-    <text name="cs_help_irr_hdr"     text="Irrigation"/>
-    <text name="cs_help_irr_1"       text="Place Center Pivots or Drip Lines from the build menu."/>
-    <text name="cs_help_irr_2"       text="Use Irrigation Schedule to set automatic run windows."/>
-    <text name="cs_help_keys_hdr"    text="Monitor Information"/>
-    <text name="cs_help_keys_1"      text="ESC (Pause Menu) -&gt; Crop Moisture Monitor"/>
-    <text name="cs_help_keys_2"      text="Tab 1 (Overview) -&gt;  Overall field status"/>
-    <text name="cs_help_keys_3"      text="Tab 2 (Irrigation) -&gt;  Irrigation management"/>
-    <!-- ========== PDA SCREEN ========== -->
-    <text name="cs_pda_btn_irrigation"         text="Irrigation Schedule"/>
-    <text name="cs_pda_btn_consultant"         text="Crop Consultant"/>
-    <text name="cs_pda_btn_help"               text="Help"/>
-    <text name="cs_pda_filter_all"             text="ALL FIELDS"/>
-    <text name="cs_pda_filter_owned"           text="MY FIELDS"/>
-    <text name="cs_pda_no_system_msg"          text="No irrigation system is connected to this field. Place a center pivot or drip line to manage irrigation."/>
-    
-    <!-- ========== HELP LINE (sprayer) ========== -->
-    <text name="helpLine_cs_t3_title"          text="Sprayers &amp; Watering"/>
-    <text name="helpLine_cs_t3_sprayer_title"  text="Using Sprayers as Irrigation"/>
-    <text name="helpLine_cs_t3_sprayer_text"   text="Standard vehicle-based sprayers can be used as a manual alternative to permanent irrigation systems. If you fill a sprayer with WATER, any area you spray will receive an immediate moisture boost. This is useful for small fields or as a temporary measure until you can afford a centre pivot or drip line."/>
+    <!-- ========== FENÊTRE D'AIDE ========== -->
+<text name="cs_help_title" text="Moniteur d'humidité des cultures -- Aide"/>
+<text name="cs_help_ov_hdr" text="Fonctionnement"/>
+<text name="cs_help_ov_1" text="Suit l'humidité du sol pour chaque champ du jeu."/>
+<text name="cs_help_ov_2" text="Les précipitations augmentent l'humidité ; la chaleur et le temps la réduisent."/>
+<text name="cs_help_ov_3" text="Utilisez le bouton de filtre pour afficher uniquement vos champs."/>
+<text name="cs_help_status_hdr" text="Niveaux d'humidité"/>
+<text name="cs_help_status_1" text="Sain >=40% Aucun besoin d'action."/>
+<text name="cs_help_status_2" text="Alerte 25-40% Irriguez bientôt."/>
+<text name="cs_help_status_3" text="Critique &lt;25% Irriguez immédiatement !"/>
+<text name="cs_help_stress_hdr" text="Stress des cultures"/>
+<text name="cs_help_stress_1" text="Augmente chaque heure où l'humidité reste sous 40% pendant la croissance."/>
+<text name="cs_help_stress_2" text="Jusqu'à 60% de perte de rendement au stress maximal. Ne peut pas être inversé."/>
+<text name="cs_help_irr_hdr" text="Irrigation"/>
+<text name="cs_help_irr_1" text="Placez des pivots centraux ou des lignes goutte-à-goutte depuis le menu de construction."/>
+<text name="cs_help_irr_2" text="Utilisez le programme d'irrigation pour définir des plages automatiques de fonctionnement."/>
+<text name="cs_help_keys_hdr" text="Informations du moniteur"/>
+<text name="cs_help_keys_1" text="ESC (Menu pause) -> Moniteur d'humidité des cultures"/>
+<text name="cs_help_keys_2" text="Onglet 1 (Vue d'ensemble) -> État général des champs"/>
+<text name="cs_help_keys_3" text="Onglet 2 (Irrigation) -> Gestion de l'irrigation"/>
+    <!-- ========== ÉCRAN PDA ========== -->
+<text name="cs_pda_btn_irrigation" text="Programme d'irrigation"/>
+<text name="cs_pda_btn_consultant" text="Conseiller agricole"/>
+<text name="cs_pda_btn_help" text="Aide"/>
+<text name="cs_pda_filter_all" text="TOUS LES CHAMPS"/>
+<text name="cs_pda_filter_owned" text="MES CHAMPS"/>
+<text name="cs_pda_no_system_msg" text="Aucun système d'irrigation n'est connecté à ce champ. Placez un pivot central ou une ligne goutte-à-goutte pour gérer l'irrigation."/>
+
+<!-- ========== LIGNE D'AIDE (pulvérisateur) ========== -->
+<text name="helpLine_cs_t3_title" text="Pulvérisateurs &amp; arrosage"/>
+<text name="helpLine_cs_t3_sprayer_title" text="Utiliser les pulvérisateurs comme irrigation"/>
+<text name="helpLine_cs_t3_sprayer_text" text="Les pulvérisateurs standards montés sur véhicule peuvent être utilisés comme alternative manuelle aux systèmes d'irrigation permanents. Si vous remplissez un pulvérisateur avec de l'EAU, toute zone pulvérisée recevra immédiatement un gain d'humidité. Cela est utile pour les petits champs ou comme solution temporaire jusqu'à ce que vous puissiez vous offrir un pivot central ou une ligne goutte-à-goutte."/>
     </texts>
 </l10n>


### PR DESCRIPTION
## Summary

Applies a full native French translation for the SeasonalCropStress mod, contributed by community member Seb/Squall39 (via FS25_SoilFertilizer issue #373).

---

## What's Included

### 🌍 French Translation — Full Update

All 250 keys are accounted for. Previously, 71 entries in the PDA screen, map overlay, help dialog, and sprayer help section were in English. This update translates all of them:

**Sections translated:**
- PDA screen — title, tabs, column headers, filter buttons, status labels, overview stats
- Map overlay — page title, sidebar legend, status labels, PDA button
- Help dialog — all how-it-works, moisture levels, crop stress, irrigation, and monitor info entries
- Sprayer help line — sprayer-as-irrigation description

**No keys removed or added** — verified 250 keys in, 250 keys out.

---

## Commits

| Hash | Message |
|------|---------|
| `023ad97` | l18n(fr): apply native French translation from Seb/Squall39 |

---

## Testing Checklist

- [ ] Switch game language to French — PDA screen displays in French
- [ ] Map overlay legend and buttons display in French
- [ ] Help dialog fully in French
- [ ] No missing or broken string keys