### PR TITLE
chore: bump to 1.2.4.0 for A5 Reinke release

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.3.4</version>
+    <version>1.2.4.0</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>


### PR DESCRIPTION
Bumps version from 1.2.3.4 to 1.2.4.0 for the A5 Reinke pivot release.

Phase 4 verification gate closure for A5 (Reinke pivot fixes at HEAD: rotation-under-SCS, dialog, PDA). The code changes were already merged to main via PR #101, so this carries the version bump only.
