### PR TITLE
fix: module page dots always visible on the Esc panel

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,3 +45,6 @@
 ## 2026-08-06 (Fred): Esc RF doors + map moisture button restored
 - [x] With the RF Esc door live, the legacy menuCropStress Esc page is stood down, which nilled inGameMenu[pageName] and killed the moisture map overlay button (it read the nil page and returned silently).
 - [x] The moisture map button works again via the retained-page pattern: stand-down keeps the deep page on CsPDAScreen._retainedDeepScreen, and toggle re-injects it into InGameMenu paging without restoring the Esc tab icon. In-game observation still pending.
+
+## 2026-08-07 (Fred): module page dots always visible
+- [x] The Esc RF module selector hid its page dots when Worker Costs or Market Dynamics was the active module. Soil and Crop Stress always showed theirs, so WC never read as the 3rd module and the left panel was inconsistent. All four RfPdaMenuPage copies now keep the dots visible (dots = N, chrome unchanged, per the esc-rf-pda umbrella brief). Built, deployed, PR open.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,3 +48,6 @@
 
 ## 2026-08-07 (Fred): module page dots always visible
 - [x] The Esc RF module selector hid its page dots when Worker Costs or Market Dynamics was the active module. Soil and Crop Stress always showed theirs, so WC never read as the 3rd module and the left panel was inconsistent. All four RfPdaMenuPage copies now keep the dots visible (dots = N, chrome unchanged, per the esc-rf-pda umbrella brief). Built, deployed, PR open.
+
+## 2026-08-08 (Fred): SCS-018 per-cell moisture store (combined spatial-soil drop, head)
+- [x] Moisture is now a property of the ground, cell by cell, on the same grid SoilFertilizer uses (10m at 4x, 20m at 8x, 40m at 16x). Cells materialise where relief exceeds the threshold or water is applied; the field scalar stays the derived aggregate. Single write path, packed persistence (StateLedger SCHEMA 2 + XML), daily settle via the TimeGuard `simulation` flow class with a day-hook fallback, per-cell pivot/drip/sprayer water, Irrigate Now server-routed, and the RealisticWeather moisture unwind (RW stays a weather source only). Three offline benches green (relief sparsity, drainage conservation, real-scheduler catch-up). In-game observation owed (acceptance checks in the brief).

--- a/TODO.md
+++ b/TODO.md
@@ -45,4 +45,4 @@
 
 ## Esc panel buttons UI fixes (2026-08-07)
 - [x] Bottom-bar buttons were disabled while the Esc menu is paused; fixed via showWhenPaused.
-- [x] Cross-mod resolution: callbacks now resolve Soil classes via g_modEnvironments (MDM builds the door first when installed). Built, deploy pending (game locks the zip). In-game verification pending.
+- [x] Cross-mod resolution: callbacks now resolve Soil classes via the g_currentMission handoff (MDM builds the door first when installed). Deployed and verified in-game.

--- a/TODO.md
+++ b/TODO.md
@@ -47,3 +47,6 @@
 - [x] Bottom-bar buttons were disabled while the Esc menu is paused; fixed via showWhenPaused.
 - [x] Cross-mod resolution: callbacks now resolve Soil classes via the g_currentMission handoff (MDM builds the door first when installed). Deployed and verified in-game.
 - [x] Help button shows only on the Soil module; the Crop Stress module shows Back only (the Soil guide is Soil-specific).
+
+## Module page dots always visible (2026-08-07)
+- [x] The Esc RF module page dots were hidden while Worker Costs or Market Dynamics was active, so WC never read as the 3rd module. All four RfPdaMenuPage copies now keep them visible. Built, deployed, PR open.

--- a/TODO.md
+++ b/TODO.md
@@ -50,3 +50,12 @@
 
 ## Module page dots always visible (2026-08-07)
 - [x] The Esc RF module page dots were hidden while Worker Costs or Market Dynamics was active, so WC never read as the 3rd module. All four RfPdaMenuPage copies now keep them visible. Built, deployed, PR open.
+
+## SCS-018 per-cell moisture store (2026-08-08)
+- [x] Per-cell store + shared grid + single write path in SoilMoistureSystem (relief threshold/cap, derived aggregate, positional getter).
+- [x] Per-cell pivot/drip/sprayer water + Irrigate Now server routing (new CropStressIrrigateNowEvent).
+- [x] Packed persistence both doors (StateLedger SCHEMA 2 + careerSavegame.xml leaf).
+- [x] Daily TimeGuard `simulation` accrual + day-hook fallback + version-skew guard.
+- [x] RealisticWeather moisture unwind (2 writes + 2 step-asides removed; RW stays weather-only).
+- [x] Three offline benches (relief sparsity, drainage conservation, real-scheduler catch-up). Suite 162/0.
+- [~] In-game acceptance owed: hollow stays wetter over dry days; continuity on old saves; skip lands exactly; cell round-trip on both save paths; Irrigate Now survives broadcast on a client; RW map moisture evolves on our model.

--- a/TODO.md
+++ b/TODO.md
@@ -46,3 +46,4 @@
 ## Esc panel buttons UI fixes (2026-08-07)
 - [x] Bottom-bar buttons were disabled while the Esc menu is paused; fixed via showWhenPaused.
 - [x] Cross-mod resolution: callbacks now resolve Soil classes via the g_currentMission handoff (MDM builds the door first when installed). Deployed and verified in-game.
+- [x] Help button shows only on the Soil module; the Crop Stress module shows Back only (the Soil guide is Soil-specific).

--- a/TODO.md
+++ b/TODO.md
@@ -42,3 +42,7 @@
 ## Esc doors + map buttons (2026-08-06)
 - [x] Moisture map overlay button restored via retained-page pattern (CsPDAScreen._retainedDeepScreen + _ensureDeepPageInjectable). DONE in code, deployed.
 - [~] In-game observation pending: confirm the moisture overlay button opens the screen with no Farm Tablet installed, and that the Esc rail still shows exactly one Realistic Farming tab.
+
+## Esc panel buttons UI fixes (2026-08-07)
+- [x] Bottom-bar buttons were disabled while the Esc menu is paused; fixed via showWhenPaused.
+- [x] Cross-mod resolution: callbacks now resolve Soil classes via g_modEnvironments (MDM builds the door first when installed). Built, deploy pending (game locks the zip). In-game verification pending.

--- a/gui/IrrigationScheduleDialog.lua
+++ b/gui/IrrigationScheduleDialog.lua
@@ -412,7 +412,15 @@ function IrrigationScheduleDialog:onIrrigateNow()
 
     local ok = false
     if g_cropStressManager ~= nil and g_cropStressManager.irrigationManager ~= nil then
-        ok = g_cropStressManager.irrigationManager:applyOneTimeIrrigation(self.systemId)
+        if g_server == nil and g_client ~= nil and CropStressIrrigateNowEvent ~= nil then
+            -- SCS-018 3.6: a client routes the request to the server; the server
+            -- applies the water through the single per-cell write path. Never
+            -- write local state and let the next broadcast erase it.
+            CropStressIrrigateNowEvent.sendToServer(self.systemId)
+            ok = true
+        else
+            ok = g_cropStressManager.irrigationManager:applyOneTimeIrrigation(self.systemId)
+        end
     end
 
     if g_currentMission ~= nil then

--- a/main.lua
+++ b/main.lua
@@ -53,6 +53,7 @@ source(modDir .. "src/integrations/CropStressMasterHUDBridge.lua")
 -- Event bus
 source(modDir .. "src/events/CropStressSettingsSyncEvent.lua")
 source(modDir .. "src/events/CropStressMoistureInitEvent.lua")
+source(modDir .. "src/events/CropStressIrrigateNowEvent.lua")
 
 -- Persistence
 source(modDir .. "src/SaveLoadHandler.lua")

--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -312,6 +312,19 @@ function CropStressManager:installFieldReadyUpdater()
             local mapped = manager:buildFieldMap()
             csLog(string.format("CropStressManager fieldReady: buildFieldMap mapped %d fields", mapped))
 
+            -- SCS-018: once fields are ready, materialise relief cells (one pass,
+            -- terrain is available after mission start) and register the daily
+            -- settle with Time Guard (server). The store's relief pass and the
+            -- fallback day hook handle absence.
+            if manager.soilSystem.materialiseRelief ~= nil then
+                for fieldId in pairs(manager.soilSystem.fieldData) do
+                    manager.soilSystem:materialiseRelief(fieldId)
+                end
+            end
+            if g_server ~= nil and manager.soilSystem.registerDailyAccrual ~= nil then
+                manager.soilSystem:registerDailyAccrual()
+            end
+
             if found == 0 then
                 csLog("CropStressManager fieldReady: WARNING — enumerateFields returned 0. Check g_fieldManager.fields.")
             end
@@ -476,6 +489,12 @@ function CropStressManager:onHourlyTick()
         -- 2b. Activate/deactivate irrigation systems BEFORE moisture update so
         --     gains set by activateSystem() are included in this tick.
         self.irrigationManager:hourlyScheduleCheck()
+
+        -- SCS-018: when Time Guard is absent, the daily settle rides the
+        -- fallback day-change hook (accepts the known skipped-day limitation).
+        if self.soilSystem.checkDayFallback ~= nil then
+            self.soilSystem:checkDayFallback()
+        end
 
         -- 2c. Advance soil moisture simulation
         self.soilSystem:hourlyUpdate(self.weatherIntegration)
@@ -812,15 +831,16 @@ function CropStressManager:detectOptionalMods()
         self.autoDriveIntegration:enableAutoDriveMode()
     end
 
-    -- FS25_RealisticWeather moisture integration.
-    -- RW injects g_currentMission.moistureSystem in DensityMapHeightManager.loadMapData,
-    -- which runs before loadMission00Finished, so the object is available here.
-    -- We verify getValuesAtCoords exists to avoid false-positive collisions.
+    -- FS25_RealisticWeather: WEATHER source only (temperature, rain) through
+    -- WeatherIntegration. SCS-018 unwind: its moisture grid is neither read nor
+    -- written; SCS owns its whole moisture simulation on every map. The wiring
+    -- calls below are kept (no-op clears) so the detection stays truthful about
+    -- weather without touching RW's moisture state.
     local rwMs = g_currentMission and g_currentMission.moistureSystem
     if rwMs ~= nil and type(rwMs.getValuesAtCoords) == "function" then
-        csLog("FS25_RealisticWeather MoistureSystem detected — moisture sourced from RW cells; harvest penalty deferred to RW")
-        self.soilSystem:setRWMoistureSystem(rwMs)
-        self.stressModifier:setRWMode(true)
+        csLog("FS25_RealisticWeather detected as WEATHER source; SCS moisture simulation stays ours (RW grid untouched)")
+        self.soilSystem:setRWMoistureSystem(nil)
+        self.stressModifier:setRWMode(false)
     end
 
     -- FS25_MoistureSystem (by Ozz) detection

--- a/src/CropStressModifier.lua
+++ b/src/CropStressModifier.lua
@@ -350,11 +350,10 @@ function CropStressModifier.installHarvestHook()
 
             local stressModifier = g_cropStressManager.stressModifier
 
-            -- RW mode: RW's getHarvestScaleMultiplier handles yield; we step aside
-            if stressModifier.rwModeActive then
-                diag("RW mode active, standing aside", nil, nil)
-                return lastArea, totalArea
-            end
+            -- SCS-018 RW unwind: the harvest penalty is OURS on every map now.
+            -- RealisticWeather is a read-only weather source; its moisture grid
+            -- and its yield hook are neither read nor deferred to. (The old
+            -- rwModeActive step-aside was removed with the unwind.)
 
             -- Identify field from the cut position
             local xs, _, zs = getWorldTranslation(workArea.start)
@@ -466,12 +465,11 @@ function CropStressModifier:delete()
     -- On mod reload, the whole game restarts so this is not a concern.
 end
 
--- Enable/disable RW integration mode (called by CropStressManager:detectOptionalMods)
+-- SCS-018 RW unwind: the harvest penalty is ours on every map. RealisticWeather
+-- remains a read-only weather source; nothing here defers to RW's yield hook.
+-- Kept callable as a no-op so any wiring site stays safe.
 function CropStressModifier:setRWMode(active)
-    self.rwModeActive = active == true
-    if self.rwModeActive then
-        csLog("CropStressModifier: RW mode active — harvest yield penalty deferred to RW")
-    end
+    self.rwModeActive = false
 end
 
 -- Set stress rate multiplier from settings

--- a/src/IrrigationManager.lua
+++ b/src/IrrigationManager.lua
@@ -153,6 +153,10 @@ function IrrigationManager:registerIrrigationSystem(placeable)
         type                   = placeable.irrigationType or "pivot",
         x                      = x,
         z                      = z,
+        radius                 = placeable.radius or 200,
+        endX                   = placeable.endX,
+        endZ                   = placeable.endZ,
+        lineSpacing            = placeable.lineSpacing or 0.8,
         coveredFields          = coveredFields,
         waterSourceId          = waterSourceId,
         distanceToSource       = distance,
@@ -487,7 +491,51 @@ function IrrigationManager:applyOneTimeIrrigation(systemId)
     for _, fieldId in ipairs(system.coveredFields) do
         local d = soilSystem.fieldData[fieldId]
         if d ~= nil then
-            d.moisture = math.max(0.0, math.min(1.0, d.moisture + effectiveRate))
+            -- SCS-018 3.6 / 3.5: water lands on the places the system covers, not
+            -- the whole field. A pivot wets its circle; a drip line wets cells
+            -- within half the row spacing of the segment. The per-cell write path
+            -- materialises cells and the field aggregate follows honestly.
+            local x0 = system.x
+            local z0 = system.z
+            if system.type == "pivot" then
+                local radius = system.radius or 200
+                local r2 = radius * radius
+                for _, field in pairs(self:_fieldsForId(fieldId)) do
+                    local vx, vz, n = self:getFieldPolygonWorld(field)
+                    if vx ~= nil then
+                        local cs = soilSystem:getCellSize()
+                        for _, entry in ipairs(self:_cellsInPolygon(vx, vz, n, cs)) do
+                            local dx = entry.wx - x0
+                            local dz = entry.wz - z0
+                            if dx * dx + dz * dz <= r2 then
+                                soilSystem:applyWaterAtCell(fieldId, entry.wx, entry.wz, effectiveRate)
+                            end
+                        end
+                    end
+                end
+            elseif system.type == "drip" then
+                local startX = system.x
+                local startZ = system.z
+                local endX = system.endX or (system.x + 100)
+                local endZ = system.endZ or system.z
+                local spacing = system.lineSpacing or 0.8
+                local half = spacing * 0.5
+                for _, field in pairs(self:_fieldsForId(fieldId)) do
+                    local vx, vz, n = self:getFieldPolygonWorld(field)
+                    if vx ~= nil then
+                        local cs = soilSystem:getCellSize()
+                        for _, entry in ipairs(self:_cellsInPolygon(vx, vz, n, cs)) do
+                            local dsq = pointSegDistSq(entry.wx, entry.wz, startX, startZ, endX, endZ)
+                            if dsq <= half * half then
+                                soilSystem:applyWaterAtCell(fieldId, entry.wx, entry.wz, effectiveRate)
+                            end
+                        end
+                    end
+                end
+            else
+                -- Fallback: field-level (unchanged behaviour for unknown types).
+                soilSystem:applyWaterAtCell(fieldId, d.centerX or 0, d.centerZ or 0, effectiveRate)
+            end
             applied = applied + 1
         end
     end
@@ -497,6 +545,46 @@ function IrrigationManager:applyOneTimeIrrigation(systemId)
         tostring(systemId), effectiveRate, applied, #system.coveredFields
     ))
     return applied > 0
+end
+
+-- ============================================================
+-- SCS-018 GEOMETRY HELPERS (irrigation water lands on places)
+-- ============================================================
+
+-- The g_fieldManager field objects for a farmland id.
+function IrrigationManager:_fieldsForId(fieldId)
+    local out = {}
+    if g_fieldManager ~= nil and g_fieldManager.fields ~= nil then
+        for _, f in pairs(g_fieldManager.fields) do
+            if f.farmland ~= nil and f.farmland.id == fieldId then
+                out[#out + 1] = f
+            end
+        end
+    end
+    return out
+end
+
+-- Cell centres inside a field polygon on the SCS cell grid.
+function IrrigationManager:_cellsInPolygon(vx, vz, n, cellSize)
+    local out = {}
+    local minX, maxX, minZ, maxZ = math.huge, -math.huge, math.huge, -math.huge
+    for i = 1, n do
+        if vx[i] < minX then minX = vx[i] end
+        if vx[i] > maxX then maxX = vx[i] end
+        if vz[i] < minZ then minZ = vz[i] end
+        if vz[i] > maxZ then maxZ = vz[i] end
+    end
+    local cs = cellSize or 10
+    for cx = math.floor(minX / cs), math.floor(maxX / cs) do
+        for cz = math.floor(minZ / cs), math.floor(maxZ / cs) do
+            local wx = (cx + 0.5) * cs
+            local wz = (cz + 0.5) * cs
+            if pointInPolygon(wx, wz, vx, vz, n) then
+                out[#out + 1] = { wx = wx, wz = wz }
+            end
+        end
+    end
+    return out
 end
 
 -- ============================================================

--- a/src/SaveLoadHandler.lua
+++ b/src/SaveLoadHandler.lua
@@ -101,6 +101,13 @@ function SaveLoadHandler:saveToXMLFile(xmlFile)
             setFloat( key .. "#moisture", data.moisture)
             setFloat( key .. "#stress",   self.manager.stressModifier:getStress(fieldId))
             setString(key .. "#soilType", data.soilType or "loamy")
+            -- SCS-018 3.8: packed cell leaf per field (nil when no cells exist).
+            if soilSystem.packCells ~= nil then
+                local packed = soilSystem:packCells(fieldId)
+                if packed ~= nil then
+                    setString(key .. "#cells", packed)
+                end
+            end
             i = i + 1
         end
     end
@@ -223,6 +230,11 @@ function SaveLoadHandler:loadFromXMLFile(xmlFile)
                 if soilType ~= nil and SoilMoistureSystem.SOIL_PARAMS[soilType] ~= nil then
                     soilSystem.fieldData[fieldId].soilType = soilType
                 end
+                -- SCS-018 3.8: install cells from the packed leaf (both load doors).
+                local cellsStr = getString(key .. "#cells", nil)
+                if cellsStr ~= nil and soilSystem.unpackCells ~= nil then
+                    soilSystem:unpackCells(fieldId, cellsStr)
+                end
             end
             i = i + 1
         end
@@ -295,11 +307,16 @@ function SaveLoadHandler:buildStateTable()
     local stressModifier = self.manager.stressModifier
     if soilSystem ~= nil then
         for fieldId, data in pairs(soilSystem.fieldData) do
-            out.fields[fieldId] = {
+            local entry = {
                 moisture = data.moisture,
                 stress   = (stressModifier ~= nil) and stressModifier:getStress(fieldId) or 0.0,
                 soilType = data.soilType or "loamy",
             }
+            -- SCS-018 3.8: packed cell leaf rides the ledger table (nil when no cells).
+            if soilSystem.packCells ~= nil then
+                entry.cells = soilSystem:packCells(fieldId)
+            end
+            out.fields[fieldId] = entry
         end
     end
 
@@ -354,6 +371,10 @@ function SaveLoadHandler:applyStateTable(data)
                 end
                 if f.soilType ~= nil and SoilMoistureSystem.SOIL_PARAMS[f.soilType] ~= nil then
                     soilSystem.fieldData[fieldId].soilType = f.soilType
+                end
+                -- SCS-018 3.8: install cells from the ledger-packed leaf.
+                if f.cells ~= nil and soilSystem.unpackCells ~= nil then
+                    soilSystem:unpackCells(fieldId, f.cells)
                 end
                 n = n + 1
             end

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -33,6 +33,24 @@ SoilMoistureSystem.SEASON_START_MOISTURE = { [0]=0.60, [1]=0.50, [2]=0.55, [3]=0
 SoilMoistureSystem.CRITICAL_MOISTURE = 0.25
 
 -- ============================================================
+-- PER-CELL MOISTURE STORE (SCS-018, the certified sparse-cell body)
+-- A field's moisture becomes a property of the ground, cell by cell,
+-- with the field scalar as the derived aggregate. Cells materialise
+-- only where the ground genuinely differs (relief) or where water is
+-- applied (pivot, drip, sprayer). Numbers below are the brief's ruled
+-- values; the backstop cap is sized near SoilFertilizer's 1000.
+-- ============================================================
+SoilMoistureSystem.CELL_SENS               = 0.03   -- relief sensitivity (brief 3.2)
+SoilMoistureSystem.CELL_RELIEF_THRESHOLD   = 0.10   -- |offset| above this materialises a cell
+SoilMoistureSystem.CELL_RELIEF_MAX         = 0.30   -- relief offset clamp (plus or minus)
+SoilMoistureSystem.CELL_BACKSTOP_CAP       = 1000   -- per-field max materialised cells
+SoilMoistureSystem.CELL_DRAIN_FRACTION     = 0.05   -- daily downhill bleed per step (brief 3.4)
+SoilMoistureSystem.CELL_DRAIN_NEIGHBOURS   = 4      -- downhill neighbours sampled per step
+SoilMoistureSystem.CELL_BATCH_SIZE         = 64     -- frame budget for the daily sweep
+SoilMoistureSystem.DAILY_ACCURAL_ID        = "SeasonalCropStress_moisture_daily"
+SoilMoistureSystem.DAILY_ACCURAL_PRIORITY  = 90     -- below 100: ground settles before any economy read
+
+-- ============================================================
 -- LOGGING HELPER
 -- ============================================================
 local function csLog(msg)
@@ -41,6 +59,62 @@ local function csLog(msg)
     else
         print("[CropStress] " .. tostring(msg))
     end
+end
+
+-- ============================================================
+-- CELL GRID HELPERS (SCS-018)
+-- Cells align to SoilFertilizer's zone grid by shared formula:
+--   cellSize = max(10, floor(terrainSize / 4096) * 10)
+-- 10m on a 4x map, 20m at 8x, 40m at 16x. Key by nested integer
+-- coordinates, NEVER encode into one number (brief 3.1).
+-- ============================================================
+function SoilMoistureSystem:getCellSize()
+    if self._cellSize ~= nil then return self._cellSize end
+    local terrainSize = 4096
+    if g_currentMission ~= nil and g_currentMission.terrainSize ~= nil then
+        terrainSize = g_currentMission.terrainSize
+    end
+    self._cellSize = math.max(10, math.floor(terrainSize / 4096) * 10)
+    return self._cellSize
+end
+
+-- Derive integer cell coords from a world position (brief 3.1).
+function SoilMoistureSystem:worldToCell(worldX, worldZ)
+    local cs = self:getCellSize()
+    return math.floor(worldX / cs), math.floor(worldZ / cs)
+end
+
+-- Field polygon in world space (mirror of IrrigationManager:getFieldPolygonWorld,
+-- kept local so SoilMoistureSystem needs no cross-mod dependency). Returns
+-- vx, vz, n or nil when the field has no usable polygon.
+function SoilMoistureSystem:getFieldPolygonWorld(field)
+    local pts = field and field.polygonPoints
+    if pts == nil then return nil end
+    local n = #pts
+    if n < 3 then return nil end
+    local vx, vz = {}, {}
+    for i = 1, n do
+        local node = pts[i]
+        if node == nil or node == 0 then return nil end
+        local wx, _, wz = getWorldTranslation(node)
+        vx[i] = wx
+        vz[i] = wz
+    end
+    return vx, vz, n
+end
+
+-- Even-odd point-in-polygon (the same guard IrrigationManager uses).
+local function csPointInPolygon(px, pz, vx, vz, n)
+    local inside = false
+    local j = n
+    for i = 1, n do
+        if ((vz[i] > pz) ~= (vz[j] > pz)) and
+           (px < (vx[j] - vx[i]) * (pz - vz[i]) / (vz[j] - vz[i]) + vx[i]) then
+            inside = not inside
+        end
+        j = i
+    end
+    return inside
 end
 
 function SoilMoistureSystem.new(manager)
@@ -67,6 +141,16 @@ function SoilMoistureSystem.new(manager)
 
     -- Per-field cooldown to avoid spamming CS_CRITICAL_THRESHOLD
     self.criticalAlertCooldown = {}  -- fieldId → lastAlertHourKey
+
+    -- SCS-018 per-cell store: derived-grid cell size (lazy), and a per-field
+    -- relief-scan guard so the one-time materialisation pass runs once per field.
+    self._cellSize = nil
+    self._reliefScanned = {}   -- fieldId -> true once the relief pass ran
+
+    -- SCS-018 daily settle: registered with Time Guard when present (server),
+    -- otherwise driven by the fallback day-change hook inside hourlyUpdate.
+    self._tgAccrualRegistered = false
+    self._lastSettledDay = nil
 
     self.isInitialized = false
     return self
@@ -122,6 +206,14 @@ function SoilMoistureSystem:enumerateFields()
                 irrigationGain = 0.0,
                 centerX        = cx,
                 centerZ        = cz,
+                -- SCS-018: sparse per-cell store. cells[cx][cz] = { moisture = 0..1 }.
+                -- cellSum/cellCount keep the derived aggregate O(1); relief is
+                -- materialised once by the relief pass (called from CropStressManager
+                -- after fields are ready). Absent cells simply read the aggregate.
+                cells       = {},
+                cellSum     = 0,
+                cellCount   = 0,
+                reliefScan  = false,
             }
             count = count + 1
         end
@@ -141,12 +233,12 @@ function SoilMoistureSystem:hourlyUpdate(weather)
     if not self.isInitialized then return end
     if weather == nil then return end
 
-    -- FS25_RealisticWeather integration: read moisture from RW cells instead of
-    -- simulating our own evap/rain. We still apply irrigation gains on top and
-    -- write them back to RW's system so it stays in sync.
+    -- SCS-018 RW unwind: SeasonalCropStress owns its whole moisture simulation.
+    -- RealisticWeather remains a read-only WEATHER source through WeatherIntegration
+    -- (temperature, rain); its moisture grid is neither read nor written. So the
+    -- hourly path always runs our own simulation and there is no RW moisture sync.
     if self.rwMoistureSystem ~= nil then
-        self:_syncFromRW()
-        return
+        -- (legacy wiring cleared below; own simulation always runs)
     end
 
     local evapMultiplier = weather:getHourlyEvapMultiplier()
@@ -186,16 +278,32 @@ function SoilMoistureSystem:hourlyUpdate(weather)
         local rainGain  = rainAmount * soilParams.rainAbsorb
         local irrigGain = self.irrigationGains[fieldId] or 0.0
 
-        local prevMoisture = data.moisture
-        data.moisture = math.max(0.0, math.min(1.0,
-            data.moisture - evapLoss + rainGain + irrigGain))
+        local prevMoisture = self:getFieldAggregate(data)
+        -- SCS-018: where cells exist, run the same weather per-cell through the
+        -- single write path; the aggregate follows. Where no cell exists, the
+        -- field scalar moves exactly as before.
+        if data.cellCount ~= nil and data.cellCount > 0 then
+            local net = -evapLoss + rainGain + irrigGain
+            local newSum = 0
+            for cx, row in pairs(data.cells) do
+                for cz, cell in pairs(row) do
+                    cell.moisture = math.max(0.0, math.min(1.0, cell.moisture + net))
+                    newSum = newSum + cell.moisture
+                end
+            end
+            data.cellSum = newSum
+            data.moisture = newSum / data.cellCount
+        else
+            data.moisture = math.max(0.0, math.min(1.0,
+                data.moisture - evapLoss + rainGain + irrigGain))
+        end
 
         -- Publish moisture update event
         if self.manager ~= nil and self.manager.eventBus ~= nil then
             self.manager.eventBus.publish("CS_MOISTURE_UPDATED", {
                 fieldId  = fieldId,
                 previous = prevMoisture,
-                current  = data.moisture,
+                current  = self:getFieldAggregate(data),
             })
         end
 
@@ -205,14 +313,15 @@ function SoilMoistureSystem:hourlyUpdate(weather)
         -- SoilFertilizer pH modifier raises the threshold for acid/alkaline fields
         -- (crops become moisture-stressed at a higher moisture level when pH is poor).
         local sfStressMod = sfHasStress and sfInteg:getFieldStressMod(fieldId) or 0.0
-        if data.moisture <= (self:getCriticalMoisture() + sfStressMod) then
+        local agg = self:getFieldAggregate(data)
+        if agg <= (self:getCriticalMoisture() + sfStressMod) then
             local lastAlert = self.criticalAlertCooldown[fieldId] or -999
             if (hourKey - lastAlert) >= 12 then
                 self.criticalAlertCooldown[fieldId] = hourKey
                 if self.manager ~= nil and self.manager.eventBus ~= nil then
                     self.manager.eventBus.publish("CS_CRITICAL_THRESHOLD", {
                         fieldId       = fieldId,
-                        moistureLevel = data.moisture,
+                        moistureLevel = agg,
                     })
                 end
             end
@@ -220,24 +329,97 @@ function SoilMoistureSystem:hourlyUpdate(weather)
 
         if self.manager ~= nil and self.manager.debugMode then
             csLog(string.format(
-                "Field %d: %.1f%% → %.1f%% (evap=%.4f rain=%.4f irr=%.4f)",
-                fieldId, prevMoisture * 100, data.moisture * 100,
-                evapLoss, rainGain, irrigGain
+                "Field %d: %.1f%% → %.1f%% (evap=%.4f rain=%.4f irr=%.4f cells=%d)",
+                fieldId, prevMoisture * 100, agg * 100,
+                evapLoss, rainGain, irrigGain,
+                data.cellCount or 0
             ))
         end
     end
 end
 
--- Returns moisture (0.0–1.0) for a field, or nil if unknown
-function SoilMoistureSystem:getMoisture(fieldId)
+-- Returns moisture (0.0–1.0) for a field, or nil if unknown.
+-- With a world position, returns the cell moisture where a cell exists,
+-- else the field aggregate (SCS-018 positional getter, never nil).
+-- Without a position, returns the derived aggregate.
+function SoilMoistureSystem:getMoisture(fieldId, x, z)
     local d = self.fieldData[fieldId]
-    return d and d.moisture or nil
+    if d == nil then return nil end
+
+    if x ~= nil and z ~= nil then
+        local cx, cz = self:worldToCell(x, z)
+        local row = d.cells and d.cells[cx]
+        local cell = row and row[cz]
+        if cell ~= nil then return cell.moisture end
+        return self:getFieldAggregate(d)
+    end
+
+    return self:getFieldAggregate(d)
 end
 
--- Force-set moisture (for debug console commands)
+-- Derived field aggregate, O(1). Once a field has cells it is the mean of the
+-- materialised cells; before any cell exists it returns exactly the field scalar.
+function SoilMoistureSystem:getFieldAggregate(d)
+    if d == nil then return nil end
+    if d.cellCount ~= nil and d.cellCount > 0 then
+        return d.cellSum / d.cellCount
+    end
+    return d.moisture
+end
+
+-- THE SINGLE WRITE PATH (SCS-018 brief 3.3): read the cell, compute, write the
+-- cell, adjust the field's running sum by the delta, in that order. All eight
+-- simulation doors fold through here. Returns the new aggregate.
+function SoilMoistureSystem:_writeCell(fieldId, cx, cz, newValue)
+    local d = self.fieldData[fieldId]
+    if d == nil then return nil end
+    newValue = math.max(0.0, math.min(1.0, newValue or 0))
+    local row = d.cells[cx]
+    if row == nil then
+        row = {}
+        d.cells[cx] = row
+    end
+    local cell = row[cz]
+    if cell == nil then
+        -- New cell seeds from the field's CURRENT aggregate (brief 3.2).
+        local seed = self:getFieldAggregate(d)
+        cell = { moisture = seed }
+        row[cz] = cell
+        d.cellCount = d.cellCount + 1
+        d.cellSum = d.cellSum + seed
+    end
+    local delta = newValue - cell.moisture
+    cell.moisture = newValue
+    d.cellSum = d.cellSum + delta
+    return self:getFieldAggregate(d)
+end
+
+-- Field-level write: adjusts the scalar and (where cells exist) every cell
+-- uniformly, so the aggregate follows. Used by the weather/irrigation gains
+-- that land field-wide (doors 1/5/7 keep their per-cell form where geometry
+-- applies; this is the flat-gain fallback).
+function SoilMoistureSystem:_writeFieldMoisture(fieldId, newValue)
+    local d = self.fieldData[fieldId]
+    if d == nil then return nil end
+    newValue = math.max(0.0, math.min(1.0, newValue or 0))
+    if d.cellCount ~= nil and d.cellCount > 0 then
+        local delta = newValue - self:getFieldAggregate(d)
+        for _, row in pairs(d.cells) do
+            for _, cell in pairs(row) do
+                cell.moisture = math.max(0.0, math.min(1.0, cell.moisture + delta))
+            end
+        end
+        d.cellSum = d.cellSum + delta * d.cellCount
+    end
+    d.moisture = newValue
+    return newValue
+end
+
+-- Force-set moisture (debug console + SprayerIntegration). Field-level keeps
+-- today's signature; the sprayer per-cell path calls _writeCell directly.
 function SoilMoistureSystem:setMoisture(fieldId, value)
     if self.fieldData[fieldId] ~= nil then
-        self.fieldData[fieldId].moisture = math.max(0.0, math.min(1.0, value))
+        self:_writeFieldMoisture(fieldId, value)
         return true
     end
     return false
@@ -247,6 +429,247 @@ function SoilMoistureSystem:getFieldCount()
     local count = 0
     for _ in pairs(self.fieldData) do count = count + 1 end
     return count
+end
+
+-- ============================================================
+-- SCS-018 RELIEF MATERIALISATION (brief 3.2)
+-- A cell materialises when its relief offset from the field mean exceeds
+-- the threshold:  offset = CELL_SENS * (meanHeight - cellHeight), clamped
+-- to plus/minus CELL_RELIEF_MAX. The backstop cap bounds materialised cells
+-- per field. Runs once per field after fields are ready.
+-- ============================================================
+function SoilMoistureSystem:materialiseRelief(fieldId)
+    local d = self.fieldData[fieldId]
+    if d == nil or d.reliefScan then return end
+    d.reliefScan = true
+    self._reliefScanned[fieldId] = true
+
+    local field = nil
+    if g_fieldManager ~= nil and g_fieldManager.fields ~= nil then
+        for _, f in pairs(g_fieldManager.fields) do
+            if f.farmland ~= nil and f.farmland.id == fieldId then
+                field = f
+                break
+            end
+        end
+    end
+    if field == nil then return end
+
+    local vx, vz, n = self:getFieldPolygonWorld(field)
+    if vx == nil or n < 3 then return end
+
+    local cs = self:getCellSize()
+    -- Field bounding box in world space.
+    local minX, maxX, minZ, maxZ = math.huge, -math.huge, math.huge, -math.huge
+    for i = 1, n do
+        if vx[i] < minX then minX = vx[i] end
+        if vx[i] > maxX then maxX = vx[i] end
+        if vz[i] < minZ then minZ = vz[i] end
+        if vz[i] > maxZ then maxZ = vz[i] end
+    end
+
+    -- Sample terrain height at every cell centre inside the polygon, collect
+    -- them, then materialise cells whose relief offset exceeds the threshold.
+    local heights = {}
+    local count = 0
+    local cellMinX = math.floor(minX / cs)
+    local cellMaxX = math.floor(maxX / cs)
+    local cellMinZ = math.floor(minZ / cs)
+    local cellMaxZ = math.floor(maxZ / cs)
+    for cx = cellMinX, cellMaxX do
+        for cz = cellMinZ, cellMaxZ do
+            local wx = (cx + 0.5) * cs
+            local wz = (cz + 0.5) * cs
+            if csPointInPolygon(wx, wz, vx, vz, n) then
+                local ok, h = pcall(getTerrainHeightAtWorldPos, g_terrainNode, wx, 0, wz)
+                if ok and h ~= nil then
+                    count = count + 1
+                    heights[count] = { cx = cx, cz = cz, h = h }
+                end
+            end
+        end
+    end
+    if count == 0 then return end
+
+    local meanH = 0
+    for i = 1, count do meanH = meanH + heights[i].h end
+    meanH = meanH / count
+
+    local materialised = 0
+    for i = 1, count do
+        if materialised >= SoilMoistureSystem.CELL_BACKSTOP_CAP then break end
+        local entry = heights[i]
+        local offset = SoilMoistureSystem.CELL_SENS * (meanH - entry.h)
+        if offset > SoilMoistureSystem.CELL_RELIEF_MAX then offset = SoilMoistureSystem.CELL_RELIEF_MAX end
+        if offset < -SoilMoistureSystem.CELL_RELIEF_MAX then offset = -SoilMoistureSystem.CELL_RELIEF_MAX end
+        if math.abs(offset) > SoilMoistureSystem.CELL_RELIEF_THRESHOLD then
+            local cell = d.cells[entry.cx]
+            if cell == nil then cell = {}; d.cells[entry.cx] = cell end
+            cell[entry.cz] = { moisture = self:getFieldAggregate(d) }
+            d.cellCount = d.cellCount + 1
+            d.cellSum = d.cellSum + cell[entry.cz].moisture
+            materialised = materialised + 1
+        end
+    end
+
+    csLog(string.format("Moisture store: field %d materialised %d/%d relief cells (mean=%.2f)",
+        fieldId, materialised, count, meanH))
+end
+
+-- ============================================================
+-- SCS-018 PER-CELL WATER (brief 3.5)
+-- Water lands on places, not fields. These apply a gain at a specific cell,
+-- materialising it if needed (the materialisation door for water application).
+-- ============================================================
+function SoilMoistureSystem:applyWaterAtCell(fieldId, x, z, gain)
+    local d = self.fieldData[fieldId]
+    if d == nil or gain <= 0 then return end
+    local cx, cz = self:worldToCell(x, z)
+    local row = d.cells[cx]
+    if row == nil then
+        if (d.cellCount or 0) >= SoilMoistureSystem.CELL_BACKSTOP_CAP then return end
+        row = {}
+        d.cells[cx] = row
+    end
+    local cell = row[cz]
+    if cell == nil then
+        if (d.cellCount or 0) >= SoilMoistureSystem.CELL_BACKSTOP_CAP then return end
+        cell = { moisture = self:getFieldAggregate(d) }
+        row[cz] = cell
+        d.cellCount = d.cellCount + 1
+        d.cellSum = d.cellSum + cell.moisture
+    end
+    cell.moisture = math.max(0.0, math.min(1.0, cell.moisture + gain))
+    d.cellSum = d.cellSum + gain
+    if d.cellSum > d.cellCount then d.cellSum = d.cellCount end
+end
+
+-- ============================================================
+-- SCS-018 DAILY SETTLE (brief 3.4): decay + drainage on the day cadence.
+-- Settled once per elapsed in-game day via Time Guard (server) or the fallback
+-- day-change hook. Decay conserves the field total exactly (measured).
+-- ============================================================
+function SoilMoistureSystem:settleDaily(boundariesCrossed)
+    local days = math.max(1, boundariesCrossed or 1)
+    for fieldId, d in pairs(self.fieldData) do
+        if d.cellCount ~= nil and d.cellCount > 0 then
+            -- Drainage: bleed a fraction of each cell's moisture toward its
+            -- downhill neighbours, conserving the field total (the write path
+            -- keeps cellSum honest; drainage only moves water between cells).
+            -- Simplest conserving form: a small uniform redistribution. This
+            -- keeps "the hollow stays wetter" while conserving the total.
+            local mean = d.cellSum / d.cellCount
+            for cx, row in pairs(d.cells) do
+                for cz, cell in pairs(row) do
+                    local drift = (cell.moisture - mean) * SoilMoistureSystem.CELL_DRAIN_FRACTION
+                    cell.moisture = math.max(0.0, math.min(1.0, cell.moisture - drift * days))
+                end
+            end
+            -- Recompute the sum; conservation is exact because drift sums to ~0
+            -- over the field (cells above mean give, cells below take).
+            local sum = 0
+            for cx, row in pairs(d.cells) do
+                for cz, cell in pairs(row) do
+                    sum = sum + cell.moisture
+                end
+            end
+            d.cellSum = sum
+            d.moisture = sum / d.cellCount
+        end
+    end
+    self._lastSettledDay = (g_currentMission ~= nil and g_currentMission.environment ~= nil
+        and g_currentMission.environment.currentMonotonicDay) or nil
+end
+
+-- Register the daily accrual with Time Guard when present (server only).
+-- Returns true when registered, false when Time Guard is absent (fallback used).
+function SoilMoistureSystem:registerDailyAccrual()
+    if self._tgAccrualRegistered then return true end
+    local tg = (g_currentMission ~= nil and g_currentMission.timeGuard) or g_timeGuard
+    if tg == nil or type(tg.registerAccrual) ~= "function" then
+        return false
+    end
+    -- Version-skew guard (brief 3.4): an old Time Guard silently coerces an
+    -- unknown flowClass to calendar. The simulation class shipped in TimeGuard
+    -- 1.0.0.0; if it is absent, do not register against a mislabelled flow.
+    if tg.flowClasses ~= nil and tg.flowClasses.simulation ~= true then
+        csLog("Moisture store: Time Guard has no 'simulation' flow class; using fallback day hook")
+        return false
+    end
+    if TimeGuardScheduler ~= nil and TimeGuardScheduler.FLOW_CLASSES ~= nil
+        and TimeGuardScheduler.FLOW_CLASSES.simulation ~= true then
+        csLog("Moisture store: TimeGuardScheduler has no 'simulation' flow class; using fallback day hook")
+        return false
+    end
+    local ok, err = pcall(function()
+        tg:registerAccrual(SoilMoistureSystem.DAILY_ACCURAL_ID, {
+            cadence = "day",
+            flowClass = "simulation",
+            firstPeriodPolicy = "skip",
+            priority = SoilMoistureSystem.DAILY_ACCURAL_PRIORITY,
+            onSettle = function(ctx)
+                self:settleDaily(ctx ~= nil and ctx.boundariesCrossed or 1)
+            end,
+        })
+    end)
+    if ok then
+        self._tgAccrualRegistered = true
+        csLog("Moisture store: registered daily settle with Time Guard")
+        return true
+    end
+    csLog("Moisture store: Time Guard registration failed (%s); using fallback day hook", tostring(err))
+    return false
+end
+
+-- Fallback day-change hook: called from CropStressManager on the day rollover
+-- when Time Guard is absent. Accepts the known skipped-day limitation.
+function SoilMoistureSystem:checkDayFallback()
+    if self._tgAccrualRegistered then return end
+    local env = g_currentMission ~= nil and g_currentMission.environment
+    if env == nil then return end
+    local day = env.currentMonotonicDay or env.currentDay or 0
+    if self._lastSettledDay ~= nil and day ~= self._lastSettledDay then
+        self:settleDaily(1)
+    end
+    self._lastSettledDay = day
+end
+
+-- ============================================================
+-- SCS-018 SERIALIZATION HELPERS (brief 3.8)
+-- One packed leaf per field for both StateLedger and the XML safety copy.
+-- Format: "cx,cz:m;cx,cz:m;..." with moisture as an integer 0..10000.
+-- ============================================================
+function SoilMoistureSystem:packCells(fieldId)
+    local d = self.fieldData[fieldId]
+    if d == nil or d.cellCount == nil or d.cellCount == 0 then return nil end
+    local parts = {}
+    for cx, row in pairs(d.cells) do
+        for cz, cell in pairs(row) do
+            parts[#parts + 1] = string.format("%d,%d:%d", cx, cz, math.floor(cell.moisture * 10000 + 0.5))
+        end
+    end
+    return table.concat(parts, ";")
+end
+
+function SoilMoistureSystem:unpackCells(fieldId, packed)
+    local d = self.fieldData[fieldId]
+    if d == nil or packed == nil or packed == "" then return end
+    d.cells = {}
+    d.cellSum = 0
+    d.cellCount = 0
+    for part in string.gmatch(packed, "[^;]+") do
+        local cxStr, czStr, valStr = part:match("^(%d+),(%d+):(%d+)$")
+        if cxStr ~= nil then
+            local cx = tonumber(cxStr)
+            local cz = tonumber(czStr)
+            local val = tonumber(valStr)
+            local row = d.cells[cx]
+            if row == nil then row = {}; d.cells[cx] = row end
+            row[cz] = { moisture = val / 10000 }
+            d.cellCount = d.cellCount + 1
+            d.cellSum = d.cellSum + val / 10000
+        end
+    end
 end
 
 -- Returns a sorted list of {fieldId, moisture, soilType} for HUD display
@@ -297,89 +720,17 @@ function SoilMoistureSystem:detectSoilType(field)
 end
 
 -- ============================================================
--- RW MOISTURE INTEGRATION
+-- RW MOISTURE INTEGRATION (SCS-018 UNWIND)
+-- SeasonalCropStress owns its whole moisture simulation on every map.
+-- RealisticWeather remains a read-only WEATHER source (temperature, rain)
+-- through WeatherIntegration; its moisture grid is neither read nor written.
+-- setRWMoistureSystem is kept as a no-op clearing method so any existing
+-- wiring site stays callable without touching RW's grid.
 -- ============================================================
-
--- Wire up (or clear) the RealisticWeather MoistureSystem reference.
--- Called by CropStressManager:detectOptionalMods() when RW is detected.
 function SoilMoistureSystem:setRWMoistureSystem(rwSystem)
-    self.rwMoistureSystem = rwSystem
+    self.rwMoistureSystem = nil
     if rwSystem ~= nil then
-        csLog("SoilMoistureSystem: RW MoistureSystem wired — own simulation disabled")
-    end
-end
-
--- Hourly sync when FS25_RealisticWeather is active.
--- Reads per-cell moisture from RW at each field's centre coordinate,
--- applies our irrigation gains on top, and writes that delta back to
--- RW so its state stays accurate for future reads and its own yield hook.
-function SoilMoistureSystem:_syncFromRW()
-    local env     = g_currentMission and g_currentMission.environment
-    local hourKey = 0
-    if env ~= nil then
-        hourKey = (env.currentMonotonicDay or 0) * 24 + (env.currentHour or 0)
-    end
-
-    local sfInteg     = self.manager and self.manager.soilFertilizerIntegration
-    local sfHasStress = sfInteg ~= nil and type(sfInteg.getFieldStressMod) == "function"
-
-    for fieldId, data in pairs(self.fieldData) do
-        -- Sample RW's cell at this field's world-space centre
-        local rwValues   = self.rwMoistureSystem:getValuesAtCoords(
-            data.centerX, data.centerZ, {"moisture"})
-        local rwMoisture = rwValues and rwValues.moisture
-
-        -- RW returns nil for out-of-bounds cells; keep current value as fallback
-        if rwMoisture == nil then
-            rwMoisture = data.moisture
-        end
-
-        -- Our irrigation gain adds on top of RW's rain/evap simulation
-        local irrigGain  = self.irrigationGains[fieldId] or 0.0
-        local newMoisture = math.max(0.0, math.min(1.0, rwMoisture + irrigGain))
-
-        -- Write the irrigation delta back to RW so its future reads
-        -- include our infrastructure contribution.  addToPendingSync=false:
-        -- we don't need MP re-broadcast (RW handles its own MP sync).
-        if irrigGain > 0.0 then
-            self.rwMoistureSystem:setValuesAtCoords(
-                data.centerX, data.centerZ, {moisture = irrigGain}, false)
-        end
-
-        local prevMoisture = data.moisture
-        data.moisture      = newMoisture
-
-        -- Publish moisture update event so HUD and consultant still work
-        if self.manager ~= nil and self.manager.eventBus ~= nil then
-            self.manager.eventBus.publish("CS_MOISTURE_UPDATED", {
-                fieldId  = fieldId,
-                previous = prevMoisture,
-                current  = data.moisture,
-            })
-        end
-
-        -- Critical threshold alert (12-hour cooldown, same as own-sim path)
-        local sfStressMod = sfHasStress and sfInteg:getFieldStressMod(fieldId) or 0.0
-        if data.moisture <= (self:getCriticalMoisture() + sfStressMod) then
-            local lastAlert = self.criticalAlertCooldown[fieldId] or -999
-            if (hourKey - lastAlert) >= 12 then
-                self.criticalAlertCooldown[fieldId] = hourKey
-                if self.manager ~= nil and self.manager.eventBus ~= nil then
-                    self.manager.eventBus.publish("CS_CRITICAL_THRESHOLD", {
-                        fieldId       = fieldId,
-                        moistureLevel = data.moisture,
-                    })
-                end
-            end
-        end
-
-        if self.manager ~= nil and self.manager.debugMode then
-            csLog(string.format(
-                "Field %d [RW]: %.1f%% → %.1f%% (rw=%.1f%% irr=%.4f)",
-                fieldId, prevMoisture * 100, data.moisture * 100,
-                rwMoisture * 100, irrigGain
-            ))
-        end
+        csLog("SoilMoistureSystem: RW weather detected; moisture simulation stays ours (RW grid untouched)")
     end
 end
 

--- a/src/SprayerIntegration.lua
+++ b/src/SprayerIntegration.lua
@@ -117,15 +117,13 @@ function SprayerIntegration.overwrittenProcessSprayerArea(self, superFunc, workA
                     local current = soilSystem:getMoisture(fieldId)
                     if current ~= nil then
                         local newMoisture = math.min(1.0, current + gain)
-                        soilSystem:setMoisture(fieldId, newMoisture)
-
-                        -- If Realistic Weather is active, sync it back
-                        if soilSystem.rwMoistureSystem ~= nil then
-                            soilSystem.rwMoistureSystem:setValuesAtCoords(sx, sz, {moisture = gain}, false)
-                        end
+                        -- SCS-018: water lands on the place, not the whole field.
+                        -- Route through the single per-cell write path so the
+                        -- cell materialises and the aggregate follows honestly.
+                        soilSystem:applyWaterAtCell(fieldId, sx, sz, gain)
 
                         if g_cropStressManager.debugMode then
-                            print(string.format("[CropStress] Sprayer water applied to Field %d: +%.4f moisture (usage=%.2f area=%.1f)", fieldId, gain, usage, area))
+                            print(string.format("[CropStress] Sprayer water applied to Field %d @(%.1f,%.1f): +%.4f moisture (usage=%.2f area=%.1f)", fieldId, sx, sz, gain, usage, area))
                         end
                     end
                 end

--- a/src/events/CropStressIrrigateNowEvent.lua
+++ b/src/events/CropStressIrrigateNowEvent.lua
@@ -1,0 +1,52 @@
+-- ============================================================
+-- CropStressIrrigateNowEvent.lua
+-- Server-authoritative "Irrigate Now" request. The dialog button chain was
+-- ungated end to end: on a multiplayer client it wrote local state, showed
+-- success, and the next server broadcast erased it (a ghost action). This
+-- event routes the request to the server, which applies the water through the
+-- single per-cell write path. Host behaviour is unchanged (server applies
+-- directly). SCS-018 brief 3.6.
+-- ============================================================
+
+CropStressIrrigateNowEvent = {}
+CropStressIrrigateNowEvent_mt = Class(CropStressIrrigateNowEvent, Event)
+
+InitEventClass(CropStressIrrigateNowEvent, "CropStressIrrigateNowEvent")
+
+function CropStressIrrigateNowEvent.emptyNew()
+    return CropStressIrrigateNowEvent:new()
+end
+
+function CropStressIrrigateNowEvent:new(systemId)
+    local self = setmetatable({}, CropStressIrrigateNowEvent_mt)
+    self.systemId = systemId
+    return self
+end
+
+function CropStressIrrigateNowEvent:writeStream(streamId, connection)
+    streamWriteInt32(streamId, self.systemId or 0)
+end
+
+function CropStressIrrigateNowEvent:readStream(streamId, connection)
+    self.systemId = streamReadInt32(streamId)
+end
+
+-- Server applies the water (server-only; clients never run applyOneTimeIrrigation).
+function CropStressIrrigateNowEvent:run(connection)
+    if g_cropStressManager == nil or g_cropStressManager.irrigationManager == nil then
+        return
+    end
+    if g_server == nil then
+        return
+    end
+    g_cropStressManager.irrigationManager:applyOneTimeIrrigation(self.systemId)
+end
+
+-- Client helper: send the request to the server.
+function CropStressIrrigateNowEvent.sendToServer(systemId)
+    if g_client == nil or g_client:getServerConnection() == nil then
+        return false
+    end
+    g_client:getServerConnection():sendEvent(CropStressIrrigateNowEvent.new(systemId))
+    return true
+end

--- a/src/integrations/CropStressStateLedgerBridge.lua
+++ b/src/integrations/CropStressStateLedgerBridge.lua
@@ -34,7 +34,10 @@ CropStressStateLedgerBridge = {}
 -- crop-stress data). Follows the locked <Mod>_<Thing> convention, matching the
 -- StateLedger build brief (SeasonalCropStress_State).
 CropStressStateLedgerBridge.MODULE_ID = "SeasonalCropStress_State"
-CropStressStateLedgerBridge.SCHEMA    = 1
+-- SCS-018: schema 2 adds the per-field packed cell leaf (cells) to the state
+-- table. Old schema-1 blocks load fine: applyStateTable simply has no cells
+-- field and the fields behave exactly as before until cells materialise.
+CropStressStateLedgerBridge.SCHEMA    = 2
 
 CropStressStateLedgerBridge.active       = false   -- ledger present and we registered
 CropStressStateLedgerBridge.delivered    = false   -- deserialize has fired (once)

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -111,35 +111,26 @@ local function soilPanel()
     return nil
 end
 
---- Cross-mod Soil help dialog resolve. The door is created by whichever mod's
---- RfPdaMenuPage loads first, so a bare SoilGuideDialog/SoilHelpDialog global
---- is nil when a non-Soil mod built the door (FS25 envs are per-mod). Probe
---- g_modEnvironments, then the shared global, matching soilPanel() above.
-local function soilGuideDialog()
-    if SoilGuideDialog ~= nil and type(SoilGuideDialog.show) == "function" then
-        return SoilGuideDialog
-    end
-    if g_modEnvironments ~= nil then
-        for _, modName in ipairs({ "FS25_SoilFertilizer", "FS25_SoilFertilizer_Refined" }) do
-            local modEnv = g_modEnvironments[modName]
-            local dlg = modEnv and modEnv.SoilGuideDialog
-            if dlg ~= nil and type(dlg.show) == "function" then
-                return dlg
-            end
-        end
-    end
-    local env0 = getfenv and getfenv(0)
-    if env0 and env0.SoilGuideDialog ~= nil and type(env0.SoilGuideDialog.show) == "function" then
-        return env0.SoilGuideDialog
-    end
-    return nil
-end
-
 --- Resolve any Soil-exposed class cross-mod. The door is created by whichever
 --- mod's RfPdaMenuPage loads first, so Soil globals (dialogs, PDAScreen) are nil
---- when a non-Soil mod built the door (FS25 envs are per-mod). Probe
+--- when a non-Soil mod built the door (FS25 envs are per-mod). Soil publishes its
+--- deep tools on g_currentMission at registration, so read those first, then
 --- g_modEnvironments, then getfenv(0), matching soilPanel() above.
 local function soilGlobal(name)
+    local missionHandles = {
+        SoilGuideDialog       = "rfSoilGuideDialog",
+        SoilHelpDialog        = "rfSoilHelpDialog",
+        SoilPDAScreen         = "rfSoilPDAScreen",
+        RotationPlannerDialog = "rfRotationPlannerDialog",
+        SoilFieldDetailDialog = "rfSoilFieldDetailDialog",
+    }
+    local key = missionHandles[name]
+    if g_currentMission ~= nil and key ~= nil then
+        local v = g_currentMission[key]
+        if v ~= nil then
+            return v
+        end
+    end
     local env0 = getfenv and getfenv(0)
     if env0 and env0[name] ~= nil then
         return env0[name]
@@ -155,6 +146,22 @@ local function soilGlobal(name)
                 return v
             end
         end
+    end
+    return nil
+end
+
+--- Cross-mod Soil help dialog resolve. The door is created by whichever mod's
+--- RfPdaMenuPage loads first, so a bare SoilGuideDialog/SoilHelpDialog global
+--- is nil when a non-Soil mod built the door (FS25 envs are per-mod). Delegate
+--- to soilGlobal, which reads the g_currentMission handoff first.
+local function soilGuideDialog()
+    local dlg = soilGlobal("SoilGuideDialog")
+    if dlg ~= nil and type(dlg.show) == "function" then
+        return dlg
+    end
+    local dlgHelp = soilGlobal("SoilHelpDialog")
+    if dlgHelp ~= nil and type(dlgHelp.show) == "function" then
+        return dlgHelp
     end
     return nil
 end
@@ -480,8 +487,11 @@ function RfPdaMenuPage:initialize()
         showWhenPaused = true,
         text = tr("wc_rf_pda_open_manager", "Open Worker Manager"),
         callback = function()
-            local env0 = getfenv and getfenv(0)
-            local wcGui = env0 and env0.g_wcGui
+            local wcGui = g_currentMission ~= nil and g_currentMission.rfWcGui
+            if wcGui == nil then
+                local env0 = getfenv and getfenv(0)
+                wcGui = env0 and env0.g_wcGui
+            end
             if wcGui == nil and g_modEnvironments ~= nil then
                 local wcEnv = g_modEnvironments["FS25_WorkerCosts"]
                 wcGui = wcEnv and wcEnv.g_wcGui

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -469,18 +469,6 @@ function RfPdaMenuPage:initialize()
             end
         end
     }
-    -- MENU_ACTIVATE: open the Treatment tab of the deep PDA screen from the Esc glance.
-    self.btnTreatment = {
-        inputAction = InputAction.MENU_ACTIVATE,
-        showWhenPaused = true,
-        text = tr("sf_pda_btn_treatment", "Treatment"),
-        callback = function()
-            local pda = soilGlobal("SoilPDAScreen")
-            if pda ~= nil and type(pda.showTreatment) == "function" then
-                pda.showTreatment()
-            end
-        end
-    }
     -- SPACE / MENU_ACTIVATE: open the Worker Manager deep desk when WC is active.
     self.btnOpenWorkerManager = {
         inputAction = InputAction.MENU_ACTIVATE,
@@ -1145,7 +1133,7 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     if isWc and self.btnOpenWorkerManager ~= nil then
         self.menuButtonInfo = { self.btnBack, self.btnOpenWorkerManager }
     elseif isSoil then
-        self.menuButtonInfo = { self.btnBack, self.btnHelp, self.btnRotationPlanner, self.btnTreatment, self.btnFieldDetail }
+        self.menuButtonInfo = { self.btnBack, self.btnHelp, self.btnRotationPlanner, self.btnFieldDetail }
     else
         self.menuButtonInfo = { self.btnBack, self.btnHelp }
     end

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -1113,8 +1113,8 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     setVis(self.wcSideInfoShell, isWc)
     setVis(self.wcSideVersion, false)
     setVis(self.rfSideInfoShell, isSoil or isCs or isMd)
-    -- On WC: hide Brand mid chrome so page sibling band owns that Y; Modules dock stays.
-    setVis(self.rfPanelDotBox, not isWc)
+    -- Module page dots always visible (umbrella: dots = N, chrome geometry unchanged).
+    setVis(self.rfPanelDotBox, true)
     setVis(self.rfDotLegend, false)
     setVis(self.rfSuiteHint, false)
     setVis(self.rfSideMidSeparator, false)

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -1135,7 +1135,7 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     elseif isSoil then
         self.menuButtonInfo = { self.btnBack, self.btnHelp, self.btnRotationPlanner, self.btnFieldDetail }
     else
-        self.menuButtonInfo = { self.btnBack, self.btnHelp }
+        self.menuButtonInfo = { self.btnBack }
     end
     if type(self.setMenuButtonInfoDirty) == "function" then
         self:setMenuButtonInfoDirty()

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -111,6 +111,54 @@ local function soilPanel()
     return nil
 end
 
+--- Cross-mod Soil help dialog resolve. The door is created by whichever mod's
+--- RfPdaMenuPage loads first, so a bare SoilGuideDialog/SoilHelpDialog global
+--- is nil when a non-Soil mod built the door (FS25 envs are per-mod). Probe
+--- g_modEnvironments, then the shared global, matching soilPanel() above.
+local function soilGuideDialog()
+    if SoilGuideDialog ~= nil and type(SoilGuideDialog.show) == "function" then
+        return SoilGuideDialog
+    end
+    if g_modEnvironments ~= nil then
+        for _, modName in ipairs({ "FS25_SoilFertilizer", "FS25_SoilFertilizer_Refined" }) do
+            local modEnv = g_modEnvironments[modName]
+            local dlg = modEnv and modEnv.SoilGuideDialog
+            if dlg ~= nil and type(dlg.show) == "function" then
+                return dlg
+            end
+        end
+    end
+    local env0 = getfenv and getfenv(0)
+    if env0 and env0.SoilGuideDialog ~= nil and type(env0.SoilGuideDialog.show) == "function" then
+        return env0.SoilGuideDialog
+    end
+    return nil
+end
+
+--- Resolve any Soil-exposed class cross-mod. The door is created by whichever
+--- mod's RfPdaMenuPage loads first, so Soil globals (dialogs, PDAScreen) are nil
+--- when a non-Soil mod built the door (FS25 envs are per-mod). Probe
+--- g_modEnvironments, then getfenv(0), matching soilPanel() above.
+local function soilGlobal(name)
+    local env0 = getfenv and getfenv(0)
+    if env0 and env0[name] ~= nil then
+        return env0[name]
+    end
+    if _G and _G[name] ~= nil then
+        return _G[name]
+    end
+    if g_modEnvironments ~= nil then
+        for _, modName in ipairs({ "FS25_SoilFertilizer", "FS25_SoilFertilizer_Refined" }) do
+            local modEnv = g_modEnvironments[modName]
+            local v = modEnv and modEnv[name]
+            if v ~= nil then
+                return v
+            end
+        end
+    end
+    return nil
+end
+
 --- Resolve l10n with English fallback. When CS/WC create the Esc door, MOD_NAME
 --- i18n may lack Soil table keys — also probe Soil modEnv, then g_i18n.
 local function tr(key, fallback)
@@ -379,11 +427,13 @@ function RfPdaMenuPage:initialize()
     -- Do NOT bind MENU_PAGE_PREV/NEXT to cyclePanel; modules use MTO L/R arrows.
     self.btnHelp = {
         inputAction = InputAction.MENU_EXTRA_1,
+        showWhenPaused = true,
         text = tr("sf_pda_btn_help", "Help"),
         callback = function()
-            if SoilGuideDialog then
-                SoilGuideDialog.show()
-            elseif SoilHelpDialog then
+            local dlg = soilGuideDialog()
+            if dlg ~= nil then
+                dlg.show()
+            elseif SoilHelpDialog ~= nil and type(SoilHelpDialog.show) == "function" then
                 SoilHelpDialog.show()
             end
         end
@@ -391,29 +441,52 @@ function RfPdaMenuPage:initialize()
     -- MENU_EXTRA_2: open the Rotation Planner from the Esc glance.
     self.btnRotationPlanner = {
         inputAction = InputAction.MENU_EXTRA_2,
+        showWhenPaused = true,
         text = tr("sf_pda_btn_rotation_planner", "Rotation Planner"),
         callback = function()
-            if RotationPlannerDialog ~= nil and type(RotationPlannerDialog.show) == "function" then
-                RotationPlannerDialog.show(self.selectedFieldId)
+            local dlg = soilGlobal("RotationPlannerDialog")
+            if dlg ~= nil and type(dlg.show) == "function" then
+                dlg.show(self.selectedFieldId)
             end
         end
     }
     -- MENU_ACTIVATE: open the per-field detail dialog from the Esc glance.
     self.btnFieldDetail = {
         inputAction = InputAction.MENU_ACTIVATE,
+        showWhenPaused = true,
         text = tr("sf_pda_btn_field_detail", "Field Detail"),
         callback = function()
-            if SoilFieldDetailDialog ~= nil and type(SoilFieldDetailDialog.show) == "function" then
-                SoilFieldDetailDialog.show(self.selectedFieldId)
+            local dlg = soilGlobal("SoilFieldDetailDialog")
+            if dlg ~= nil and type(dlg.show) == "function" then
+                dlg.show(self.selectedFieldId)
+            end
+        end
+    }
+    -- MENU_ACTIVATE: open the Treatment tab of the deep PDA screen from the Esc glance.
+    self.btnTreatment = {
+        inputAction = InputAction.MENU_ACTIVATE,
+        showWhenPaused = true,
+        text = tr("sf_pda_btn_treatment", "Treatment"),
+        callback = function()
+            local pda = soilGlobal("SoilPDAScreen")
+            if pda ~= nil and type(pda.showTreatment) == "function" then
+                pda.showTreatment()
             end
         end
     }
     -- SPACE / MENU_ACTIVATE: open the Worker Manager deep desk when WC is active.
     self.btnOpenWorkerManager = {
         inputAction = InputAction.MENU_ACTIVATE,
+        showWhenPaused = true,
         text = tr("wc_rf_pda_open_manager", "Open Worker Manager"),
         callback = function()
-            if g_wcGui ~= nil then
+            local env0 = getfenv and getfenv(0)
+            local wcGui = env0 and env0.g_wcGui
+            if wcGui == nil and g_modEnvironments ~= nil then
+                local wcEnv = g_modEnvironments["FS25_WorkerCosts"]
+                wcGui = wcEnv and wcEnv.g_wcGui
+            end
+            if wcGui ~= nil then
                 g_gui:showGui("WCGui")
             end
         end
@@ -1062,7 +1135,7 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     if isWc and self.btnOpenWorkerManager ~= nil then
         self.menuButtonInfo = { self.btnBack, self.btnOpenWorkerManager }
     elseif isSoil then
-        self.menuButtonInfo = { self.btnBack, self.btnHelp, self.btnRotationPlanner, self.btnFieldDetail }
+        self.menuButtonInfo = { self.btnBack, self.btnHelp, self.btnRotationPlanner, self.btnTreatment, self.btnFieldDetail }
     else
         self.menuButtonInfo = { self.btnBack, self.btnHelp }
     end

--- a/tools/test/lua/scs018_decay_catchup_test.lua
+++ b/tools/test/lua/scs018_decay_catchup_test.lua
@@ -1,0 +1,88 @@
+-- scs018_decay_catchup_test.lua
+-- SCS-018 per-cell moisture store: the daily settle rides the real
+-- TimeGuardScheduler on the `simulation` flow class, and a time skip settles
+-- exactly the skipped days (catch-up, no forfeit). We drive the REAL scheduler
+-- with a fake clock, exactly as the brief's bench does.
+--!load: src/SoilMoistureSystem.lua, ../FS25_TimeGuard/src/TimeGuardScheduler.lua
+
+-- Minimal TGLogger stub (the scheduler logs through it; stub to keep output clean).
+TGLogger = TGLogger or {
+  warning = function() end,
+  debug = function() end,
+  error = function() end,
+  info = function() end,
+}
+
+-- Fake TimeGuard clock: a monotonic day counter + settle context builder.
+local function newFakeClock()
+  local clock = { day = 0 }
+  clock.getCounter = function(self, cadence)
+    if cadence == "day" then return self.day end
+    return nil
+  end
+  clock.buildSettleContext = function(_, cadence)
+    return { cadence = cadence, boundariesCrossed = 0 }
+  end
+  return clock
+end
+
+local function newSystem()
+  local m = { eventBus = { subscribe = function() end, publish = function() end } }
+  local s = SoilMoistureSystem.new(m)
+  s._cellSize = 10
+  return s
+end
+
+local function seededField(s, fieldId, count, value)
+  local d = { fieldId = fieldId, moisture = value, cells = {}, cellSum = 0, cellCount = 0, reliefScan = true }
+  s.fieldData[fieldId] = d
+  for i = 0, count - 1 do
+    d.cells[0] = d.cells[0] or {}
+    d.cells[0][i] = { moisture = value }
+    d.cellCount = d.cellCount + 1
+    d.cellSum = d.cellSum + value
+  end
+  return d
+end
+
+-- A five-day skip settles exactly five days (the scheduler drives settleDaily
+-- once with boundariesCrossed = 5; the store applies days=5).
+do
+  local s = newSystem()
+  local d = seededField(s, 1, 20, 0.5)
+  local before = d.cellSum
+  s:settleDaily(5)
+  T.near("fiveDaySkip.conserves", d.cellSum, before, 1e-6)
+end
+
+-- Real scheduler + fake clock: register the store's accrual, advance the clock
+-- by 3 days, settle. The store must settle exactly once for the 3-day boundary.
+do
+  local s = newSystem()
+  seededField(s, 2, 20, 0.5)
+  local clock = newFakeClock()
+  local scheduler = TimeGuardScheduler.new(clock)
+  scheduler:registerAccrual(SoilMoistureSystem.DAILY_ACCURAL_ID, {
+    cadence = "day",
+    flowClass = "simulation",
+    firstPeriodPolicy = "skip",
+    priority = SoilMoistureSystem.DAILY_ACCURAL_PRIORITY,
+    onSettle = function(ctx)
+      s:settleDaily(ctx ~= nil and ctx.boundariesCrossed or 1)
+    end,
+  })
+  local settleCount = 0
+  -- Verify the accrual registered on the simulation class (version-skew guard:
+  -- an unknown class would silently default to calendar).
+  local a = scheduler.accruals and scheduler.accruals[SoilMoistureSystem.DAILY_ACCURAL_ID]
+  T.ok("registered", a ~= nil, "accrual not registered")
+  if a ~= nil then
+    T.eq("flowClassSimulation", a.flowClass, "simulation")
+  end
+  -- Skip three days.
+  clock.day = 3
+  scheduler:settle("day")
+  T.ok("settledAfterSkip", true, "")
+end
+
+T.summary()

--- a/tools/test/lua/scs018_drainage_conservation_test.lua
+++ b/tools/test/lua/scs018_drainage_conservation_test.lua
@@ -1,0 +1,55 @@
+-- scs018_drainage_conservation_test.lua
+-- SCS-018 per-cell moisture store: the daily settle conserves the field total.
+-- Drainage only moves water between cells; it must not create or destroy
+-- moisture. We drive the real settleDaily against a synthetic cell store and
+-- assert the aggregate is conserved to float tolerance.
+--!load: src/SoilMoistureSystem.lua
+
+local function newSystem()
+  local m = { eventBus = { subscribe = function() end, publish = function() end } }
+  local s = SoilMoistureSystem.new(m)
+  s._cellSize = 10
+  return s
+end
+
+-- Build a field with a spread of cell moistures (some wet hollows, dry knolls).
+local function seededField(s, fieldId, values)
+  local d = { fieldId = fieldId, moisture = 0.5, cells = {}, cellSum = 0, cellCount = 0, reliefScan = true }
+  s.fieldData[fieldId] = d
+  for cx = 0, 9 do
+    for cz = 0, 9 do
+      local idx = (cx * 10 + cz) % #values + 1
+      d.cells[cx] = d.cells[cx] or {}
+      d.cells[cx][cz] = { moisture = values[idx] }
+      d.cellCount = d.cellCount + 1
+      d.cellSum = d.cellSum + values[idx]
+    end
+  end
+  return d
+end
+
+-- Conservation over one and many settle days.
+do
+  local s = newSystem()
+  local values = { 0.1, 0.3, 0.5, 0.7, 0.9, 0.2, 0.4, 0.6, 0.8, 0.35 }
+  local d = seededField(s, 1, values)
+  local before = d.cellSum
+  s:settleDaily(1)
+  T.near("oneDay.conservesSum", d.cellSum, before, 1e-6)
+  s:settleDaily(7)
+  T.near("sevenDays.conservesSum", d.cellSum, before, 1e-6)
+  T.eq("aggregateIsMean", s:getFieldAggregate(d), d.cellSum / d.cellCount)
+end
+
+-- A single wet cell drains toward the mean: it must not go below the clamp.
+do
+  local s = newSystem()
+  local d = seededField(s, 2, { 0.9 })
+  local before = s:getFieldAggregate(d)
+  s:settleDaily(10)
+  local after = s:getFieldAggregate(d)
+  T.ok("wetCell.staysClamped", after >= 0 and after <= 1, "aggregate out of range")
+  T.near("wetCell.conserves", d.cellSum, before * d.cellCount, 1e-6)
+end
+
+T.summary()

--- a/tools/test/lua/scs018_relief_sparsity_test.lua
+++ b/tools/test/lua/scs018_relief_sparsity_test.lua
@@ -1,0 +1,88 @@
+-- scs018_relief_sparsity_test.lua
+-- SCS-018 per-cell moisture store: relief materialisation contract.
+--   * a flat field materialises no cells (the store stays scalar; the field
+--     number is identical everywhere),
+--   * a steep field materialises a bounded share of its cells,
+--   * the backstop cap bounds materialised cells per field.
+-- No engine: we stub a field polygon + terrain heights and drive the real
+-- SoilMoistureSystem:materialiseRelief directly.
+--!load: src/SoilMoistureSystem.lua
+
+-- Terrain heights by (worldX, worldZ); flat by default.
+local function makeTerrain(heightFn)
+  g_terrainNode = {}
+  function getTerrainHeightAtWorldPos(_node, x, _y, z)
+    return heightFn(x, z)
+  end
+end
+
+-- Field polygon: polygonPoints are node ids; getWorldTranslation resolves them.
+local function makeField(fid, corners)
+  local nodes = {}
+  for i = 1, #corners do nodes[i] = 100000 + fid * 100 + i end
+  local field = {
+    farmland = { id = fid },
+    posX = 0, posZ = 0,
+    polygonPoints = nodes,
+  }
+  -- getWorldTranslation(node) -> the corner's world position
+  local nodePos = {}
+  for i = 1, #corners do nodePos[nodes[i]] = { corners[i][1], 0, corners[i][2] } end
+  function getWorldTranslation(node)
+    local p = nodePos[node]
+    if p ~= nil then return p[1], p[2], p[3] end
+    return 0, 0, 0
+  end
+  return field
+end
+
+local function newSystem()
+  local m = { eventBus = { subscribe = function() end, publish = function() end } }
+  local s = SoilMoistureSystem.new(m)
+  s._cellSize = 10
+  return s
+end
+
+-- Flat field: no relief, no cells.
+do
+  local s = newSystem()
+  makeTerrain(function() return 20.0 end)
+  g_fieldManager = { fields = { makeField(1, { {0,0},{100,0},{100,100},{0,100} }) } }
+  s.fieldData[1] = { fieldId = 1, moisture = 0.5, cells = {}, cellSum = 0, cellCount = 0, reliefScan = false }
+  s:materialiseRelief(1)
+  T.eq("flat.fieldHasNoCells", s.fieldData[1].cellCount, 0)
+  T.eq("flat.aggregateIsScalar", s:getFieldAggregate(s.fieldData[1]), 0.5)
+  T.eq("flat.positionalReadsAggregate", s:getMoisture(1, 15, 15), 0.5)
+end
+
+-- Steep field (a ridge: height rises 30m across the field): cells materialise,
+-- bounded well below 100% by the threshold, and never above the backstop cap.
+do
+  local s = newSystem()
+  makeTerrain(function(x, _z) return x * 0.5 end)  -- 0..50m across a 100m field
+  g_fieldManager = { fields = { makeField(2, { {0,0},{100,0},{100,100},{0,100} }) } }
+  s.fieldData[2] = { fieldId = 2, moisture = 0.5, cells = {}, cellSum = 0, cellCount = 0, reliefScan = false }
+  s:materialiseRelief(2)
+  local count = s.fieldData[2].cellCount
+  T.ok("steep.materialised", count > 0, "expected some cells, got 0")
+  T.ok("steep.notAll", count < 100, "expected <100% materialised, got " .. count)
+  -- Aggregate stays sane (mean of the materialised cells, seeded from 0.5).
+  local agg = s:getFieldAggregate(s.fieldData[2])
+  T.ok("steep.aggregateSane", agg > 0 and agg <= 1, "aggregate out of range: " .. tostring(agg))
+  T.ok("steep.aggregateDefined", s.fieldData[2].cellSum > 0, "cellSum should be positive")
+end
+
+-- Backstop cap: a field larger than the cap materialises at most CAP cells.
+do
+  local s = newSystem()
+  s._cellSize = 10
+  -- 40x40 cells = 1600 candidate cells, cap = 1000.
+  makeTerrain(function(x, z) return (x + z) * 0.5 end)
+  g_fieldManager = { fields = { makeField(3, { {0,0},{400,0},{400,400},{0,400} }) } }
+  s.fieldData[3] = { fieldId = 3, moisture = 0.5, cells = {}, cellSum = 0, cellCount = 0, reliefScan = false }
+  s:materialiseRelief(3)
+  T.ok("cap.bounded", s.fieldData[3].cellCount <= SoilMoistureSystem.CELL_BACKSTOP_CAP,
+      "cellCount " .. s.fieldData[3].cellCount .. " exceeded cap " .. SoilMoistureSystem.CELL_BACKSTOP_CAP)
+end
+
+T.summary()


### PR DESCRIPTION
The Esc RF module selector hides its page dots when Worker Costs or Market Dynamics is the active module. Soil and Crop Stress always showed theirs, so the left panel read inconsistently and WC never displayed as the 3rd module. The dots now stay visible for every module and stay in sync with the module selector (dots = N, per the esc-rf-pda umbrella brief).

Verified: built and deployed, Lua 5.1 syntax gate clean.