### PR TITLE
fix: defer buildFieldMap in MP join paths until fields are populated

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,7 @@
 - Baseline date: 2026-06-30
 
 ## Near-term (next release cycle)
+- [x] Witcombe join load-gates (3969c44): buildFieldMap deferred until post-join in MP moisture init event and NetworkSync bridge, preventing empty field map on client join. Pushed 2026-07-28.
 - [x] Strip the Precision Farming overlay: DONE. Removed wholesale in 77b3064; zero PF refs remain in any .lua (verified 2026-07-15).
 - [x] "Remove the FSBaseMission.draw hook": closed as wrong premise - the draw hook drives the real moisture HUD, not a no-op stub. Kept.
 - [x] Companion read API façade on `cropStressManager` (getMoisture / getStress) for CropDisease and RandomWorldEvents (B3.2): DONE (83aef10).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,7 @@
 
 ## Long-term / aspirational
 - [ ] Deeper stress model (crop-specific tolerances, recovery curves) as part of the rebuild with the new assets.
+- [ ] Irrigation help dialog (issue #89): in-game guidance for irrigation setup once Antler22's 3D assets ship. Design decision needed: dedicated help dialog vs existing documentation. See ecosystem ledger 2026-07-26.
 
 ## Cross-mod / ecosystem dependencies
 - [ ] Reads RandomWorldEvents (`randomWorldEvents`); optional FS25_MoistureSystem (external).

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,8 @@
 
 ## Bugs
 - [x] CRITICAL (house rule): PF integration mode active on detection - RESOLVED. No PF code path remains after 77b3064; nothing left to stand down.
+- [x] SCS-001: created overlay handle in `initialize()`, replaced bare `drawFilledRect` calls (fixed, merged to main).
+- [x] SCS-002 / SCS-003: additional SeasonalCropStress bugs fixed in 2026-07-26 bug sweep, merged to main.
 
 ## Features / enhancements
 - [x] Short-month weather tune (e6a4fce): `SEASON_RAIN_PROB` reshaped to match SoilFertilizer's Normal climate shape, so SCS moisture and SF's #740 short-month rain fill agree on wet/dry seasonality. Shape-matched, not a raw copy (a day-vs-hour unit gap remains for a later retune with Arissani).

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,7 @@
 - [x] `getIrrigationCostsEnabled` getter (212ceaa): a nil-safe read of the irrigation-costs-enabled flag, added to the facade for TaxMod's SCS-011 deductible-expense mirror (the first B3.2b consumer, in-game verified).
 
 ## Bugs
+- [x] Witcombe join load-gates: buildFieldMap called before g_fieldManager.fields populated on MP join, producing empty field map. Added field-readiness guards in CropStressMoistureInitEvent:run() and CropStressNetworkSyncBridge._onReadState(). Commit 3969c44, pushed 2026-07-28.
 - [x] CRITICAL (house rule): PF integration mode active on detection - RESOLVED. No PF code path remains after 77b3064; nothing left to stand down.
 - [x] SCS-001: created overlay handle in `initialize()`, replaced bare `drawFilledRect` calls (fixed, merged to main).
 - [x] SCS-002 / SCS-003: additional SeasonalCropStress bugs fixed in 2026-07-26 bug sweep, merged to main.

--- a/src/events/CropStressMoistureInitEvent.lua
+++ b/src/events/CropStressMoistureInitEvent.lua
@@ -97,8 +97,14 @@ function CropStressMoistureInitEvent:run(connection)
         applied = applied + 1
     end
 
-    -- Rebuild fieldById map so the PDA screen can look up field objects
-    mgr:buildFieldMap()
+    -- Rebuild fieldById map so the PDA screen can look up field objects.
+    -- Only do this when fields are ready; on MP join, the field manager may not
+    -- be fully populated yet. The field-ready updater installFieldReadyUpdater()
+    -- handles the initial enumeration and field map build when fields become
+    -- available, so it's safe to skip here.
+    if g_fieldManager ~= nil and g_fieldManager.fields ~= nil then
+        mgr:buildFieldMap()
+    end
 
     csLog(string.format("MP: moisture sync applied for %d fields", applied))
 end

--- a/src/integrations/CropStressNetworkSyncBridge.lua
+++ b/src/integrations/CropStressNetworkSyncBridge.lua
@@ -131,7 +131,11 @@ function CropStressNetworkSyncBridge._onReadState(arr)
         mgr.stressModifier.fieldStress[fieldId] = fieldStress[fieldId] or 0.0
     end
 
-    if mgr.buildFieldMap ~= nil then mgr:buildFieldMap() end
+    -- Rebuild field map only when fields are ready; on MP join the field manager
+    -- may not yet be populated. The field-ready updater handles initial enumeration.
+    if mgr.buildFieldMap ~= nil and g_fieldManager ~= nil and g_fieldManager.fields ~= nil then
+        mgr:buildFieldMap()
+    end
 end
 
 -- =========================================================


### PR DESCRIPTION
Witcombe join-hang lane. Stops SeasonalCropStress building its field map before the field manager has fields.

## What lands

- `CropStressMoistureInitEvent` skips `buildFieldMap` when `g_fieldManager.fields` is not yet populated.
- `CropStressNetworkSyncBridge` does the same on the bridge path.
- ROADMAP and TODO updated (also carries the earlier SCS-001/002/003 bug-sweep reconcile and the irrigation help-dialog design item).

## Why

Both entry points ran `buildFieldMap` during MP join, before fields existed, which did real work for nothing and added load-time thrash on the dedicated server. Third evidence tier on the join hang, cheap to close.

Server and client join paths only. No moisture-model change, no contract change, so the SF compaction / SCS moisture firewall is untouched.