### PR TITLE
feat: wire the release gate; #89 rebuild and moisture coupling rows noted

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,7 @@
 - Baseline date: 2026-06-30
 
 ## Near-term (next release cycle)
+- [x] Release gate (2026-08-04): wired per Arissani's 2026-08-03 lock set. The #89 rebuild and the moisture coupling LOCK when built (both unbuilt today; the two registry rows are noted as such). F93 ships STABLE, it is a fix not a system. `ReleaseGate.lua` + `experimentalSystems` opt-in (default false, orthogonal to difficulty) through settings/persistence/MP sync/SettingsHub/panel + `csRelease` status command. 145 assertions green.
 - [x] F93 temperature fix (2026-08-02): the temperature read was a permanent 15.0. `getTemperatureFromWeather()` probed a nonexistent `weatherSystem` class; it now delegates to WeatherGuard's `getCurrentSky().temperature` first (the certified temperatureUpdater route via the mission bridge), then the certified vanilla `Weather:getCurrentTemperature()`. Heat-driven behaviours were inert while looking healthy; this unblocks them. Covered by `tools/test/lua/weather_temp_f93_test.lua` (8 assertions).
 - [x] Witcombe join load-gates (3969c44): buildFieldMap deferred until post-join in MP moisture init event and NetworkSync bridge, preventing empty field map on client join. Pushed 2026-07-28.
 - [x] Strip the Precision Farming overlay: DONE. Removed wholesale in 77b3064; zero PF refs remain in any .lua (verified 2026-07-15).

--- a/TODO.md
+++ b/TODO.md
@@ -21,6 +21,7 @@
 - [x] SCS-002 / SCS-003: additional SeasonalCropStress bugs fixed in 2026-07-26 bug sweep, merged to main.
 
 ## Features / enhancements
+- [x] Release gate (2026-08-04): `ReleaseGate.lua` with the `cs_89_rebuild` and `moisture_coupling` rows, both noted "not built yet; locks when it lands" (Arissani 2026-08-03). F93 ships stable and is not in the registry. `experimentalSystems` opt-in (default false, orthogonal to difficulty) through `CropStressSettings` defaults/load/save/validate, the MP bulk sync (count 10 to 11), the SettingsHub mirror and a settings-panel row. `csRelease` status command. 23 assertions in release_gate_test.lua.
 - [x] Short-month weather tune (e6a4fce): `SEASON_RAIN_PROB` reshaped to match SoilFertilizer's Normal climate shape, so SCS moisture and SF's #740 short-month rain fill agree on wet/dry seasonality. Shape-matched, not a raw copy (a day-vs-hour unit gap remains for a later retune with Arissani).
 - [x] Bedrock migration per Point 1-4: all four now BUILT. SettingsHub was already live; StateLedger + NetworkSync + MasterHUD (B3.4) were built this session against the SoilFertilizer reference, delegate-when-present. Not shipped until the SCS module-ids are locked with Claude(A) + a single-host in-game smoke passes.
 

--- a/main.lua
+++ b/main.lua
@@ -26,6 +26,7 @@ source(modDir .. "src/CropStressModifier.lua")
 source(modDir .. "src/IrrigationManager.lua")
 
 -- Settings
+source(modDir .. "src/ReleaseGate.lua")
 source(modDir .. "src/settings/CropStressSettings.lua")
 source(modDir .. "src/settings/CropStressSettingsPanel.lua")
 source(modDir .. "src/settings/CropStressSettingsIntegration.lua")
@@ -252,6 +253,7 @@ Mission00.loadMission00Finished = Utils.appendedFunction(Mission00.loadMission00
         addConsoleCommand("csSimulateHeat","Simulate heat wave: csSimulateHeat <days>",                    "consoleSimulateHeat",g_csManager)
         addConsoleCommand("csDebug",       "Toggle verbose debug logging",                                 "consoleToggleDebug", g_csManager)
         addConsoleCommand("csConsultant",  "Open the Crop Consultant dialog",                              "consoleConsultant",  g_csManager)
+        addConsoleCommand("csRelease",     "Release gate: show STABLE vs experimental-LOCKED systems",     "consoleRelease",     g_csManager)
     end
 end)
 
@@ -302,6 +304,7 @@ FSBaseMission.delete = Utils.appendedFunction(FSBaseMission.delete, function(sel
             removeConsoleCommand("csSimulateHeat")
             removeConsoleCommand("csDebug")
             removeConsoleCommand("csConsultant")
+            removeConsoleCommand("csRelease")
         end
     end
 end)

--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -986,6 +986,15 @@ function CropStressManager:consoleStatus()
     end
 end
 
+function CropStressManager:consoleRelease()
+    if not ReleaseGate then
+        print("[CropStress] Release gate not loaded")
+        return
+    end
+    local optIn = self.settings ~= nil and self.settings.experimentalSystems == true or nil
+    print(ReleaseGate.status(optIn))
+end
+
 function CropStressManager:consoleSetMoisture(fieldIdStr, valueStr)
     local fieldId = tonumber(fieldIdStr)
     local value   = tonumber(valueStr)

--- a/src/ReleaseGate.lua
+++ b/src/ReleaseGate.lua
@@ -1,0 +1,123 @@
+-- =========================================================
+-- FS25 Seasonal Crop Stress - Release Gate
+-- =========================================================
+-- The release gate: which systems are released (STABLE) vs experimental (LOCKED).
+--
+-- Orthogonal to difficulty. The gate is its own explicit opt-in (experimental
+-- systems, on at your own risk), independent of difficulty, and the two locks
+-- STACK.
+--
+-- The lock set and the rule that generates it come from Arissani's certification
+-- (2026-08-03, ledger): LOCK the #89 rebuild and the moisture coupling when they
+-- are built (both are gated or unbuilt today, so no live rows yet). F93 the
+-- temperature fix ships STABLE, it is a fix and not a system, so it is not in the
+-- registry. The two rows below are noted as unbuilt so the registry is honest.
+-- =========================================================
+
+-- Local log helper (the mod has no shared logger global).
+local function csLog(msg)
+    if g_logManager ~= nil then
+        g_logManager:devInfo("[CropStress]", msg)
+    else
+        print("[CropStress] " .. tostring(msg))
+    end
+end
+
+ReleaseGate = {}
+
+-- The certified experimental (LOCKED) set. Each entry: [systemId] = { name, status }.
+-- `status` is a SHORT player-facing note on what is not working or implemented yet.
+-- A system that is NOT in this table is released (the proven baseline).
+ReleaseGate.EXPERIMENTAL = {
+    cs_89_rebuild = {
+        name = "Crop stress rebuild (#89)",
+        status = "not built yet; locks when it lands",
+    },
+    moisture_coupling = {
+        name = "Moisture coupling",
+        status = "not built yet; locks when it lands",
+    },
+}
+
+-- Console command -> systemId, so command refusals route through the same registry.
+ReleaseGate.COMMAND_TO_SYSTEM = {}
+
+--- A system is released when it is NOT experimental, or the player has explicitly
+--- opted into experimental systems. `optIn` is the settings.experimentalSystems boolean.
+---@param systemId string
+---@param optIn boolean|nil
+---@return boolean
+function ReleaseGate.isReleased(systemId, optIn)
+    if not ReleaseGate.EXPERIMENTAL[systemId] then return true end
+    return optIn == true
+end
+
+--- The LIVE opt-in: reads the player's current settings.experimentalSystems value
+--- through the manager. Returns nil when the manager/settings are not available yet
+--- (pre-init or the offline test bench); callers decide what nil means.
+---@return boolean|nil
+function ReleaseGate.liveOptIn()
+    local cs = g_cropStressManager
+    if cs and cs.settings and cs.settings.allowsExperimentalSystems then
+        return cs.settings:allowsExperimentalSystems()
+    end
+    return nil
+end
+
+--- A system is LIVE right now: released, or the player has opted in.
+--- FAIL-OPEN: when the live settings cannot be read (nil manager, nil settings, or
+--- a settings object without the predicate - e.g. the offline test bench), the
+--- system counts as live. The gate is an explicit opt-out of NEW systems; it must
+--- never silently disable a path just because the opt-in flag is not readable at
+--- that moment.
+---@param systemId string
+---@return boolean
+function ReleaseGate.isSystemLive(systemId)
+    local optIn = ReleaseGate.liveOptIn()
+    if optIn == nil then return true end
+    return ReleaseGate.isReleased(systemId, optIn)
+end
+
+--- Refusal message when a system is locked; nil when released.
+---@param systemId string
+---@param optIn boolean|nil
+---@return string|nil
+function ReleaseGate.lockMessage(systemId, optIn)
+    local entry = ReleaseGate.EXPERIMENTAL[systemId]
+    if not entry or optIn == true then return nil end
+    return string.format(
+        "Locked: %s is not released yet. Enable Experimental Systems to use it at your own risk.",
+        entry.name)
+end
+
+--- Console command gate. Mirrors the SF bypass-lock pattern but on the release axis.
+---@param commandName string
+---@param optIn boolean|nil
+---@return string|nil
+function ReleaseGate.commandLockMessage(commandName, optIn)
+    return ReleaseGate.lockMessage(ReleaseGate.COMMAND_TO_SYSTEM[commandName], optIn)
+end
+
+--- Player-friendly gate status, for the status/help surfaces and tests.
+---@param optIn boolean|nil
+---@return string
+function ReleaseGate.status(optIn)
+    local lines = { "=== Release gate ===" }
+    lines[#lines + 1] = string.format("  Experimental systems: %s",
+        optIn == true and "ON (at your own risk)" or "OFF (stable only)")
+    local on = optIn == true
+    if on then
+        lines[#lines + 1] = "  All experimental systems: ON"
+        for id, entry in pairs(ReleaseGate.EXPERIMENTAL) do
+            lines[#lines + 1] = string.format("    [ON] %s", entry.name)
+        end
+    else
+        lines[#lines + 1] = "  Not yet released:"
+        for id, entry in pairs(ReleaseGate.EXPERIMENTAL) do
+            lines[#lines + 1] = string.format("    [LOCKED] %s - %s", entry.name, entry.status)
+        end
+    end
+    return table.concat(lines, "\n")
+end
+
+csLog("Release gate loaded")

--- a/src/events/CropStressSettingsSyncEvent.lua
+++ b/src/events/CropStressSettingsSyncEvent.lua
@@ -30,11 +30,11 @@ CropStressSettingsSyncEvent.TYPE_BULK = 2
 
 -- Number of settings written/read in a bulk event.
 -- MUST match the number of writeSetting() calls in writeStream().
--- Intentionally 10 (not 12) — hudPanelX and hudPanelY are client-local
+-- Intentionally 11 (not 12) — hudPanelX and hudPanelY are client-local
 -- display preferences and must NOT be overwritten by a server-pushed sync.
 -- If you add or remove a synced setting, update this constant and the
 -- writeSetting() calls in writeStream() together.
-CropStressSettingsSyncEvent.BULK_COUNT = 10
+CropStressSettingsSyncEvent.BULK_COUNT = 11
 
 -- Value type constants for serialization
 CropStressSettingsSyncEvent.VALUE_TYPE_BOOL = 1
@@ -84,6 +84,7 @@ function CropStressSettingsSyncEvent:writeStream(streamId, connection)
         self:writeSetting(streamId, "alertsEnabled",      settings.alertsEnabled)
         self:writeSetting(streamId, "alertCooldown",      settings.alertCooldown)
         self:writeSetting(streamId, "debugMode",          settings.debugMode)
+        self:writeSetting(streamId, "experimentalSystems", settings.experimentalSystems)
     end
 end
 

--- a/src/settings/CropStressSettings.lua
+++ b/src/settings/CropStressSettings.lua
@@ -34,6 +34,8 @@ local DEFAULTS = {
     alertsEnabled = true,
     alertCooldown = 12,
     debugMode = false,
+    -- Release-gate opt-in (default false), orthogonal to difficulty. See ReleaseGate.lua.
+    experimentalSystems = false,
     hudPanelX = 0.010,   -- matches HUDOverlay.PANEL_X
     hudPanelY = 0.175    -- matches HUDOverlay.PANEL_Y
 }
@@ -156,6 +158,7 @@ function CropStressSettings:load(missionInfo)
     self.alertsEnabled      = readBool(xmlFile, "cropStressSettings.alertsEnabled",      DEFAULTS.alertsEnabled)
     self.alertCooldown      = xmlFile:getInt("cropStressSettings.alertCooldown")         or DEFAULTS.alertCooldown
     self.debugMode          = readBool(xmlFile, "cropStressSettings.debugMode",          DEFAULTS.debugMode)
+    self.experimentalSystems = readBool(xmlFile, "cropStressSettings.experimentalSystems", DEFAULTS.experimentalSystems)
     self.hudPanelX          = xmlFile:getFloat("cropStressSettings.hudPanelX")           or DEFAULTS.hudPanelX
     self.hudPanelY          = xmlFile:getFloat("cropStressSettings.hudPanelY")           or DEFAULTS.hudPanelY
 
@@ -235,6 +238,7 @@ function CropStressSettings:saveToXMLFile(missionInfo)
     xmlFile:setBool("cropStressSettings.alertsEnabled", self.alertsEnabled)
     xmlFile:setInt("cropStressSettings.alertCooldown", self.alertCooldown)
     xmlFile:setBool("cropStressSettings.debugMode", self.debugMode)
+    xmlFile:setBool("cropStressSettings.experimentalSystems", self.experimentalSystems)
     xmlFile:setFloat("cropStressSettings.hudPanelX", self.hudPanelX)
     xmlFile:setFloat("cropStressSettings.hudPanelY", self.hudPanelY)
 
@@ -295,6 +299,14 @@ function CropStressSettings:validateSettings()
     self.irrigationCosts = not not self.irrigationCosts
     self.alertsEnabled = not not self.alertsEnabled
     self.debugMode = not not self.debugMode
+    self.experimentalSystems = not not self.experimentalSystems
+end
+
+--- Release-gate opt-in. True when the player has explicitly enabled experimental
+--- (LOCKED) systems. Orthogonal to difficulty: the two locks stack, see ReleaseGate.lua.
+---@return boolean
+function CropStressSettings:allowsExperimentalSystems()
+    return self.experimentalSystems == true
 end
 
 -- Get stress rate multiplier based on difficulty

--- a/src/settings/CropStressSettingsPanel.lua
+++ b/src/settings/CropStressSettingsPanel.lua
@@ -99,6 +99,7 @@ local CATEGORIES = {
             { header = "HUD",    items = { "hudVisible" } },
             { header = "Alerts", items = { "alertsEnabled", "alertCooldown" } },
             { header = "Debug",  items = { "debugMode" } },
+            { header = "Release Gate", items = { "experimentalSystems" } },
         },
     },
 }
@@ -166,6 +167,11 @@ local SETTINGS_META = {
     debugMode = {
         label = "Debug Mode",
         desc  = "Extra logging to game log for troubleshooting",
+        stype = "bool",
+    },
+    experimentalSystems = {
+        label = "Experimental Systems",
+        desc  = "Enable experimental (not yet released) systems at your own risk",
         stype = "bool",
     },
 }

--- a/src/settings/SettingsHubBridge.lua
+++ b/src/settings/SettingsHubBridge.lua
@@ -45,6 +45,7 @@ function SeasonalSettingsHubBridge.register(mgr)
         { id = "alertsEnabled",      type = "bool",  default = s.alertsEnabled,      adminOnly = false, label = "Stress Alerts" },
         { id = "alertCooldown",      type = "int",   default = s.alertCooldown,      adminOnly = false, min = 4, max = 24, label = "Alert Cooldown (hours)" },
         { id = "debugMode",          type = "bool",  default = s.debugMode,          adminOnly = false, label = "Debug Mode" },
+        { id = "experimentalSystems", type = "bool", default = s.experimentalSystems, adminOnly = true, label = "Experimental Systems" },
     }
 
     local ok, err = pcall(function()

--- a/tools/test/lua/release_gate_test.lua
+++ b/tools/test/lua/release_gate_test.lua
@@ -1,0 +1,53 @@
+-- release_gate_test.lua - the release gate (STABLE vs experimental-LOCKED).
+--
+-- The gate is orthogonal to difficulty and mirrors the bypass lock, but on the
+-- release axis. Arissani's certification (2026-08-03): the #89 rebuild and the
+-- moisture coupling LOCK when built (both unbuilt today, so the rows are noted
+-- as such). F93 the temperature fix ships STABLE, it is a fix and not a system,
+-- so it is NOT in the registry.
+--!load: src/ReleaseGate.lua, src/settings/CropStressSettings.lua
+
+-- Sanity: the two future rows exist and carry the not-built note.
+T.ok("cs_89_rebuild registered", ReleaseGate.EXPERIMENTAL.cs_89_rebuild ~= nil)
+T.ok("moisture_coupling registered", ReleaseGate.EXPERIMENTAL.moisture_coupling ~= nil)
+T.ok("rebuild row notes not built", string.find(ReleaseGate.EXPERIMENTAL.cs_89_rebuild.status, "not built", 1, true) ~= nil)
+T.ok("coupling row notes not built", string.find(ReleaseGate.EXPERIMENTAL.moisture_coupling.status, "not built", 1, true) ~= nil)
+
+-- F93 is a fix, not a system: it is NOT in the registry (ships stable).
+T.ok("F93 not in the experimental registry", ReleaseGate.EXPERIMENTAL.f93_temperature == nil)
+
+-- isReleased: a non-experimental system is always released regardless of opt-in.
+T.ok("stable system released with no opt-in", ReleaseGate.isReleased("yieldCap", nil) == true)
+T.ok("stable system released with opt-in off", ReleaseGate.isReleased("yieldCap", false) == true)
+
+-- isReleased: the future rows are LOCKED until the explicit opt-in.
+T.ok("rebuild LOCKED by default", ReleaseGate.isReleased("cs_89_rebuild", nil) == false)
+T.ok("rebuild LOCKED with opt-in off", ReleaseGate.isReleased("cs_89_rebuild", false) == false)
+T.ok("rebuild released when opt-in on", ReleaseGate.isReleased("cs_89_rebuild", true) == true)
+T.ok("coupling LOCKED by default", ReleaseGate.isReleased("moisture_coupling", nil) == false)
+T.ok("coupling released when opt-in on", ReleaseGate.isReleased("moisture_coupling", true) == true)
+
+-- lockMessage: nil when released, a refusal string when locked.
+T.eq("no lock message for a stable system", ReleaseGate.lockMessage("yieldCap", nil), nil)
+T.eq("no lock message when opted in", ReleaseGate.lockMessage("cs_89_rebuild", true), nil)
+local msg = ReleaseGate.lockMessage("cs_89_rebuild", false)
+T.ok("lock message when locked", msg ~= nil)
+T.ok("message names the not-released state", string.find(msg, "not released", 1, true) ~= nil)
+
+-- status: player-friendly, short, one line per system.
+local st = ReleaseGate.status(false)
+T.ok("status says OFF when not opted in", string.find(st, "OFF", 1, true) ~= nil)
+T.ok("status lists LOCKED systems", string.find(st, "LOCKED", 1, true) ~= nil)
+local stOn = ReleaseGate.status(true)
+T.ok("status says ON when opted in", string.find(stOn, "ON", 1, true) ~= nil)
+
+-- The settings predicate: default false, orthogonal to difficulty.
+local s = CropStressSettings.new()
+T.ok("experimentalSystems defaults off", s:allowsExperimentalSystems() == false)
+s.experimentalSystems = true
+T.ok("experimentalSystems reads on", s:allowsExperimentalSystems() == true)
+s:resetToDefaults()
+T.ok("reset returns the opt-in to off", s:allowsExperimentalSystems() == false)
+
+-- Fail-open: no manager means the gate cannot be read, so a system counts as live.
+T.ok("isSystemLive fails open with no manager", ReleaseGate.isSystemLive("cs_89_rebuild"))


### PR DESCRIPTION
## Release gate wiring (#89 rebuild + moisture coupling rows, both noted unbuilt)

Wires Arissani's certified 2026-08-03 lock set into Seasonal Crop Stress, mirroring the SoilFertilizer reference gate (PR #777).

### The ruling

- The **#89 rebuild** and the **moisture coupling** LOCK when built. Both are gated or unbuilt today, so there are no live rows yet; the two registry rows are noted as not built to keep the registry honest.
- **F93 the temperature fix ships STABLE.** It is a fix, not a system, so it is not in the registry.

### What changed

- **`src/ReleaseGate.lua`** (new): the release gate module with the two future rows (`cs_89_rebuild`, `moisture_coupling`), both noted "not built yet; locks when it lands". Same shape as SF's module: `isReleased`, `isSystemLive` (fail-open), `lockMessage`, `commandLockMessage`, `status`.
- **`experimentalSystems` setting**: default `false`, orthogonal to difficulty. Wired through `CropStressSettings` defaults/load/save/validate, the MP `CropStressSettingsSyncEvent` bulk sync (count 10 to 11), the SettingsHub mirror, and a settings-panel row under a Release Gate header.
- **`csRelease` console command**: prints the gate status.

Nothing is gated today (the two rows are future). Verification: suite 145 assertions / 0 failed across 6 files, syntax clean. Not loaded in a game session.
