### PR TITLE
hotfix: unbound default keybindings v1.2.3.2

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -170,21 +170,11 @@ FUNKTIONER:
     </actions>
 
     <inputBinding>
-        <actionBinding action="CS_TOGGLE_HUD">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_m"/>
-        </actionBinding>
-        <actionBinding action="CS_OPEN_IRRIGATION">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_i"/>
-        </actionBinding>
-        <actionBinding action="CS_OPEN_CONSULTANT">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_c"/>
-        </actionBinding>
-        <actionBinding action="CS_EDIT_HUD">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_h"/>
-        </actionBinding>
-        <actionBinding action="CS_OPEN_SETTINGS">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_s"/>
-        </actionBinding>
+        <actionBinding action="CS_TOGGLE_HUD" />
+        <actionBinding action="CS_OPEN_IRRIGATION" />
+        <actionBinding action="CS_OPEN_CONSULTANT" />
+        <actionBinding action="CS_EDIT_HUD" />
+        <actionBinding action="CS_OPEN_SETTINGS" />
     </inputBinding>
 
     <!--

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.3.1</version>
+    <version>1.2.3.2</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>


### PR DESCRIPTION
## Summary
- Removed all default keybindings (Shift+S, Shift+H, Shift+M, Shift+I, Shift+C)
- Fixes hard-lock caused by Shift+S conflicting with FS25_SoilFertilizer and vanilla sprint-backwards

## ⚠️ ACTION REQUIRED FOR EXISTING PLAYERS
All keybindings are now **unbound by default**.

**To set up your keys:**
1. Launch the game
2. Go to **Settings → Controls → Mods**
3. Find **FS25_SeasonalCropStress** in the list
4. Assign a key to each action you want to use

This is a one-time setup — your bindings are saved automatically.

## Why this change?
Shift+S (the previous default for CS_OPEN_SETTINGS) is the vanilla sprint-backwards combo and conflicted with FS25_SoilFertilizer. Shift+H and Shift+M also conflicted with SoilFertilizer bindings. Shipping unbound eliminates all current and future cross-mod conflicts.

## Save compatibility
✅ No save migration needed.