### PR TITLE
SCS-039: moisture on the 2m grid, plus the SCS-018 positional read fix and the Esc chrome unification

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,3 +51,7 @@
 
 ## 2026-08-08 (Fred): SCS-018 per-cell moisture store (combined spatial-soil drop, head)
 - [x] Moisture is now a property of the ground, cell by cell, on the same grid SoilFertilizer uses (10m at 4x, 20m at 8x, 40m at 16x). Cells materialise where relief exceeds the threshold or water is applied; the field scalar stays the derived aggregate. Single write path, packed persistence (StateLedger SCHEMA 2 + XML), daily settle via the TimeGuard `simulation` flow class with a day-hook fallback, per-cell pivot/drip/sprayer water, Irrigate Now server-routed, and the RealisticWeather moisture unwind (RW stays a weather source only). Three offline benches green (relief sparsity, drainage conservation, real-scheduler catch-up). In-game observation owed (acceptance checks in the brief).
+
+## 2026-08-08 (Fred): SCS-018 positional read facade fixed
+- [x] The SCS-018 contract claimed getMoisture(fieldId, x, z) shipped, but the CropStressManager facade forwarded only fieldId, so SF-18's positional reads degraded to the field aggregate. SoilMoistureSystem already had the positional getter; the facade now forwards x, z. One-arg callers unchanged. Suite 162/0 across 9 files. Built and deployed. The SF-18 keystone (FS25_SoilFertilizer) consumes the positional read.
+

--- a/TODO.md
+++ b/TODO.md
@@ -58,4 +58,6 @@
 - [x] Daily TimeGuard `simulation` accrual + day-hook fallback + version-skew guard.
 - [x] RealisticWeather moisture unwind (2 writes + 2 step-asides removed; RW stays weather-only).
 - [x] Three offline benches (relief sparsity, drainage conservation, real-scheduler catch-up). Suite 162/0.
+- [x] SCS-018 positional read facade fixed: CropStressManager.getMoisture forwards x, z to SoilMoistureSystem (the 1-arg facade was the uncommitted gap; SF-18 consumes the positional read). Suite 162/0.
 - [~] In-game acceptance owed: hollow stays wetter over dry days; continuity on old saves; skip lands exactly; cell round-trip on both save paths; Irrigate Now survives broadcast on a client; RW map moisture evolves on our model.
+

--- a/main.lua
+++ b/main.lua
@@ -59,6 +59,7 @@ source(modDir .. "src/integrations/CropStressMasterHUDBridge.lua")
 source(modDir .. "src/events/CropStressSettingsSyncEvent.lua")
 source(modDir .. "src/events/CropStressMoistureInitEvent.lua")
 source(modDir .. "src/events/CropStressIrrigateNowEvent.lua")
+source(modDir .. "src/events/CropStressMoistureRowEvent.lua")
 
 -- Persistence
 source(modDir .. "src/SaveLoadHandler.lua")
@@ -269,6 +270,7 @@ Mission00.loadMission00Finished = Utils.appendedFunction(Mission00.loadMission00
         addConsoleCommand("csDebug",       "Toggle verbose debug logging",                                 "consoleToggleDebug", g_csManager)
         addConsoleCommand("csConsultant",  "Open the Crop Consultant dialog",                              "consoleConsultant",  g_csManager)
         addConsoleCommand("csRelease",     "Release gate: show STABLE vs experimental-LOCKED systems",     "consoleRelease",     g_csManager)
+        addConsoleCommand("csMapStats",    "Moisture value map: grain, settle cost, sync progress",       "consoleMapStats",    g_csManager)
     end
 end)
 

--- a/main.lua
+++ b/main.lua
@@ -20,6 +20,11 @@ local modDir = g_currentModDirectory
 -- Weather bridge
 source(modDir .. "src/WeatherIntegration.lua")
 
+-- Value-map substrate (SCS-039): loads BEFORE SoilMoistureSystem, which
+-- delegates to it when the engine is capable and falls back to its own
+-- cell store when it is not.
+source(modDir .. "src/maps/CropStressValueMap.lua")
+
 -- Core simulation
 source(modDir .. "src/SoilMoistureSystem.lua")
 source(modDir .. "src/CropStressModifier.lua")

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.5.5</version>
+    <version>1.2.5.9</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -312,11 +312,28 @@ function CropStressManager:installFieldReadyUpdater()
             local mapped = manager:buildFieldMap()
             csLog(string.format("CropStressManager fieldReady: buildFieldMap mapped %d fields", mapped))
 
+            -- SCS-039: stand the 2m value map up FIRST, because whether it is
+            -- carrying the truth decides whether the relief pass below runs at
+            -- all. Terrain is available by this point, which is what the map
+            -- needs. Declines quietly on any install the engine cannot carry.
+            local mapLive = false
+            if manager.soilSystem.initValueMap ~= nil then
+                local sgDir = g_currentMission ~= nil and g_currentMission.missionInfo ~= nil
+                    and g_currentMission.missionInfo.savegameDirectory or nil
+                mapLive = manager.soilSystem:initValueMap(sgDir)
+            end
+
             -- SCS-018: once fields are ready, materialise relief cells (one pass,
             -- terrain is available after mission start) and register the daily
             -- settle with Time Guard (server). The store's relief pass and the
             -- fallback day hook handle absence.
-            if manager.soilSystem.materialiseRelief ~= nil then
+            --
+            -- UNDER THE MAP DEFAULT THE RELIEF PASS IS FALLBACK-ONLY, per the
+            -- moisture brief's ratified rebase addendum: the materialisation
+            -- machinery (threshold, relief trigger, backstop cap) is text that
+            -- only applies when the map is absent. Running it anyway would build
+            -- a second store nothing reads and pay for it every load.
+            if not mapLive and manager.soilSystem.materialiseRelief ~= nil then
                 for fieldId in pairs(manager.soilSystem.fieldData) do
                     manager.soilSystem:materialiseRelief(fieldId)
                 end

--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -605,9 +605,11 @@ end
 -- ============================================================
 
 -- Moisture (0.0-1.0) for a field, or nil if the field is not tracked.
-function CropStressManager:getMoisture(fieldId)
+-- With a world position (fieldId, x, z) returns the per-cell moisture where a
+-- cell exists, else the field aggregate (SCS-018 positional read; never nil).
+function CropStressManager:getMoisture(fieldId, x, z)
     if self.soilSystem == nil then return nil end
-    return self.soilSystem:getMoisture(fieldId)
+    return self.soilSystem:getMoisture(fieldId, x, z)
 end
 
 -- Stress (0.0-1.0) for a field; 0.0 if the field is not tracked.

--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -456,6 +456,12 @@ function CropStressManager:update(dt)
         self.npcIntegration:tryDeferredRegistration()
     end
 
+    -- SCS-039: walk any queued moisture-map delivery a few rows per frame.
+    -- Returns immediately when the queue is empty, which is the normal case.
+    if g_server ~= nil and self.soilSystem ~= nil and self.soilSystem.updateMapSync ~= nil then
+        self.soilSystem:updateMapSync()
+    end
+
     local env = g_currentMission.environment
     if env == nil then return end
 
@@ -606,6 +612,14 @@ function CropStressManager:sendInitialClientState(connection)
         self.stressModifier.fieldStress
     )
     connection:sendEvent(moistureEvent)
+
+    -- 3. SCS-039: queue the 2m map for this client. The snapshot above already
+    --    gave them every field SCALAR, so their HUD is correct immediately; the
+    --    map rows fill in the sub-field detail behind it, a few per frame. A
+    --    client that disconnects mid-walk simply stops receiving rows.
+    if self.soilSystem.queueMapSync ~= nil then
+        self.soilSystem:queueMapSync(connection)
+    end
 
     local fieldCount = 0
     for _ in pairs(self.soilSystem.fieldData) do fieldCount = fieldCount + 1 end
@@ -1023,6 +1037,35 @@ function CropStressManager:consoleStatus()
         print(string.format("    Field %d: %.1f%% moisture, stress %.2f",
             f.fieldId, f.moisture * 100, stress))
     end
+end
+
+--- SCS-039 THE FRAME-COST INSTRUMENT. The brief left in-game frame cost as its
+--- one open measurement; this makes it readable rather than guessed at.
+function CropStressManager:consoleMapStats()
+    local soil = self.soilSystem
+    if soil == nil or soil.getMapStats == nil then
+        print("Moisture map: unavailable (soil system not ready)")
+        return
+    end
+    local s = soil:getMapStats()
+    print("=== Moisture value map (SCS-039) ===")
+    if not s.active then
+        print("  ACTIVE: no - the sparse-cell store is carrying moisture")
+        print("  (engine incapable, release-gated off, or the map declined to load)")
+        return
+    end
+    local m = s.map or {}
+    print(string.format("  ACTIVE: yes   grain %.2f m/px   %dx%d   %s",
+        m.grainMetres or 0, m.resolution or 0, m.resolution or 0,
+        m.fromSave and "restored from savegame" or "fresh"))
+    print(string.format("  one raw step = %.5f moisture (the quantisation floor)", m.unitsPerRaw or 0))
+    print(string.format("  fields seeded onto the map: %d", s.seededFields or 0))
+    print(string.format("  last daily settle: %s ms over %d fields / %d sampled blocks",
+        tostring(s.settleMs or "n/a"), s.settleFields or 0, s.settleBlocks or 0))
+    print(string.format("  MP rows sent: %d   deliveries pending: %d",
+        s.syncRowsSent or 0, s.syncPending or 0))
+    print(string.format("  engine paths: executeAdd=%s polygonOps=%s",
+        tostring(m.executeAdd), tostring(m.polygonOps)))
 end
 
 function CropStressManager:consoleRelease()

--- a/src/ReleaseGate.lua
+++ b/src/ReleaseGate.lua
@@ -37,6 +37,14 @@ ReleaseGate.EXPERIMENTAL = {
         name = "Moisture coupling",
         status = "not built yet; locks when it lands",
     },
+    -- SCS-039 / GRID-1. LOCKED at merge per the brief. Unlock gates on the
+    -- standard in-game layer look: no FPS regression beside the six shipped
+    -- soil layers. The system is inert on any install where the engine cannot
+    -- carry the map, so a locked row here never costs the fallback anything.
+    cs_grid_concordance = {
+        name = "Moisture on the 2m grid",
+        status = "new; awaiting the in-game layer look",
+    },
 }
 
 -- Console command -> systemId, so command refusals route through the same registry.

--- a/src/SaveLoadHandler.lua
+++ b/src/SaveLoadHandler.lua
@@ -56,6 +56,20 @@ function SaveLoadHandler:saveToXMLFile(xmlFile)
     if not self.isInitialized then return end
     if xmlFile == nil then return end
 
+    -- SCS-039: the value map SAVES NATIVELY, per the ratified persistence
+    -- posture. The per-field scalar rows written below stay exactly as they are
+    -- and become the DEGRADE layer: if the .grle is missing or refuses to load,
+    -- the field scalars still restore and the cell store carries the save.
+    local soilSystemForMap = self.manager ~= nil and self.manager.soilSystem or nil
+    if soilSystemForMap ~= nil and soilSystemForMap.valueMap ~= nil
+       and soilSystemForMap.valueMap.available then
+        local sgDir = g_currentMission ~= nil and g_currentMission.missionInfo ~= nil
+            and g_currentMission.missionInfo.savegameDirectory or nil
+        if sgDir ~= nil then
+            soilSystemForMap.valueMap:saveToSavegame(sgDir)
+        end
+    end
+
     local root = "careerSavegame.cropStress"
 
     -- Helper functions that work with both object and global APIs

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -172,11 +172,32 @@ end
 --- carrying the moisture truth, false when the cell store still is.
 function SoilMoistureSystem:initValueMap(savegameDir)
     if self.valueMap ~= nil then return self.valueMap.available end
+    -- Once it has declined it stays declined for the session. Without this the
+    -- nil-on-failure below would make every caller retry the whole engine probe.
+    if self._valueMapTried then return false end
+    self._valueMapTried = true
     if CropStressValueMap == nil then return false end
+
+    -- SCS-039 ships LOCKED. Until the in-game layer look clears it, the map only
+    -- stands up for a player who has opted into experimental systems; everyone
+    -- else runs the shipped cell store, which is exactly today.
+    if ReleaseGate ~= nil and ReleaseGate.isSystemLive ~= nil
+       and not ReleaseGate.isSystemLive("cs_grid_concordance") then
+        csLog("Moisture: the 2m value map is release-gated off; using the cell store")
+        return false
+    end
+
     self.valueMap = CropStressValueMap.new()
     local ok = self.valueMap:initialize(savegameDir)
     if ok then
         csLog("Moisture: the 2m value map is live; the cell store is now the fallback only")
+    else
+        -- THE DEGRADE, and it is the whole reason the scalar rows stay in the
+        -- savegame. A map that cannot stand up (no engine, or a .grle that is
+        -- missing or refuses to load) leaves the cell store and its per-field
+        -- scalars carrying the save, with nothing lost but the sub-field detail.
+        csLog("Moisture: the 2m value map declined; the cell store and its scalars carry this save")
+        self.valueMap = nil
     end
     return ok
 end
@@ -326,10 +347,21 @@ function SoilMoistureSystem:enumerateFields()
     return count
 end
 
--- Called every in-game hour
-function SoilMoistureSystem:hourlyUpdate(weather)
+--- Called every in-game hour.
+---
+--- SCS-037 COMPOSITION SEAM: `elapsedHours` defaults to 1, which is exactly
+--- today's behaviour. SCS-037 replaces the hourly EDGE DETECTOR with a real
+--- elapsed count, and when it lands it passes that count here and this path
+--- integrates it without any further change. The map's pending-delta
+--- accumulator is what makes that safe: a 72-hour catch-up is 72 hours of
+--- weather added to the accumulator, which then spends whole raw steps once,
+--- rather than 72 separate sub-step writes that would each floor to nothing.
+---@param weather table
+---@param elapsedHours number|nil  hours since the last tick (default 1)
+function SoilMoistureSystem:hourlyUpdate(weather, elapsedHours)
     if not self.isInitialized then return end
     if weather == nil then return end
+    local hours = math.max(1, math.floor(elapsedHours or 1))
 
     -- SCS-018 RW unwind: SeasonalCropStress owns its whole moisture simulation.
     -- RealisticWeather remains a read-only WEATHER source through WeatherIntegration
@@ -366,15 +398,19 @@ function SoilMoistureSystem:hourlyUpdate(weather)
         -- sfEvapMod        = per-field organic matter modifier from FS25_SoilFertilizer (if present)
         --                    High OM (>5%) lowers evap; poor OM (<1%) raises it. Default 1.0.
         local sfEvapMod = sfHasEvap and sfInteg:getFieldEvapMod(fieldId) or 1.0
+        -- Every term below is a PER-HOUR quantity, so each is multiplied by the
+        -- elapsed count. At the default of 1 this is arithmetically identical to
+        -- what shipped; SCS-037 changes only what arrives in `hours`.
         local evapLoss = SoilMoistureSystem.BASE_EVAP_RATE
             * evapMultiplier
             * soilParams.evapMod
             * settingsEvapMult
             * sfEvapMod
+            * hours
 
         -- Rain gain (modulated by soil absorption)
-        local rainGain  = rainAmount * soilParams.rainAbsorb
-        local irrigGain = self.irrigationGains[fieldId] or 0.0
+        local rainGain  = rainAmount * soilParams.rainAbsorb * hours
+        local irrigGain = (self.irrigationGains[fieldId] or 0.0) * hours
 
         local prevMoisture = self:getFieldAggregate(data)
         -- SCS-039 MAP PATH. The hourly net is almost always SMALLER than one raw
@@ -734,13 +770,27 @@ function SoilMoistureSystem:settleDaily(boundariesCrossed)
     -- Re-deriving once a day makes the scalar self-correcting instead of
     -- slowly drifting away from the map it is supposed to describe.
     if self:mapActive() then
+        -- Instrumented: the brief's one open measurement is the in-game frame
+        -- cost of this pass, so it is measured rather than estimated. Read it
+        -- with csMapStats.
+        local t0 = (g_currentMission ~= nil and g_currentMission.time) or nil
+        local fields, blocks = 0, 0
         for fieldId, d in pairs(self.fieldData) do
-            self:_drainFieldOnMap(fieldId, days)
+            local drained = self:_drainFieldOnMap(fieldId, days)
+            if drained then
+                fields = fields + 1
+                blocks = blocks + (self._lastFieldBlocks or 0)
+            end
             local vx, vz, n = self:_getFieldVerts(fieldId)
             if vx ~= nil then
                 local mean = self.valueMap:readAverageOfPolygon(vx, vz, n)
                 if mean ~= nil then d.moisture = mean end
             end
+        end
+        self._lastSettleFields = fields
+        self._lastSettleBlocks = blocks
+        if t0 ~= nil and g_currentMission.time ~= nil then
+            self._lastSettleMs = g_currentMission.time - t0
         end
         self._lastSettledDay = (g_currentMission ~= nil and g_currentMission.environment ~= nil
             and g_currentMission.environment.currentMonotonicDay) or nil
@@ -830,6 +880,7 @@ function SoilMoistureSystem:_drainFieldOnMap(fieldId, days)
         end
         x = x + step
     end
+    self._lastFieldBlocks = count
     if count < 2 then return false end
 
     -- Pass 2: the drift. A block's share of the move is set by how far its
@@ -887,6 +938,77 @@ function SoilMoistureSystem.computeDrainageAdditions(heights, moistures, frac)
                        + (meanH - heights[i]) * SoilMoistureSystem.CELL_SENS)
     end
     return out
+end
+
+-- ============================================================
+-- SCS-039 MP DELIVERY: the server walks the map to a joining client a few rows
+-- per frame. Never in one payload: a 2048x2048 map is 4 MB of raw bytes, and
+-- sending it whole would stall the join for everyone already in the game.
+-- ============================================================
+SoilMoistureSystem.SYNC_ROWS_PER_FRAME = 8
+
+--- Queue the whole map for a connection. Safe to call for each joining client.
+function SoilMoistureSystem:queueMapSync(connection)
+    if not self:mapActive() or connection == nil then return false end
+    if g_server == nil then return false end
+    self._syncQueue = self._syncQueue or {}
+    self._syncQueue[#self._syncQueue + 1] = { conn = connection, nextRow = 0 }
+    return true
+end
+
+--- Drive the queue. Called from the manager's per-frame update on the server.
+--- Returns the number of rows sent this frame (0 when there is nothing to do),
+--- which is also what makes the cost visible to the instrument below.
+function SoilMoistureSystem:updateMapSync()
+    local q = self._syncQueue
+    if q == nil or #q == 0 then return 0 end
+    if not self:mapActive() then
+        self._syncQueue = nil
+        return 0
+    end
+
+    local job = q[1]
+    local total = self.valueMap:getSyncRowCount()
+    local sent = 0
+    while sent < SoilMoistureSystem.SYNC_ROWS_PER_FRAME and job.nextRow < total do
+        local raw = self.valueMap:readSyncRow(job.nextRow)
+        if raw ~= nil and CropStressMoistureRowEvent ~= nil then
+            local packed = CropStressValueMap.packRow(raw)
+            g_server:sendEvent(CropStressMoistureRowEvent.new(job.nextRow, packed),
+                false, nil, job.conn)
+        end
+        job.nextRow = job.nextRow + 1
+        sent = sent + 1
+    end
+
+    if job.nextRow >= total then
+        table.remove(q, 1)
+        csLog(string.format("Moisture map: delivered %d rows to a client", total))
+    end
+    self._syncTotalRowsSent = (self._syncTotalRowsSent or 0) + sent
+    return sent
+end
+
+-- ============================================================
+-- SCS-039 THE FRAME-COST INSTRUMENT (the brief's one named open measurement).
+-- Nothing here changes behaviour; it makes the cost the brief asked K to
+-- measure READABLE in-game instead of guessed at, via csMapStats.
+-- ============================================================
+function SoilMoistureSystem:getMapStats()
+    local s = {
+        active         = self:mapActive(),
+        settleMs       = self._lastSettleMs,
+        settleBlocks   = self._lastSettleBlocks,
+        settleFields   = self._lastSettleFields,
+        syncRowsSent   = self._syncTotalRowsSent or 0,
+        syncPending    = (self._syncQueue ~= nil) and #self._syncQueue or 0,
+        seededFields   = 0,
+    }
+    for _ in pairs(self._mapSeeded or {}) do s.seededFields = s.seededFields + 1 end
+    if self.valueMap ~= nil and self.valueMap.getDebugStats ~= nil then
+        s.map = self.valueMap:getDebugStats()
+    end
+    return s
 end
 
 -- Register the daily accrual with Time Guard when present (server only).

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -152,8 +152,106 @@ function SoilMoistureSystem.new(manager)
     self._tgAccrualRegistered = false
     self._lastSettledDay = nil
 
+    -- SCS-039: the vendored 2 m value map. nil until initValueMap runs, and
+    -- still inert afterwards on any install where the engine cannot carry it.
+    -- Every branch below tests mapActive(); when it is false NOTHING changes and
+    -- the sparse-cell store above is the whole system, bit for bit.
+    self.valueMap = nil
+    self._fieldVerts = {}      -- fieldId -> {vx, vz, n}, cached polygon
+    self._mapSeeded  = {}      -- fieldId -> true once migrated onto the map
+
     self.isInitialized = false
     return self
+end
+
+-- ============================================================
+-- SCS-039 THE VALUE MAP: detection, and the one test every branch uses.
+-- ============================================================
+
+--- Stand the map up. Safe to call more than once. Returns true when the map is
+--- carrying the moisture truth, false when the cell store still is.
+function SoilMoistureSystem:initValueMap(savegameDir)
+    if self.valueMap ~= nil then return self.valueMap.available end
+    if CropStressValueMap == nil then return false end
+    self.valueMap = CropStressValueMap.new()
+    local ok = self.valueMap:initialize(savegameDir)
+    if ok then
+        csLog("Moisture: the 2m value map is live; the cell store is now the fallback only")
+    end
+    return ok
+end
+
+--- THE SINGLE DELEGATE TEST. Read it as "is the map carrying the truth".
+function SoilMoistureSystem:mapActive()
+    return self.valueMap ~= nil and self.valueMap.available == true
+end
+
+--- Field polygon in world space, cached. The map's region ops need it on every
+--- hourly write, and rebuilding it per tick from scene nodes would be wasteful.
+function SoilMoistureSystem:_getFieldVerts(fieldId)
+    local cached = self._fieldVerts[fieldId]
+    if cached ~= nil then
+        if cached.n == 0 then return nil end
+        return cached.vx, cached.vz, cached.n
+    end
+    local field = nil
+    if g_fieldManager ~= nil and g_fieldManager.fields ~= nil then
+        for _, f in pairs(g_fieldManager.fields) do
+            if f.farmland ~= nil and f.farmland.id == fieldId then
+                field = f
+                break
+            end
+        end
+    end
+    local vx, vz, n = nil, nil, nil
+    if field ~= nil then
+        vx, vz, n = self:getFieldPolygonWorld(field)
+    end
+    if vx == nil or n == nil or n < 3 then
+        -- Cache the refusal too, or every tick re-walks the field list.
+        self._fieldVerts[fieldId] = { n = 0 }
+        return nil
+    end
+    self._fieldVerts[fieldId] = { vx = vx, vz = vz, n = n }
+    return vx, vz, n
+end
+
+--- ONE-TIME MIGRATION (brief step 4): seed the map from whatever the cell store
+--- already knows, once per field, at the first engine-present load.
+---
+--- CLAMP-HONEST: the field is painted at its aggregate first so no pixel is left
+--- at the raw-0 no-data sentinel, then each materialised cell stamps its own
+--- value over the top. Totals are preserved up to each tier's clamp, which is
+--- the most that can be promised when 10-40 m cells land on a 2 m grid.
+function SoilMoistureSystem:migrateFieldToMap(fieldId)
+    if not self:mapActive() then return false end
+    if self._mapSeeded[fieldId] then return true end
+    local d = self.fieldData[fieldId]
+    if d == nil then return false end
+    local vx, vz, n = self:_getFieldVerts(fieldId)
+    if vx == nil then return false end
+
+    self._mapSeeded[fieldId] = true
+    local base = self:getFieldAggregate(d) or 0.5
+    self.valueMap:paintPolygon(vx, vz, n, base)
+
+    -- Stamp the materialised cells over the base coat. Absent cells were always
+    -- "read the aggregate", and the base coat is exactly that, so nothing is lost.
+    local cs = self:getCellSize()
+    local stamped = 0
+    if d.cells ~= nil then
+        for cx, row in pairs(d.cells) do
+            for cz, cell in pairs(row) do
+                local wx = (cx + 0.5) * cs
+                local wz = (cz + 0.5) * cs
+                self.valueMap:writeValueAtWorld(wx, wz, cell.moisture, cs * 0.5)
+                stamped = stamped + 1
+            end
+        end
+    end
+    csLog(string.format("Moisture map: field %d migrated (base=%.2f, %d cells stamped)",
+        fieldId, base, stamped))
+    return true
 end
 
 function SoilMoistureSystem:initialize()
@@ -279,10 +377,35 @@ function SoilMoistureSystem:hourlyUpdate(weather)
         local irrigGain = self.irrigationGains[fieldId] or 0.0
 
         local prevMoisture = self:getFieldAggregate(data)
-        -- SCS-018: where cells exist, run the same weather per-cell through the
-        -- single write path; the aggregate follows. Where no cell exists, the
-        -- field scalar moves exactly as before.
-        if data.cellCount ~= nil and data.cellCount > 0 then
+        -- SCS-039 MAP PATH. The hourly net is almost always SMALLER than one raw
+        -- step (one step is ~0.0039 moisture), so writing it straight through
+        -- would floor to nothing every hour and the ground would stop answering
+        -- the weather entirely. Accumulate instead, and spend only whole steps.
+        -- The remainder is carried, so nothing is lost and nothing is invented.
+        if self:mapActive() then
+            self:migrateFieldToMap(fieldId)
+            local net = -evapLoss + rainGain + irrigGain
+            local pending = (data.mapPending or 0) + net
+            local applied, remainder = CropStressValueMap.quantiseDelta(pending)
+            data.mapPending = remainder
+            if applied ~= 0 then
+                local vx, vz, n = self:_getFieldVerts(fieldId)
+                if vx ~= nil then
+                    local moved = self.valueMap:applyDeltaToPolygon(vx, vz, n, applied)
+                    if moved == 0 then
+                        -- The engine refused the add path. Give the delta back to
+                        -- the accumulator rather than dropping it on the floor.
+                        data.mapPending = pending
+                    else
+                        -- applyDeltaToPolygon shifts every written pixel by the
+                        -- same amount, so the field mean moves by exactly that.
+                        -- The daily settle re-derives from the map and corrects
+                        -- any drift the positional writes introduce.
+                        data.moisture = math.max(0.0, math.min(1.0, data.moisture + moved))
+                    end
+                end
+            end
+        elseif data.cellCount ~= nil and data.cellCount > 0 then
             local net = -evapLoss + rainGain + irrigGain
             local newSum = 0
             for cx, row in pairs(data.cells) do
@@ -342,19 +465,35 @@ end
 -- With a world position, returns the cell moisture where a cell exists,
 -- else the field aggregate (SCS-018 positional getter, never nil).
 -- Without a position, returns the derived aggregate.
+--- SCS-039 THE CONCORDANCE: every read now also reports the GRAIN it was
+--- measured at, in metres, as a second return. A consumer that cares can tell a
+--- 2 m map reading from a 10-40 m cell reading; one that does not care ignores
+--- the extra value and behaves exactly as it always has. That additive shape is
+--- why all six existing consumers are untouched.
+---@return number|nil moisture 0..1
+---@return number|nil grainMetres
 function SoilMoistureSystem:getMoisture(fieldId, x, z)
     local d = self.fieldData[fieldId]
-    if d == nil then return nil end
+    if d == nil then return nil, nil end
 
     if x ~= nil and z ~= nil then
+        if self:mapActive() then
+            local v, grain = self.valueMap:readValueAtWorld(x, z)
+            -- nil means nothing is written at that pixel (off-field or not yet
+            -- seeded), which is the aggregate's job to answer, not a hole.
+            if v ~= nil then return v, grain end
+            return self:getFieldAggregate(d), grain
+        end
         local cx, cz = self:worldToCell(x, z)
         local row = d.cells and d.cells[cx]
         local cell = row and row[cz]
-        if cell ~= nil then return cell.moisture end
-        return self:getFieldAggregate(d)
+        if cell ~= nil then return cell.moisture, self:getCellSize() end
+        return self:getFieldAggregate(d), self:getCellSize()
     end
 
-    return self:getFieldAggregate(d)
+    -- Field-level read: the scalar is the derived aggregate either way, so the
+    -- grain reported is the field itself rather than any cell size.
+    return self:getFieldAggregate(d), nil
 end
 
 -- Derived field aggregate, O(1). Once a field has cells it is the mean of the
@@ -402,6 +541,25 @@ function SoilMoistureSystem:_writeFieldMoisture(fieldId, newValue)
     local d = self.fieldData[fieldId]
     if d == nil then return nil end
     newValue = math.max(0.0, math.min(1.0, newValue or 0))
+
+    -- SCS-039: a field-level set must reach the MAP, or the daily re-derive
+    -- reads the untouched ground back over it and the write silently reverts.
+    -- That would make csSetMoisture and the sprayer path look like they worked
+    -- for a few hours and then undo themselves, which is worse than refusing.
+    if self:mapActive() then
+        self:migrateFieldToMap(fieldId)
+        local vx, vz, n = self:_getFieldVerts(fieldId)
+        if vx ~= nil then
+            self.valueMap:paintPolygon(vx, vz, n, newValue)
+        end
+        -- The scalar is the derived aggregate, and a uniform paint makes the
+        -- mean exactly the painted value. Any carried sub-step delta is now
+        -- stale: it was accumulated against ground that no longer exists.
+        d.mapPending = 0
+        d.moisture = newValue
+        return newValue
+    end
+
     if d.cellCount ~= nil and d.cellCount > 0 then
         local delta = newValue - self:getFieldAggregate(d)
         for _, row in pairs(d.cells) do
@@ -524,6 +682,23 @@ end
 function SoilMoistureSystem:applyWaterAtCell(fieldId, x, z, gain)
     local d = self.fieldData[fieldId]
     if d == nil or gain <= 0 then return end
+
+    -- SCS-039: water lands on a PLACE, and on the map that place is a 2 m pixel
+    -- instead of a 10-40 m cell. Read what is there, add the gain, write it back.
+    -- No accumulator here: an irrigation gain at a point is a real quantity at a
+    -- real spot, not a field-wide sub-step drift, and the pivot's own pass writes
+    -- enough water to clear the floor.
+    if self:mapActive() then
+        self:migrateFieldToMap(fieldId)
+        local current = self.valueMap:readValueAtWorld(x, z)
+        if current == nil then current = self:getFieldAggregate(d) or 0 end
+        local grain = self.valueMap:getGrainMetres() or 2
+        self.valueMap:writeValueAtWorld(x, z, math.max(0.0, math.min(1.0, current + gain)), grain * 0.5)
+        -- The field aggregate is re-derived from the map on the daily settle;
+        -- a single pixel's gain is below the noise of the field mean until then.
+        return
+    end
+
     local cx, cz = self:worldToCell(x, z)
     local row = d.cells[cx]
     if row == nil then
@@ -551,6 +726,26 @@ end
 -- ============================================================
 function SoilMoistureSystem:settleDaily(boundariesCrossed)
     local days = math.max(1, boundariesCrossed or 1)
+
+    -- SCS-039: on the map, the daily settle is also where the field scalar is
+    -- RE-DERIVED from the ground rather than trusted. The hourly path keeps it
+    -- exact for uniform shifts, but positional writes (a pivot wetting its
+    -- circle) move the real mean by an area fraction we do not track per write.
+    -- Re-deriving once a day makes the scalar self-correcting instead of
+    -- slowly drifting away from the map it is supposed to describe.
+    if self:mapActive() then
+        for fieldId, d in pairs(self.fieldData) do
+            local vx, vz, n = self:_getFieldVerts(fieldId)
+            if vx ~= nil then
+                local mean = self.valueMap:readAverageOfPolygon(vx, vz, n)
+                if mean ~= nil then d.moisture = mean end
+            end
+        end
+        self._lastSettledDay = (g_currentMission ~= nil and g_currentMission.environment ~= nil
+            and g_currentMission.environment.currentMonotonicDay) or nil
+        return
+    end
+
     for fieldId, d in pairs(self.fieldData) do
         if d.cellCount ~= nil and d.cellCount > 0 then
             -- Drainage: bleed a fraction of each cell's moisture toward its

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -735,6 +735,7 @@ function SoilMoistureSystem:settleDaily(boundariesCrossed)
     -- slowly drifting away from the map it is supposed to describe.
     if self:mapActive() then
         for fieldId, d in pairs(self.fieldData) do
+            self:_drainFieldOnMap(fieldId, days)
             local vx, vz, n = self:_getFieldVerts(fieldId)
             if vx ~= nil then
                 local mean = self.valueMap:readAverageOfPolygon(vx, vz, n)
@@ -774,6 +775,118 @@ function SoilMoistureSystem:settleDaily(boundariesCrossed)
     end
     self._lastSettledDay = (g_currentMission ~= nil and g_currentMission.environment ~= nil
         and g_currentMission.environment.currentMonotonicDay) or nil
+end
+
+-- ============================================================
+-- SCS-039 CONSERVED DRAINAGE ON THE MAP (brief step 4 / the geometry audit's
+-- build law). Water moves DOWNHILL and the field total does not change.
+--
+-- FRESH HEIGHT READS EVERY TIME, and that is the audit's law rather than a
+-- preference: terrain is deformable (levelling placeables, rice fields), so a
+-- cached relief picture goes stale the day a player reshapes the ground and
+-- then drains water toward a hollow that no longer exists.
+--
+-- Conservation is by construction, the same additive shape the rest of this
+-- work uses: every block's drift is measured against the block mean, so the
+-- drifts sum to zero and the field total cannot move. Drainage only ever
+-- REDISTRIBUTES; evaporation and rain are the hourly path's job.
+-- ============================================================
+SoilMoistureSystem.MAP_DRAIN_BLOCK      = 16     -- metres per sampled block
+SoilMoistureSystem.MAP_DRAIN_MAX_BLOCKS = 400    -- per field, per settle
+
+function SoilMoistureSystem:_drainFieldOnMap(fieldId, days)
+    if not self:mapActive() then return false end
+    if getTerrainHeightAtWorldPos == nil or g_terrainNode == nil then return false end
+    local vx, vz, n = self:_getFieldVerts(fieldId)
+    if vx == nil then return false end
+
+    local step = SoilMoistureSystem.MAP_DRAIN_BLOCK
+    local half = step * 0.5
+    local minX, maxX, minZ, maxZ = math.huge, -math.huge, math.huge, -math.huge
+    for i = 1, n do
+        if vx[i] < minX then minX = vx[i] end
+        if vx[i] > maxX then maxX = vx[i] end
+        if vz[i] < minZ then minZ = vz[i] end
+        if vz[i] > maxZ then maxZ = vz[i] end
+    end
+
+    -- Pass 1: sample the ground and the water at each block centre inside the
+    -- polygon. Both reads are fresh; neither is cached between settles.
+    local bx, bz, bh, bm = {}, {}, {}, {}
+    local count = 0
+    local x = minX + half
+    while x <= maxX and count < SoilMoistureSystem.MAP_DRAIN_MAX_BLOCKS do
+        local z = minZ + half
+        while z <= maxZ and count < SoilMoistureSystem.MAP_DRAIN_MAX_BLOCKS do
+            if csPointInPolygon(x, z, vx, vz, n) then
+                local ok, h = pcall(getTerrainHeightAtWorldPos, g_terrainNode, x, 0, z)
+                local m = self.valueMap:readValueAtWorld(x, z)
+                if ok and h ~= nil and m ~= nil then
+                    count = count + 1
+                    bx[count], bz[count], bh[count], bm[count] = x, z, h, m
+                end
+            end
+            z = z + step
+        end
+        x = x + step
+    end
+    if count < 2 then return false end
+
+    -- Pass 2: the drift. A block's share of the move is set by how far its
+    -- GROUND sits from the field's mean ground, so water leaves high blocks and
+    -- arrives at low ones; the amount it can give is bounded by how much water
+    -- it holds relative to the field's mean water, so a dry ridge cannot donate
+    -- water it does not have.
+    local sumH, sumM = 0, 0
+    for i = 1, count do
+        sumH = sumH + bh[i]
+        sumM = sumM + bm[i]
+    end
+    local meanH, meanM = sumH / count, sumM / count
+
+    local frac = math.min(0.5, SoilMoistureSystem.CELL_DRAIN_FRACTION * math.max(1, days))
+
+    -- TWO TERMS, AND EACH ONE SUMS TO ZERO ON ITS OWN, so their sum does too and
+    -- conservation needs no correction pass to rescue it:
+    --   waterTerm  = (meanM - m_i)  levels the water toward the field mean
+    --   reliefTerm = (meanH - h_i) * CELL_SENS  pushes it downhill, positive for
+    --                low ground, so a hollow gains and a ridge gives
+    -- Both are deviations from a mean over the same block set, which is exactly
+    -- why they are zero-sum for every possible field shape.
+    for i = 1, count do
+        local waterTerm  = (meanM - bm[i])
+        local reliefTerm = (meanH - bh[i]) * SoilMoistureSystem.CELL_SENS
+        local addition   = frac * (waterTerm + reliefTerm)
+        -- The write clamps to 0..1. On a field already sitting at a bound the
+        -- clamp absorbs part of the move, which is the known clamp residual and
+        -- the one place conservation is approximate rather than exact.
+        self.valueMap:writeValueAtWorld(bx[i], bz[i], bm[i] + addition, half)
+    end
+    return true
+end
+
+--- The drainage maths, pure and engine-free so the bench can prove the two
+--- claims that matter: the additions sum to zero (the field total does not
+--- move) and low ground gains while high ground gives.
+---@param heights number[]   terrain height per block
+---@param moistures number[] current moisture per block
+---@param frac number        settle fraction for the elapsed days
+---@return number[] additions  signed moisture change per block
+function SoilMoistureSystem.computeDrainageAdditions(heights, moistures, frac)
+    local n = heights and #heights or 0
+    if n < 2 or moistures == nil or #moistures ~= n then return nil end
+    local sumH, sumM = 0, 0
+    for i = 1, n do
+        sumH = sumH + heights[i]
+        sumM = sumM + moistures[i]
+    end
+    local meanH, meanM = sumH / n, sumM / n
+    local out = {}
+    for i = 1, n do
+        out[i] = frac * ((meanM - moistures[i])
+                       + (meanH - heights[i]) * SoilMoistureSystem.CELL_SENS)
+    end
+    return out
 end
 
 -- Register the daily accrual with Time Guard when present (server only).

--- a/src/events/CropStressMoistureRowEvent.lua
+++ b/src/events/CropStressMoistureRowEvent.lua
@@ -1,0 +1,82 @@
+-- ============================================================
+-- CropStressMoistureRowEvent.lua  (SCS-039 / GRID-1)
+--
+-- Carries ONE ROW of the 2 m moisture value map from server to client.
+--
+-- WHY A ROW AND NOT A SNAPSHOT: at 2 m/px a 4096 m map is 2048x2048 pixels,
+-- which is 4 MB of raw bytes. No single event carries that, and trying would
+-- stall the join. The server walks the map a row at a time, frame-budgeted, and
+-- the client fills in behind it.
+--
+-- Rows travel as RAW values, run-length packed. Raw means nothing is
+-- re-quantised in flight, so a client's pixels end up bit-identical to the
+-- server's rather than a rounding generation behind. Run-length matters because
+-- a moisture map is overwhelmingly long runs: a field at a uniform level, and
+-- the entire off-field remainder sitting at the raw-0 sentinel.
+--
+-- Wire format:
+--   rowIndex : UInt16
+--   runCount : UInt16
+--   per run:  length UInt16, value UInt8
+-- ============================================================
+
+local function csLog(msg)
+    if g_logManager ~= nil then
+        g_logManager:devInfo("[CropStress]", msg)
+    else
+        print("[CropStress] " .. tostring(msg))
+    end
+end
+
+CropStressMoistureRowEvent = {}
+CropStressMoistureRowEvent_mt = Class(CropStressMoistureRowEvent, Event)
+
+InitEventClass(CropStressMoistureRowEvent, "CropStressMoistureRowEvent")
+
+--- @param rowIndex number  map row (0-based)
+--- @param packed table     run-length pairs from CropStressValueMap.packRow
+function CropStressMoistureRowEvent.new(rowIndex, packed)
+    local self = Event.new(CropStressMoistureRowEvent_mt)
+    self.rowIndex = rowIndex or 0
+    self.packed   = packed or {}
+    return self
+end
+
+function CropStressMoistureRowEvent:writeStream(streamId, connection)
+    streamWriteUInt16(streamId, self.rowIndex)
+    local runs = math.floor(#self.packed / 2)
+    streamWriteUInt16(streamId, runs)
+    for i = 1, runs do
+        local length = self.packed[(i - 1) * 2 + 1] or 0
+        local value  = self.packed[(i - 1) * 2 + 2] or 0
+        streamWriteUInt16(streamId, math.max(0, math.min(65535, length)))
+        streamWriteUInt8(streamId, math.max(0, math.min(255, value)))
+    end
+end
+
+function CropStressMoistureRowEvent:readStream(streamId, connection)
+    self.rowIndex = streamReadUInt16(streamId)
+    local runs = streamReadUInt16(streamId)
+    self.packed = {}
+    for _ = 1, runs do
+        local length = streamReadUInt16(streamId)
+        local value  = streamReadUInt8(streamId)
+        self.packed[#self.packed + 1] = length
+        self.packed[#self.packed + 1] = value
+    end
+    self:run(connection)
+end
+
+function CropStressMoistureRowEvent:run(connection)
+    -- The server is the authority and never applies a row it sent itself.
+    if g_server ~= nil then return end
+
+    local mgr = g_cropStressManager
+    local soilSystem = mgr and mgr.soilSystem
+    if soilSystem == nil or soilSystem.valueMap == nil then return end
+    local vm = soilSystem.valueMap
+    if not vm.available then return end
+
+    local row = CropStressValueMap.unpackRow(self.packed, vm.resolution)
+    vm:applySyncRow(self.rowIndex, row)
+end

--- a/src/maps/CropStressValueMap.lua
+++ b/src/maps/CropStressValueMap.lua
@@ -375,14 +375,20 @@ end
 ---@return number|nil grain  metres per pixel (the concordance)
 function CropStressValueMap:readAverageOfPolygon(vx, vz, n)
     if not self.available then return nil, nil end
-    if getDensityMapModifierStats == nil then return nil, nil end
+    local m = self.modifier
+    if m == nil or m.executeGet == nil then return nil, nil end
     if not self:_setPolygonRegion(vx, vz, n) then return nil, nil end
-    local ok, total, area = pcall(function()
-        return self.modifier:executeGet()
+    -- executeGet returns (accumulator, numPixels, totalArea), confirmed at the
+    -- decompile: PrecisionFarming NitrogenMap.lua:1034 reads it as
+    -- `local acc, numPixels, _ = modifierFruit:executeGet()`. The mean we want
+    -- is over WRITTEN pixels, so numPixels is the divisor, never totalArea.
+    local ok, acc, numPixels = pcall(function()
+        return m:executeGet()
     end)
-    if not ok or area == nil or area == 0 then return nil, nil end
-    local meanRaw = total / area
-    return decode(meanRaw, CropStressValueMap.LAYER_DEF), self:getGrainMetres()
+    if not ok or acc == nil or numPixels == nil or numPixels == 0 then
+        return nil, nil
+    end
+    return decode(acc / numPixels, CropStressValueMap.LAYER_DEF), self:getGrainMetres()
 end
 
 function CropStressValueMap:getDebugStats()

--- a/src/maps/CropStressValueMap.lua
+++ b/src/maps/CropStressValueMap.lua
@@ -391,6 +391,95 @@ function CropStressValueMap:readAverageOfPolygon(vx, vz, n)
     return decode(acc / numPixels, CropStressValueMap.LAYER_DEF), self:getGrainMetres()
 end
 
+-- ─────────────────────────────────────────────────────────
+-- MULTIPLAYER DELIVERY (brief step 5, the six-layer precedent)
+--
+-- The server owns the moisture truth; a client allocates the same map and is
+-- filled a ROW AT A TIME rather than in one payload, because a 2048x2048 map is
+-- 4 MB of raw bytes and no single event carries that. Rows are raw values, so
+-- nothing is re-quantised in flight and a client's pixels are bit-identical to
+-- the server's.
+-- ─────────────────────────────────────────────────────────
+
+function CropStressValueMap:getSyncRowCount()
+    if not self.available then return 0 end
+    return self.resolution
+end
+
+--- Read one row of RAW values off the map. Returns nil when unavailable so the
+--- caller can stop rather than send a row of zeros that would erase a client.
+function CropStressValueMap:readSyncRow(gy)
+    if not self.available then return nil end
+    if getBitVectorMapPoint == nil then return nil end
+    if gy == nil or gy < 0 or gy >= self.resolution then return nil end
+    local row = {}
+    for gx = 0, self.resolution - 1 do
+        local ok, raw = pcall(getBitVectorMapPoint, self.bvm, gx, gy, 0, NUM_CHANNELS)
+        row[gx + 1] = (ok and raw) or 0
+    end
+    return row
+end
+
+--- Apply one received row. Client side only in practice, but it is written as a
+--- plain map operation so the bench can drive it without a network.
+function CropStressValueMap:applySyncRow(gy, row)
+    if not self.available or row == nil then return false end
+    if setBitVectorMapPoint == nil then return false end
+    if gy == nil or gy < 0 or gy >= self.resolution then return false end
+    local limit = math.min(#row, self.resolution)
+    for i = 1, limit do
+        local raw = row[i] or 0
+        pcall(setBitVectorMapPoint, self.bvm, i - 1, gy, 0, NUM_CHANNELS, raw)
+    end
+    return true
+end
+
+--- Pack a raw row into a compact run-length form for the wire. Moisture maps are
+--- overwhelmingly runs of one value (a field at a uniform level, and the whole
+--- off-field remainder at the raw-0 sentinel), so this is the difference between
+--- a sane join and a stall. Falls back to nothing clever when the row is noisy.
+---@return table pairs  flat {count, value, count, value, ...}
+function CropStressValueMap.packRow(row)
+    local out = {}
+    if row == nil or #row == 0 then return out end
+    local runValue = row[1]
+    local runLen   = 1
+    for i = 2, #row do
+        local v = row[i]
+        if v == runValue and runLen < 65535 then
+            runLen = runLen + 1
+        else
+            out[#out + 1] = runLen
+            out[#out + 1] = runValue
+            runValue = v
+            runLen = 1
+        end
+    end
+    out[#out + 1] = runLen
+    out[#out + 1] = runValue
+    return out
+end
+
+--- Inverse of packRow. Never trusts the payload: a malformed or hostile run
+--- table cannot make this allocate past the map's own width.
+function CropStressValueMap.unpackRow(packed, width)
+    local row = {}
+    if packed == nil then return row end
+    local n = 0
+    local i = 1
+    while i < #packed do
+        local count = packed[i] or 0
+        local value = packed[i + 1] or 0
+        i = i + 2
+        for _ = 1, count do
+            if width ~= nil and n >= width then return row end
+            n = n + 1
+            row[n] = value
+        end
+    end
+    return row
+end
+
 function CropStressValueMap:getDebugStats()
     return {
         available   = self.available,

--- a/src/maps/CropStressValueMap.lua
+++ b/src/maps/CropStressValueMap.lua
@@ -1,0 +1,399 @@
+-- ============================================================
+-- CropStressValueMap.lua  (SCS-039 / GRID-1)
+--
+-- THE VENDORED MOISTURE VALUE MAP: one 8-bit layer at engine grain
+-- (2 m/px on 2048-4096 m maps, 4 m at 16x), so soil moisture is measured
+-- by the same ruler as the rest of the ground instead of the 10-40 m Lua
+-- cell store.
+--
+-- HOSTING IS VENDORED BY RULING (TysonK): SeasonalCropStress carries its
+-- own value-map machinery rather than registering a layer inside
+-- SoilFertilizer. SF has no layer-registration door (its LAYER_DEFS is a
+-- static table), and cross-mod writes would breach the firewall. SCS is
+-- the SOLE writer of this map; SF's own layers are never touched.
+--
+-- ENGINE-ABSENT IS TODAY, EXACTLY. When the bit-vector API or the terrain
+-- node is missing, `available` stays false, every method is inert, and the
+-- shipped sparse-cell store in SoilMoistureSystem carries on bit for bit.
+--
+-- THE QUANTISATION FLOOR, and it is the reason this file exists in this
+-- shape: moisture spans 0..1 across 254 raw steps, so ONE RAW STEP IS
+-- ~0.0039 MOISTURE. An hourly rain or evaporation delta is routinely
+-- smaller than that, and a naive per-hour write floors to zero every time:
+-- twenty four of them move the map by NOTHING. Callers MUST accumulate
+-- sub-step deltas through quantiseDelta() and apply only whole raw steps.
+-- That is a correctness law, not an optimisation.
+-- ============================================================
+
+CropStressValueMap = {}
+local CropStressValueMap_mt = Class(CropStressValueMap)
+
+-- The single layer. Moisture is a 0..1 fraction, so unitsPerRaw is 1/254.
+CropStressValueMap.LAYER_DEF = {
+    key    = "moisture",
+    file   = "csMoistureMap.grle",
+    minVal = 0.0,
+    maxVal = 1.0,
+}
+
+local NUM_CHANNELS = 8      -- bits per pixel
+local RAW_MIN      = 1      -- raw 0 is reserved as "no data" / off-field
+local RAW_MAX      = 255
+local RAW_SPAN     = RAW_MAX - RAW_MIN   -- 254 usable steps
+
+CropStressValueMap.RAW_MIN  = RAW_MIN
+CropStressValueMap.RAW_MAX  = RAW_MAX
+CropStressValueMap.RAW_SPAN = RAW_SPAN
+
+-- Map resolution: half the terrain size, so 2 m/px on a 2048-4096 m map and
+-- 4 m/px once a 16x map is capped. This is the SAME formula SoilFertilizer's
+-- engine uses, which is the whole point of the concordance: one ruler.
+local MIN_RESOLUTION = 1024
+local MAX_RESOLUTION = 4096
+
+local function csvmLog(msg)
+    if g_logManager ~= nil then
+        g_logManager:devInfo("[CropStress]", msg)
+    else
+        print("[CropStress] " .. tostring(msg))
+    end
+end
+
+-- ─────────────────────────────────────────────────────────
+-- Encode / decode. Pure, and exposed as test seams.
+-- ─────────────────────────────────────────────────────────
+
+local function encode(value, def)
+    local clamped  = math.max(def.minVal, math.min(def.maxVal, value or def.minVal))
+    local fraction = (clamped - def.minVal) / (def.maxVal - def.minVal)
+    return RAW_MIN + math.floor(fraction * RAW_SPAN + 0.5)
+end
+
+local function decode(raw, def)
+    if raw == nil or raw <= 0 then return nil end   -- raw 0 is "no data"
+    local fraction = (raw - RAW_MIN) / RAW_SPAN
+    return def.minVal + fraction * (def.maxVal - def.minVal)
+end
+
+local function unitsPerRaw(def)
+    return (def.maxVal - def.minVal) / RAW_SPAN
+end
+
+CropStressValueMap._encode      = encode
+CropStressValueMap._decode      = decode
+CropStressValueMap._unitsPerRaw = unitsPerRaw
+
+--- THE QUANTISATION LAW (SCS-039, the moisture brief's first answered blocker).
+--- Split an accumulated semantic delta into the part that can actually move the
+--- map (a whole number of raw steps) and the sub-step remainder that must be
+--- carried forward.
+---
+--- Callers keep the returned remainder and hand it back next tick. Without this
+--- every hourly write smaller than one raw step is silently discarded by the
+--- floor, and a whole day of light rain lands as nothing at all.
+---
+--- Truncates toward zero in BOTH directions on purpose: a positive remainder
+--- must not become a negative applied step, and vice versa, or a field would
+--- oscillate around a value it never reaches.
+---@param pending number  accumulated semantic delta, including this tick's
+---@return number applied    semantic amount that maps to whole raw steps (may be 0)
+---@return number remainder  sub-step amount to carry into the next tick
+function CropStressValueMap.quantiseDelta(pending)
+    pending = pending or 0
+    local upr = unitsPerRaw(CropStressValueMap.LAYER_DEF)
+    local rawSteps
+    if pending >= 0 then
+        rawSteps = math.floor(pending / upr)
+    else
+        rawSteps = -math.floor(-pending / upr)
+    end
+    if rawSteps == 0 then return 0, pending end
+    local applied = rawSteps * upr
+    return applied, pending - applied
+end
+
+-- ─────────────────────────────────────────────────────────
+-- Construction and engine detection
+-- ─────────────────────────────────────────────────────────
+
+function CropStressValueMap.new()
+    local self = setmetatable({}, CropStressValueMap_mt)
+    self.initialized  = false
+    self.available    = false
+    self.bvm          = nil
+    self.modifier     = nil
+    self.filter       = nil
+    self.resolution   = 0
+    self.terrainSize  = 0
+    self.loadedFromSave = false
+    self.hasExecuteAdd  = true
+    self.hasPolygonOps  = true
+    return self
+end
+
+--- True when every engine entry point this map needs actually exists.
+--- Checked as capability rather than as a mod-presence test, so the map works
+--- on any install where the engine offers the API.
+local function engineCapable()
+    return createBitVectorMap ~= nil
+       and loadBitVectorMapNew ~= nil
+       and DensityMapModifier ~= nil
+       and DensityMapModifier.new ~= nil
+       and g_terrainNode ~= nil
+       and g_terrainNode ~= 0
+end
+
+function CropStressValueMap:initialize(savegameDir)
+    if self.initialized then return self.available end
+    self.initialized = true
+
+    if not engineCapable() then
+        csvmLog("Moisture map: bit-vector API or terrain node unavailable; using the cell-store fallback")
+        return false
+    end
+
+    self.terrainSize = getTerrainSize(g_terrainNode) or 0
+    if self.terrainSize <= 0 then
+        csvmLog("Moisture map: getTerrainSize returned 0; using the cell-store fallback")
+        return false
+    end
+
+    self.resolution = math.max(MIN_RESOLUTION,
+                      math.min(MAX_RESOLUTION, math.floor(self.terrainSize / 2)))
+
+    local ok, err = pcall(function()
+        self.bvm = createBitVectorMap("CSMoistureMap")
+        if self.bvm == nil or self.bvm == 0 then
+            error("createBitVectorMap returned nothing")
+        end
+
+        local loaded = false
+        if savegameDir ~= nil and fileExists ~= nil then
+            local path = savegameDir .. "/" .. CropStressValueMap.LAYER_DEF.file
+            if fileExists(path) and loadBitVectorMapFromFile ~= nil then
+                loaded = loadBitVectorMapFromFile(self.bvm, path, NUM_CHANNELS) and true or false
+                if loaded and getBitVectorMapSize ~= nil then
+                    -- Adopt the persisted resolution: it may differ from the one
+                    -- computed above if the cap changed between versions, and the
+                    -- file is the authority for data already on disk.
+                    local w = getBitVectorMapSize(self.bvm)
+                    if w ~= nil and w > 0 then self.resolution = w end
+                end
+            end
+        end
+        if not loaded then
+            loadBitVectorMapNew(self.bvm, self.resolution, self.resolution, NUM_CHANNELS, false)
+        end
+        self.loadedFromSave = loaded
+
+        self.modifier = DensityMapModifier.new(self.bvm, 0, NUM_CHANNELS, g_terrainNode)
+        if DensityMapFilter ~= nil and DensityMapFilter.new ~= nil then
+            self.filter = DensityMapFilter.new(self.bvm, 0, NUM_CHANNELS)
+        end
+    end)
+
+    if not ok then
+        csvmLog(string.format("Moisture map: init failed (%s); using the cell-store fallback", tostring(err)))
+        if self.bvm ~= nil and self.bvm ~= 0 and delete ~= nil then
+            pcall(delete, self.bvm)
+        end
+        self.bvm = nil
+        self.modifier = nil
+        self.filter = nil
+        return false
+    end
+
+    self.available = true
+    csvmLog(string.format(
+        "Moisture map: %dx%d at %.1f m/px%s",
+        self.resolution, self.resolution, self:getGrainMetres(),
+        self.loadedFromSave and " [restored from savegame]" or " [fresh]"))
+    return true
+end
+
+--- THE CONCORDANCE'S TEETH: the grain, in metres, that any value read off this
+--- map was measured at. Every cross-grid read reports it alongside the value so
+--- a consumer can never silently mistake a 2 m reading for a 40 m one, or the
+--- reverse. Returns nil when the map is not carrying the data.
+function CropStressValueMap:getGrainMetres()
+    if not self.available or self.resolution <= 0 then return nil end
+    return self.terrainSize / self.resolution
+end
+
+function CropStressValueMap:delete()
+    if self.bvm ~= nil and self.bvm ~= 0 and delete ~= nil then
+        pcall(delete, self.bvm)
+    end
+    self.bvm = nil
+    self.modifier = nil
+    self.filter = nil
+    self.available = false
+end
+
+function CropStressValueMap:saveToSavegame(savegameDir)
+    if not self.available or savegameDir == nil then return false end
+    if saveBitVectorMapToFile == nil then return false end
+    local path = savegameDir .. "/" .. CropStressValueMap.LAYER_DEF.file
+    local ok = pcall(saveBitVectorMapToFile, self.bvm, path)
+    if not ok then
+        csvmLog("Moisture map: native save failed; the StateLedger scalar degrade carries this save")
+    end
+    return ok
+end
+
+-- ─────────────────────────────────────────────────────────
+-- Point reads and writes
+-- ─────────────────────────────────────────────────────────
+
+--- Read moisture at a world position.
+---@return number|nil value  0..1, or nil where nothing has been written
+---@return number|nil grain  metres per pixel of the reading (the concordance)
+function CropStressValueMap:readValueAtWorld(worldX, worldZ)
+    if not self.available then return nil, nil end
+    if getBitVectorMapPoint == nil then return nil, nil end
+    local px, pz = self:worldToPixel(worldX, worldZ)
+    if px == nil then return nil, nil end
+    local ok, raw = pcall(getBitVectorMapPoint, self.bvm, px, pz, 0, NUM_CHANNELS)
+    if not ok or raw == nil then return nil, nil end
+    return decode(raw, CropStressValueMap.LAYER_DEF), self:getGrainMetres()
+end
+
+--- World position to map pixel. Terrain is centred on the origin, so the
+--- half-size offset is what puts negative world coordinates in range.
+function CropStressValueMap:worldToPixel(worldX, worldZ)
+    if not self.available or self.terrainSize <= 0 then return nil, nil end
+    local half = self.terrainSize * 0.5
+    local px = math.floor((worldX + half) / self.terrainSize * self.resolution)
+    local pz = math.floor((worldZ + half) / self.terrainSize * self.resolution)
+    if px < 0 or pz < 0 or px >= self.resolution or pz >= self.resolution then
+        return nil, nil
+    end
+    return px, pz
+end
+
+--- Write a value over a square region centred on a world position.
+--- `radius` is in metres; it floors to one pixel so a point write is never a
+--- no-op on a coarse map.
+function CropStressValueMap:writeValueAtWorld(worldX, worldZ, value, radius)
+    if not self.available then return false end
+    local grain = self:getGrainMetres() or 2
+    local r = math.max(radius or 0, grain * 0.5)
+    local raw = encode(value, CropStressValueMap.LAYER_DEF)
+    return self:_setRegion(worldX - r, worldZ - r, worldX + r, worldZ + r, raw)
+end
+
+function CropStressValueMap:_setRegion(x0, z0, x1, z1, raw)
+    local m = self.modifier
+    if m == nil then return false end
+    local ok = pcall(function()
+        m:setParallelogramWorldCoords(x0, z0, x1, z0, x0, z1, DensityCoordType.POINT_POINT_POINT)
+        m:executeSet(raw)
+    end)
+    return ok
+end
+
+-- ─────────────────────────────────────────────────────────
+-- Polygon operations (the region ops the drainage and rain paths use)
+-- ─────────────────────────────────────────────────────────
+
+--- Bind the modifier to a field polygon. Returns false when engine polygon ops
+--- are unavailable or the polygon is malformed, so callers can fall back.
+function CropStressValueMap:_setPolygonRegion(vx, vz, n)
+    local m = self.modifier
+    if m == nil or not self.hasPolygonOps then return false end
+    if vx == nil or n == nil or n < 3 then return false end
+    if m.clearPolygonPoints == nil or m.addPolygonPointWorldCoords == nil then
+        self.hasPolygonOps = false
+        return false
+    end
+    local ok = pcall(function()
+        m:clearPolygonPoints()
+        for i = 1, n do
+            m:addPolygonPointWorldCoords(vx[i], vz[i])
+        end
+    end)
+    if not ok then
+        self.hasPolygonOps = false
+        return false
+    end
+    return true
+end
+
+--- Paint a whole field polygon to one value. Used by the one-time migration
+--- and by the flat-field seed.
+function CropStressValueMap:paintPolygon(vx, vz, n, value)
+    if not self.available then return false end
+    if not self:_setPolygonRegion(vx, vz, n) then return false end
+    local raw = encode(value, CropStressValueMap.LAYER_DEF)
+    return pcall(function() self.modifier:executeSet(raw) end)
+end
+
+--- Shift every written pixel of a field polygon by a WHOLE number of raw steps.
+--- The caller is responsible for having quantised the delta through
+--- quantiseDelta() first; a sub-step delta arriving here would floor to nothing.
+---@return number applied  semantic amount actually applied (0 when nothing moved)
+function CropStressValueMap:applyDeltaToPolygon(vx, vz, n, delta)
+    if not self.available or delta == nil or delta == 0 then return 0 end
+    local def = CropStressValueMap.LAYER_DEF
+    local upr = unitsPerRaw(def)
+    local rawDelta = (delta >= 0) and math.floor(delta / upr + 0.5)
+                                   or -math.floor(-delta / upr + 0.5)
+    if rawDelta == 0 then return 0 end
+    if not self.hasExecuteAdd then return 0 end
+    if not self:_setPolygonRegion(vx, vz, n) then return 0 end
+
+    local m = self.modifier
+    local f = self.filter
+    local ok = pcall(function()
+        if f ~= nil then
+            -- Only touch written pixels, and never push one past the raw range
+            -- (which would wrap into the raw-0 no-data sentinel and read as a
+            -- hole in the field rather than as wet or dry ground).
+            if rawDelta > 0 then
+                f:setValueCompareParams(DensityValueCompareType.BETWEEN, RAW_MIN, RAW_MAX - rawDelta)
+            else
+                f:setValueCompareParams(DensityValueCompareType.BETWEEN, RAW_MIN - rawDelta, RAW_MAX)
+            end
+            m:executeAdd(rawDelta, f)
+        else
+            m:executeAdd(rawDelta)
+        end
+    end)
+    if not ok then
+        csvmLog("Moisture map: executeAdd unavailable; disabling the add path")
+        self.hasExecuteAdd = false
+        return 0
+    end
+    return rawDelta * upr
+end
+
+--- The derived field aggregate: the mean of the written pixels inside a field
+--- polygon. This is what the field scalar becomes once the map is carrying the
+--- truth (the compaction precedent), rather than a separately maintained number
+--- that can drift from the ground it describes.
+---@return number|nil mean   0..1, nil when nothing is written in the polygon
+---@return number|nil grain  metres per pixel (the concordance)
+function CropStressValueMap:readAverageOfPolygon(vx, vz, n)
+    if not self.available then return nil, nil end
+    if getDensityMapModifierStats == nil then return nil, nil end
+    if not self:_setPolygonRegion(vx, vz, n) then return nil, nil end
+    local ok, total, area = pcall(function()
+        return self.modifier:executeGet()
+    end)
+    if not ok or area == nil or area == 0 then return nil, nil end
+    local meanRaw = total / area
+    return decode(meanRaw, CropStressValueMap.LAYER_DEF), self:getGrainMetres()
+end
+
+function CropStressValueMap:getDebugStats()
+    return {
+        available   = self.available,
+        resolution  = self.resolution,
+        terrainSize = self.terrainSize,
+        grainMetres = self:getGrainMetres(),
+        fromSave    = self.loadedFromSave,
+        executeAdd  = self.hasExecuteAdd,
+        polygonOps  = self.hasPolygonOps,
+        unitsPerRaw = unitsPerRaw(CropStressValueMap.LAYER_DEF),
+    }
+end

--- a/src/ui/CsMapHooks.lua
+++ b/src/ui/CsMapHooks.lua
@@ -4,9 +4,29 @@
 -- as a standard category tab (alongside Growth, Soil Type, etc.)
 -- =========================================================
 -- Pattern: mirrors FS25_SoilFertilizer SoilMapHooks.lua
+-- FAILFIX 2026-08-05: pairs(nil) Map freeze — nil-guards, coordinated
+-- mouseEvent chain with Soil, overwrite generateOverviewOverlay so
+-- custom page indices do not hit vanilla MAP_HOTSPOTS <= state fruit path.
 -- =========================================================
 
 CsMapHooks = {}
+
+local LOG_PREFIX = "[CropStress] CsMapHooks: "
+
+local function logNilOnce(key, msg)
+    if InGameMenuMapFrame == nil then
+        print(LOG_PREFIX .. msg)
+        return
+    end
+    if InGameMenuMapFrame._rfMapNilLog == nil then
+        InGameMenuMapFrame._rfMapNilLog = {}
+    end
+    if InGameMenuMapFrame._rfMapNilLog[key] then
+        return
+    end
+    InGameMenuMapFrame._rfMapNilLog[key] = true
+    print(LOG_PREFIX .. msg)
+end
 
 local function getCsOverlay(frame)
     if frame == nil then return nil end
@@ -20,9 +40,69 @@ local function isCsPageActive(frame)
     return frame.mapOverviewSelector:getState() == frame.csMoisturePageIndex
 end
 
+--- Ensure tables vanilla MapFrame pairs()/indexes are never nil.
+--- Shared with SoilMapHooks via InGameMenuMapFrame._rfMapNilLog (once-per-key).
+local function ensurePairsSafeTables(frame)
+    if frame == nil then
+        return
+    end
+
+    if frame.ingameMap ~= nil and frame.ingameMap.ingameMap ~= nil then
+        if frame.ingameMap.ingameMap.hotspots == nil then
+            frame.ingameMap.ingameMap.hotspots = {}
+            logNilOnce("hotspots", "ingameMap.ingameMap.hotspots was nil; guarded to {}")
+        end
+    end
+
+    if frame.subCategoryDotBox ~= nil and frame.subCategoryDotBox.elements == nil then
+        frame.subCategoryDotBox.elements = {}
+        logNilOnce("dotElements", "subCategoryDotBox.elements was nil; guarded to {}")
+    end
+
+    if frame.displayCropTypes == nil then
+        logNilOnce("displayCropTypes", "displayCropTypes is nil (loadFilters / onLoadMapFinished may not have run)")
+    end
+
+    local state = nil
+    if frame.mapOverviewSelector ~= nil then
+        state = frame.mapOverviewSelector:getState()
+    end
+    if state == nil then
+        return
+    end
+
+    if frame.dataTables ~= nil and frame.dataTables[state] == nil then
+        if frame.csMoisturePageIndex ~= nil and state == frame.csMoisturePageIndex then
+            local overlay = getCsOverlay(frame)
+            if overlay ~= nil then
+                frame.dataTables[state] = overlay:getDisplayValues() or {}
+            else
+                frame.dataTables[state] = {}
+            end
+            logNilOnce("dataTables_cs", string.format("dataTables[%s] was nil on CS page; filled", tostring(state)))
+        else
+            logNilOnce("dataTables_" .. tostring(state), string.format("dataTables[%s] is nil", tostring(state)))
+        end
+    end
+
+    if frame.filterStates ~= nil and frame.filterStates[state] == nil then
+        if frame.csMoisturePageIndex ~= nil and state == frame.csMoisturePageIndex then
+            local overlay = getCsOverlay(frame)
+            if overlay ~= nil then
+                frame.filterStates[state] = overlay:getDefaultFilterState() or {}
+            else
+                frame.filterStates[state] = {}
+            end
+            logNilOnce("filterStates_cs", string.format("filterStates[%s] was nil on CS page; filled", tostring(state)))
+        else
+            logNilOnce("filterStates_" .. tostring(state), string.format("filterStates[%s] is nil", tostring(state)))
+        end
+    end
+end
+
 local function updateSubCategoryDotBox(frame)
     if frame == nil or frame.subCategoryDotBox == nil or frame.mapSelectorTexts == nil then return end
-    local dotBox  = frame.subCategoryDotBox
+    local dotBox = frame.subCategoryDotBox
     local elements = dotBox.elements
     if elements == nil or #elements == 0 then return end
 
@@ -30,10 +110,12 @@ local function updateSubCategoryDotBox(frame)
     while #elements < expectedCount do
         dotBox:addElement(elements[1]:clone(dotBox))
         elements = dotBox.elements
+        if elements == nil then return end
     end
     while #elements > expectedCount do
         elements[#elements]:delete()
         elements = dotBox.elements
+        if elements == nil then return end
     end
     for i, dot in ipairs(dotBox.elements) do
         local index = i
@@ -42,6 +124,15 @@ local function updateSubCategoryDotBox(frame)
         end
     end
     dotBox:invalidateLayout()
+end
+
+local function suppressNativeOverlay(frame)
+    if frame.ingameMap ~= nil and frame.ingameMap.setOverlayVisible ~= nil then
+        frame.ingameMap:setOverlayVisible(false)
+    end
+    if frame.ingameMapBase ~= nil and frame.ingameMapBase.setOverlayVisible ~= nil then
+        frame.ingameMapBase:setOverlayVisible(false)
+    end
 end
 
 -- ── Hook handlers ─────────────────────────────────────────
@@ -59,7 +150,7 @@ function CsMapHooks:onLoadMapFinished()
             end
             if ref then
                 overlay.ingameMapRef = ref
-                print("[CropStress] CsMapHooks: ingameMap ref cached")
+                print(LOG_PREFIX .. "ingameMap ref cached")
             end
         end
     end
@@ -76,56 +167,64 @@ function CsMapHooks:setupMapOverview()
 
     table.insert(self.mapSelectorTexts, pageText)
     self.csMoisturePageIndex = #self.mapSelectorTexts
-    print(string.format("[CropStress] CsMapHooks: registered native page index %d", self.csMoisturePageIndex))
+    print(string.format(LOG_PREFIX .. "registered native page index %d", self.csMoisturePageIndex))
 
     self.mapOverviewSelector:setTexts(self.mapSelectorTexts)
 
     if self.dataTables ~= nil then
-        self.dataTables[self.csMoisturePageIndex] = overlay:getDisplayValues()
+        self.dataTables[self.csMoisturePageIndex] = overlay:getDisplayValues() or {}
     end
     if self.filterStates ~= nil then
-        self.filterStates[self.csMoisturePageIndex] = overlay:getDefaultFilterState()
+        self.filterStates[self.csMoisturePageIndex] = overlay:getDefaultFilterState() or {}
+    end
+    if self.numSelectedFilters ~= nil then
+        self.numSelectedFilters[self.csMoisturePageIndex] = 0
     end
 
     updateSubCategoryDotBox(self)
 end
 
-function CsMapHooks:onClickMapOverviewSelector(state)
+function CsMapHooks:onFrameOpen()
+    ensurePairsSafeTables(self)
+    if self.csMoisturePageIndex == nil then
+        CsMapHooks.setupMapOverview(self)
+    end
+end
+
+--- Own-page activation after vanilla selector work (overwrite calls this after super).
+function CsMapHooks:onCsPageSelected(state)
     if self.csMoisturePageIndex == nil or state ~= self.csMoisturePageIndex then return end
 
     local overlay = getCsOverlay(self)
     if overlay == nil then return end
 
     if self.dataTables ~= nil and self.dataTables[self.csMoisturePageIndex] == nil then
-        self.dataTables[self.csMoisturePageIndex] = overlay:getDisplayValues()
+        self.dataTables[self.csMoisturePageIndex] = overlay:getDisplayValues() or {}
     end
     if self.filterStates ~= nil and self.filterStates[self.csMoisturePageIndex] == nil then
-        self.filterStates[self.csMoisturePageIndex] = overlay:getDefaultFilterState()
+        self.filterStates[self.csMoisturePageIndex] = overlay:getDefaultFilterState() or {}
     end
     if self.numSelectedFilters ~= nil then
         self.numSelectedFilters[self.csMoisturePageIndex] = 0
     end
 
-    if self.generateOverviewOverlay ~= nil then
-        self:generateOverviewOverlay()
-    end
-
+    suppressNativeOverlay(self)
     overlay:requestRefresh()
 end
 
-function CsMapHooks:generateOverviewOverlay()
-    if self.csMoisturePageIndex == nil or self.mapOverviewSelector == nil then return end
-    if self.mapOverviewSelector:getState() ~= self.csMoisturePageIndex then return end
-
-    if self.ingameMap ~= nil and self.ingameMap.setOverlayVisible ~= nil then
-        self.ingameMap:setOverlayVisible(false)
+--- Overwrite: skip vanilla fruit/growth path when CS page active (MAP_HOTSPOTS <= state hazard).
+function CsMapHooks:generateOverviewOverlay(superFunc)
+    if isCsPageActive(self) then
+        suppressNativeOverlay(self)
+        local overlay = getCsOverlay(self)
+        if overlay ~= nil then
+            overlay:requestRefresh()
+        end
+        return
     end
-    if self.ingameMapBase ~= nil and self.ingameMapBase.setOverlayVisible ~= nil then
-        self.ingameMapBase:setOverlayVisible(false)
+    if superFunc ~= nil then
+        return superFunc(self)
     end
-
-    local overlay = getCsOverlay(self)
-    if overlay ~= nil then overlay:requestRefresh() end
 end
 
 function CsMapHooks.onDrawIngameMapElement(elementSelf, ...)
@@ -134,7 +233,7 @@ function CsMapHooks.onDrawIngameMapElement(elementSelf, ...)
     local _overlay = g_cropStressManager and g_cropStressManager.moistureMapOverlay
     if _overlay and not _overlay.ingameMapRef and elementSelf.ingameMap.layout then
         _overlay.ingameMapRef = elementSelf.ingameMap
-        print("[CropStress] CsMapHooks: ingameMap ref captured from PDA draw (fallback)")
+        print(LOG_PREFIX .. "ingameMap ref captured from PDA draw (fallback)")
     end
 
     local frame = elementSelf.parent
@@ -165,31 +264,22 @@ function CsMapHooks:onDrawOverlayHud()
     overlay:onDrawHud(self)
 end
 
-function CsMapHooks:onMouseEvent(superFunc, posX, posY, isDown, isUp, button, eventUsed)
+--- Sidebar click only; coordinated chain calls this before vanilla mouseEvent (no pcall amp).
+function CsMapHooks.handleMouseEvent(frame, posX, posY, isDown, isUp, button, eventUsed)
     local pageActive = false
-    local ok, result = pcall(isCsPageActive, self)
+    local ok, result = pcall(isCsPageActive, frame)
     if ok then pageActive = result end
-
     if not pageActive then
-        local ok2, ret = pcall(superFunc, self, posX, posY, isDown, isUp, button, eventUsed)
-        if not ok2 then
-            print("[CropStress] CsMapHooks: mouseEvent superFunc error: " .. tostring(ret))
-        end
-        return ret
+        return false
     end
 
     if not eventUsed and isDown and (button == Input.MOUSE_BUTTON_LEFT or button == Input.MOUSE_BUTTON_RIGHT) then
-        local overlay = getCsOverlay(self)
+        local overlay = getCsOverlay(frame)
         if overlay and overlay:onSideBarClick(posX, posY) then
             return true
         end
     end
-
-    local ok3, ret3 = pcall(superFunc, self, posX, posY, isDown, isUp, button, eventUsed)
-    if not ok3 then
-        print("[CropStress] CsMapHooks: mouseEvent superFunc error (2): " .. tostring(ret3))
-    end
-    return ret3
+    return false
 end
 
 function CsMapHooks:getHasChangeableFilterList(superFunc, ...)
@@ -206,6 +296,246 @@ function CsMapHooks:onFrameClose()
     if overlay ~= nil then overlay:requestRefresh() end
 end
 
+-- ── Shared installs (idempotent with SoilMapHooks) ────────
+
+--- Belt: if vanilla pageMapOverview:onLoadMapFinished never ran (e.g. aborted
+--- loadMission00Finished), restore real filter tables from mapOverlayGenerator
+--- before onFrameOpen → loadFilters. Do NOT paper with empty {} alone.
+local function restoreVanillaMapFilterInitIfMissing(frame)
+    if frame == nil then
+        return
+    end
+    local fruitKey = InGameMenuMapFrame.MAP_FRUIT_TYPE
+    local needsRestore = frame.displayCropTypes == nil
+        or frame.dataTables == nil
+        or (fruitKey ~= nil and frame.dataTables[fruitKey] == nil)
+    if not needsRestore then
+        return
+    end
+
+    local mission = g_currentMission
+    local mapOverlayGenerator = mission ~= nil and mission.mapOverlayGenerator or nil
+    frame.displaySoilStateMapping = {}
+    if mapOverlayGenerator ~= nil then
+        frame.displayCropTypes = mapOverlayGenerator:getDisplayCropTypes()
+        frame.displayGrowthStates = mapOverlayGenerator:getDisplayGrowthStates()
+        frame.displaySoilStates = mapOverlayGenerator:getDisplaySoilStates()
+        if frame.displaySoilStates ~= nil then
+            for index, state in pairs(frame.displaySoilStates) do
+                if state.isActive then
+                    state.soilStateIndex = index
+                    table.insert(frame.displaySoilStateMapping, state)
+                end
+            end
+        end
+    end
+
+    if frame.dataTables == nil then
+        frame.dataTables = {}
+    end
+    frame.dataTables[InGameMenuMapFrame.MAP_SOIL] = frame.displaySoilStateMapping or {}
+    frame.dataTables[InGameMenuMapFrame.MAP_FRUIT_TYPE] = frame.displayCropTypes or {}
+    frame.dataTables[InGameMenuMapFrame.MAP_GROWTH] = frame.displayGrowthStates or {}
+    frame.dataTables[InGameMenuMapFrame.MAP_HOTSPOTS] = InGameMenuMapFrame.HOTSPOT_FILTER_CATEGORIES or {}
+    frame.dataTables[InGameMenuMapFrame.MAP_FARMLANDS] = frame.farmlandItems or {}
+
+    if g_gameSettings ~= nil and GameSettings ~= nil and GameSettings.SETTING ~= nil then
+        g_gameSettings:setValue(GameSettings.SETTING.INGAME_MAP_HOTSPOT_FILTER, 4294967295, true)
+    end
+    if g_terrainNode ~= nil and frame.filterList ~= nil and type(frame.filterList.reloadData) == "function" then
+        frame.filterList:reloadData()
+    end
+
+    if InGameMenuMapFrame._rfVanillaFilterInitRestoredLogged ~= true then
+        InGameMenuMapFrame._rfVanillaFilterInitRestoredLogged = true
+        print(LOG_PREFIX .. "restored vanilla map filter init before onFrameOpen")
+    end
+end
+
+local function installVanillaFilterInitBelt()
+    if InGameMenuMapFrame == nil or InGameMenuMapFrame.onFrameOpen == nil then
+        return
+    end
+    if InGameMenuMapFrame._rfVanillaFilterInitBeltInstalled then
+        return
+    end
+    InGameMenuMapFrame._rfVanillaFilterInitBeltInstalled = true
+    InGameMenuMapFrame.onFrameOpen = Utils.prependedFunction(
+        InGameMenuMapFrame.onFrameOpen,
+        restoreVanillaMapFilterInitIfMissing
+    )
+end
+
+local function installPairsSafeMouseChain()
+    if InGameMenuMapFrame == nil or InGameMenuMapFrame.mouseEvent == nil then
+        return
+    end
+
+    if InGameMenuMapFrame._rfMapMouseHandlers == nil then
+        InGameMenuMapFrame._rfMapMouseHandlers = {}
+    end
+
+    local handlers = InGameMenuMapFrame._rfMapMouseHandlers
+    local replaced = false
+    for i = 1, #handlers do
+        if handlers[i].name == "CsMapHooks" then
+            handlers[i].fn = CsMapHooks.handleMouseEvent
+            replaced = true
+            break
+        end
+    end
+    if not replaced then
+        table.insert(handlers, { name = "CsMapHooks", fn = CsMapHooks.handleMouseEvent })
+    end
+
+    if InGameMenuMapFrame._rfMapMouseChainInstalled then
+        return
+    end
+    InGameMenuMapFrame._rfMapMouseChainInstalled = true
+
+    InGameMenuMapFrame.mouseEvent = Utils.overwrittenFunction(
+        InGameMenuMapFrame.mouseEvent,
+        function(self, superFunc, posX, posY, isDown, isUp, button, eventUsed)
+            ensurePairsSafeTables(self)
+            local list = InGameMenuMapFrame._rfMapMouseHandlers
+            if list ~= nil then
+                for i = 1, #list do
+                    local h = list[i]
+                    if h ~= nil and h.fn ~= nil then
+                        local used = h.fn(self, posX, posY, isDown, isUp, button, eventUsed)
+                        if used then
+                            return true
+                        end
+                    end
+                end
+            end
+            -- Do not pcall-swallow: pairs(nil) must not leave a half-live frame.
+            return superFunc(self, posX, posY, isDown, isUp, button, eventUsed)
+        end
+    )
+end
+
+local function installDeselectGuard()
+    if InGameMenuMapFrame == nil or InGameMenuMapFrame.onClickDeselectAll == nil then
+        return
+    end
+    if InGameMenuMapFrame._rfDeselectGuardInstalled then
+        return
+    end
+    InGameMenuMapFrame._rfDeselectGuardInstalled = true
+
+    InGameMenuMapFrame.onClickDeselectAll = Utils.overwrittenFunction(
+        InGameMenuMapFrame.onClickDeselectAll,
+        function(self, superFunc, exceptionSection, exceptionIndex)
+            if self.getHasChangeableFilterList ~= nil and not self:getHasChangeableFilterList() then
+                return
+            end
+            ensurePairsSafeTables(self)
+            local state = self.mapOverviewSelector and self.mapOverviewSelector:getState()
+            if state == nil then
+                return
+            end
+            local dt = self.dataTables and self.dataTables[state]
+            if dt == nil then
+                logNilOnce("deselect_nil_table", string.format("onClickDeselectAll blocked: dataTables[%s] nil", tostring(state)))
+                return
+            end
+            if InGameMenuMapFrame.MAP_HOTSPOTS ~= nil and state == InGameMenuMapFrame.MAP_HOTSPOTS then
+                if dt[1] == nil or dt[2] == nil then
+                    logNilOnce("deselect_hotspot_shape", "onClickDeselectAll blocked: hotspot filter subtables nil")
+                    return
+                end
+            end
+            return superFunc(self, exceptionSection, exceptionIndex)
+        end
+    )
+end
+
+local function installSelectorGuard()
+    if InGameMenuMapFrame == nil or InGameMenuMapFrame.onClickMapOverviewSelector == nil then
+        return
+    end
+    if InGameMenuMapFrame._rfSelectorGuardInstalled then
+        -- Still register CS post-hook if Soil installed the guard first.
+        if not InGameMenuMapFrame._rfCsSelectorPostInstalled then
+            InGameMenuMapFrame._rfCsSelectorPostInstalled = true
+            local prev = InGameMenuMapFrame.onClickMapOverviewSelector
+            InGameMenuMapFrame.onClickMapOverviewSelector = function(self, state)
+                prev(self, state)
+                CsMapHooks.onCsPageSelected(self, state)
+            end
+        end
+        return
+    end
+    InGameMenuMapFrame._rfSelectorGuardInstalled = true
+    InGameMenuMapFrame._rfCsSelectorPostInstalled = true
+
+    InGameMenuMapFrame.onClickMapOverviewSelector = Utils.overwrittenFunction(
+        InGameMenuMapFrame.onClickMapOverviewSelector,
+        function(self, superFunc, state)
+            ensurePairsSafeTables(self)
+            if superFunc ~= nil then
+                superFunc(self, state)
+            end
+            CsMapHooks.onCsPageSelected(self, state)
+        end
+    )
+end
+
+local function installFrameCloseGuard()
+    if InGameMenuMapFrame == nil or InGameMenuMapFrame.onFrameClose == nil then
+        return
+    end
+    if InGameMenuMapFrame._rfFrameCloseHotspotGuard then
+        return
+    end
+    InGameMenuMapFrame._rfFrameCloseHotspotGuard = true
+
+    InGameMenuMapFrame.onFrameClose = Utils.overwrittenFunction(
+        InGameMenuMapFrame.onFrameClose,
+        function(self, superFunc)
+            ensurePairsSafeTables(self)
+            return superFunc(self)
+        end
+    )
+end
+
+local function installFilterListDeselectGuard()
+    if InGameMenuMapFrame == nil or InGameMenuMapFrame.initialize == nil then
+        return
+    end
+    if InGameMenuMapFrame._rfFilterListInitGuardInstalled then
+        return
+    end
+    InGameMenuMapFrame._rfFilterListInitGuardInstalled = true
+
+    InGameMenuMapFrame.initialize = Utils.appendedFunction(
+        InGameMenuMapFrame.initialize,
+        function(self)
+            if self._rfFilterListDeselectGuarded then
+                return
+            end
+            local filterList = self.filterList
+            if filterList == nil or filterList.mouseEvent == nil then
+                return
+            end
+            self._rfFilterListDeselectGuarded = true
+            local prev = filterList.mouseEvent
+            function filterList.mouseEvent(list, posX, posY, isDown, isUp, button, eventUsed)
+                if isDown and button == Input.MOUSE_BUTTON_RIGHT then
+                    if self.getHasChangeableFilterList ~= nil and not self:getHasChangeableFilterList() then
+                        if SmoothListElement ~= nil and SmoothListElement.mouseEvent ~= nil then
+                            return SmoothListElement.mouseEvent(list, posX, posY, isDown, isUp, button, eventUsed)
+                        end
+                        return eventUsed
+                    end
+                end
+                return prev(list, posX, posY, isDown, isUp, button, eventUsed)
+            end
+        end
+    )
+end
+
 -- ── Install hooks ─────────────────────────────────────────
 
 if InGameMenuMapFrame ~= nil then
@@ -217,12 +547,16 @@ if InGameMenuMapFrame ~= nil then
         InGameMenuMapFrame.setupMapOverview = Utils.appendedFunction(
             InGameMenuMapFrame.setupMapOverview, CsMapHooks.setupMapOverview)
     end
-    if InGameMenuMapFrame.onClickMapOverviewSelector ~= nil then
-        InGameMenuMapFrame.onClickMapOverviewSelector = Utils.appendedFunction(
-            InGameMenuMapFrame.onClickMapOverviewSelector, CsMapHooks.onClickMapOverviewSelector)
+    if InGameMenuMapFrame.onFrameOpen ~= nil then
+        installVanillaFilterInitBelt()
+        InGameMenuMapFrame.onFrameOpen = Utils.appendedFunction(
+            InGameMenuMapFrame.onFrameOpen, CsMapHooks.onFrameOpen)
     end
+
+    installSelectorGuard()
+
     if InGameMenuMapFrame.generateOverviewOverlay ~= nil then
-        InGameMenuMapFrame.generateOverviewOverlay = Utils.appendedFunction(
+        InGameMenuMapFrame.generateOverviewOverlay = Utils.overwrittenFunction(
             InGameMenuMapFrame.generateOverviewOverlay, CsMapHooks.generateOverviewOverlay)
     end
     if InGameMenuMapFrame.draw ~= nil then
@@ -232,10 +566,12 @@ if InGameMenuMapFrame ~= nil then
         InGameMenuMapFrame.onDraw = Utils.appendedFunction(
             InGameMenuMapFrame.onDraw, CsMapHooks.onDrawOverlayHud)
     end
-    if InGameMenuMapFrame.mouseEvent ~= nil then
-        InGameMenuMapFrame.mouseEvent = Utils.overwrittenFunction(
-            InGameMenuMapFrame.mouseEvent, CsMapHooks.onMouseEvent)
-    end
+
+    installPairsSafeMouseChain()
+    installDeselectGuard()
+    installFrameCloseGuard()
+    installFilterListDeselectGuard()
+
     if InGameMenuMapFrame.getHasChangeableFilterList ~= nil then
         InGameMenuMapFrame.getHasChangeableFilterList = Utils.overwrittenFunction(
             InGameMenuMapFrame.getHasChangeableFilterList, CsMapHooks.getHasChangeableFilterList)
@@ -244,15 +580,15 @@ if InGameMenuMapFrame ~= nil then
         InGameMenuMapFrame.onFrameClose = Utils.appendedFunction(
             InGameMenuMapFrame.onFrameClose, CsMapHooks.onFrameClose)
     end
-    print("[CropStress] CsMapHooks: installed on InGameMenuMapFrame")
+    print(LOG_PREFIX .. "installed on InGameMenuMapFrame (pairs-safe mouse chain)")
 else
-    print("[CropStress] CsMapHooks: WARNING — InGameMenuMapFrame not available at load time")
+    print(LOG_PREFIX .. "WARNING — InGameMenuMapFrame not available at load time")
 end
 
 if IngameMapElement ~= nil then
     IngameMapElement.draw = Utils.appendedFunction(
         IngameMapElement.draw, CsMapHooks.onDrawIngameMapElement)
-    print("[CropStress] CsMapHooks: IngameMapElement.draw hook installed")
+    print(LOG_PREFIX .. "IngameMapElement.draw hook installed")
 else
-    print("[CropStress] CsMapHooks: WARNING — IngameMapElement not available — map dots will not draw")
+    print(LOG_PREFIX .. "WARNING — IngameMapElement not available — map dots will not draw")
 end

--- a/src/ui/RfEscModules.lua
+++ b/src/ui/RfEscModules.lua
@@ -70,6 +70,10 @@ function RfEscModules:registerModule(def)
         onHide = def.onHide,
         onWageOptionChanged = def.onWageOptionChanged,
         onWageReset = def.onWageReset,
+        -- Vera F2 2026-08-07: registerModule whitelists fields, so this was being
+        -- dropped and the door could never ask the active module to open its own
+        -- deep screen. Guests register it; keep it.
+        onOpenFullMarket = def.onOpenFullMarket,
     }
     if self.activeModuleId == nil then
         self.activeModuleId = def.id

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -361,6 +361,12 @@ function RfPdaMenuPage:onGuiSetupFinished()
     self.soilColFert = self:getDescendantById("soilColFert") or self.soilColFert
     self.soilSectionTreatment = self:getDescendantById("soilSectionTreatment") or self.soilSectionTreatment
     self.soilTreatProducts = self:getDescendantById("soilTreatProducts") or self.soilTreatProducts
+    -- Read-only rotation card (2026-08-07). Nil-safe: older door XML lacks these ids.
+    self.soilRotationCard   = self:getDescendantById("soilRotationCard") or self.soilRotationCard
+    self.soilRotationTitle  = self:getDescendantById("soilRotationTitle") or self.soilRotationTitle
+    self.soilRotationLast   = self:getDescendantById("soilRotationLast") or self.soilRotationLast
+    self.soilRotationStatus = self:getDescendantById("soilRotationStatus") or self.soilRotationStatus
+    self.soilRotationTip    = self:getDescendantById("soilRotationTip") or self.soilRotationTip
     self.treatSelectedLabel = self:getDescendantById("treatSelectedLabel") or self.treatSelectedLabel
     self.treatNextLabel     = self:getDescendantById("treatNextLabel") or self.treatNextLabel
     self.treatTargetsLabel  = self:getDescendantById("treatTargetsLabel") or self.treatTargetsLabel
@@ -469,9 +475,61 @@ function RfPdaMenuPage:initialize()
             end
         end
     }
+    -- Open full Market when MDM module is active. MENU_EXTRA_1, NOT MENU_ACTIVATE: the
+    -- commodity SmoothList consumes ACTIVATE/SPACE first so the footer callback never
+    -- fires (Ash+George r2 2026-08-07). Must exist in EVERY door carrier, because
+    -- whichever mod wins ensureDoor is the one whose footer the player actually gets
+    -- (Vera F1 2026-08-07).
+    self.btnOpenMarket = {
+        inputAction = InputAction.MENU_EXTRA_1,
+        showWhenPaused = true,
+        text = tr("md_rf_pda_open_market", "Open full Market"),
+        callback = function()
+            print("[MarketDynamics] Esc footer Open full Market pressed")
+            -- Cross-mod resolve (Vera F2 2026-08-07). MdRfPdaGuest / MDMMarketScreen are
+            -- MarketDynamics-env globals and are nil on a Soil/WC/SCS hosted door, so the
+            -- bare calls silently did nothing there. Same shape as the Worker Manager
+            -- resolve below and Soil's soilGlobal: try in-env, then g_modEnvironments.
+            local host = self:_getHost()
+            local activeId = host ~= nil and host.activeModuleId or nil
+            local mod = (host ~= nil and host.modules ~= nil and activeId ~= nil)
+                and host.modules[activeId] or nil
+            if mod ~= nil and type(mod.onOpenFullMarket) == "function" then
+                print("[MarketDynamics] Open full Market via active module def")
+                mod.onOpenFullMarket()
+                return
+            end
+            if MdRfPdaGuest ~= nil and type(MdRfPdaGuest.onOpenFullMarket) == "function" then
+                print("[MarketDynamics] Open full Market via in-env MdRfPdaGuest")
+                MdRfPdaGuest.onOpenFullMarket()
+                return
+            end
+            local mdEnv = g_modEnvironments ~= nil and g_modEnvironments["FS25_MarketDynamics"] or nil
+            local guest = mdEnv ~= nil and mdEnv.MdRfPdaGuest or nil
+            if guest ~= nil and type(guest.onOpenFullMarket) == "function" then
+                print("[MarketDynamics] Open full Market via g_modEnvironments MdRfPdaGuest")
+                guest.onOpenFullMarket()
+                return
+            end
+            local scr = mdEnv ~= nil and mdEnv.MDMMarketScreen or nil
+            if scr ~= nil and type(scr.show) == "function" then
+                print("[MarketDynamics] Open full Market via g_modEnvironments MDMMarketScreen")
+                scr.show()
+                return
+            end
+            if MDMMarketScreen ~= nil and type(MDMMarketScreen.show) == "function" then
+                print("[MarketDynamics] Open full Market via in-env MDMMarketScreen")
+                MDMMarketScreen.show()
+                return
+            end
+            print("[MarketDynamics] Open full Market: no handler available (all resolve paths nil)")
+        end
+    }
     -- SPACE / MENU_ACTIVATE: open the Worker Manager deep desk when WC is active.
     self.btnOpenWorkerManager = {
-        inputAction = InputAction.MENU_ACTIVATE,
+        -- MENU_EXTRA_2, not MENU_ACTIVATE: same SmoothList swallow class as Open full
+        -- Market (Ash 2026-08-07). Free while WC is active, Rotation Planner is Soil-only.
+        inputAction = InputAction.MENU_EXTRA_2,
         showWhenPaused = true,
         text = tr("wc_rf_pda_open_manager", "Open Worker Manager"),
         callback = function()
@@ -1130,7 +1188,13 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
         self.rfHostBody:setText("")
     end
     -- Bottom bar: SPACE opens the Worker Manager deep desk while WC is active.
-    if isWc and self.btnOpenWorkerManager ~= nil then
+    if isMd and self.btnOpenMarket ~= nil then
+        self.menuButtonInfo = { self.btnBack, self.btnOpenMarket }
+        local trFn = self._rfTr
+        if type(trFn) == "function" then
+            self.btnOpenMarket.text = trFn("md_rf_pda_open_market", "Open full Market")
+        end
+    elseif isWc and self.btnOpenWorkerManager ~= nil then
         self.menuButtonInfo = { self.btnBack, self.btnOpenWorkerManager }
     elseif isSoil then
         self.menuButtonInfo = { self.btnBack, self.btnHelp, self.btnRotationPlanner, self.btnFieldDetail }

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -167,7 +167,7 @@ local function soilGuideDialog()
 end
 
 --- Resolve l10n with English fallback. When CS/WC create the Esc door, MOD_NAME
---- i18n may lack Soil table keys — also probe Soil modEnv, then g_i18n.
+--- i18n may lack Soil table keys - also probe Soil modEnv, then g_i18n.
 local function tr(key, fallback)
     local function tryI18n(i18n)
         if i18n == nil then
@@ -257,6 +257,9 @@ function RfPdaMenuPage.new()
     self._wcLiveTimer = 0
     self.wcSubPageIndex = 1
     self.wcAboutTabIndex = 1
+    self.mdSubPageIndex = 1
+    self.mdCommodityData = {}
+    self.mdSelectedFillType = nil
     self._panelCache = {}
     self._lastPanelFingerprint = nil
     self._hostListenerBound = false
@@ -264,6 +267,8 @@ function RfPdaMenuPage.new()
     self._wcWageRefreshing = false
     self._wcSubnavSeeding = false
     self._wcSubnavSeeded = false
+    self._mdSubnavSeeding = false
+    self._mdSubnavSeeded = false
     self._lastModuleSelectId = nil
     self._lastModuleSelectAt = 0
     self._frameDebug = false
@@ -331,12 +336,26 @@ function RfPdaMenuPage:onGuiSetupFinished()
     self.mdGraphArea = self:getDescendantById("mdGraphArea") or self.mdGraphArea
     self.mdDetailStrip = self:getDescendantById("mdDetailStrip") or self.mdDetailStrip
     self.mdMoverSelector = self:getDescendantById("mdMoverSelector") or self.mdMoverSelector
+    self.mdTableRegion = self:getDescendantById("mdTableRegion") or self.mdTableRegion
+    self.mdCommodityList = self:getDescendantById("mdCommodityList") or self.mdCommodityList
+    self.mdPageBand = self:getDescendantById("mdPageBand") or self.mdPageBand
+    self.mdPricesBand = self:getDescendantById("mdPricesBand") or self.mdPricesBand
     self.mdEventsBand = self:getDescendantById("mdEventsBand") or self.mdEventsBand
+    self.mdContractsBand = self:getDescendantById("mdContractsBand") or self.mdContractsBand
     self.mdOpenMarketBtn = self:getDescendantById("mdOpenMarketBtn") or self.mdOpenMarketBtn
+    self.mdSubnavShell = self:getDescendantById("mdSubnavShell") or self.mdSubnavShell
+    self.mdSubnavSelector = self:getDescendantById("mdSubnavSelector") or self.mdSubnavSelector
+    self.mdSubnavDotBox = self:getDescendantById("mdSubnavDotBox") or self.mdSubnavDotBox
+    self.mdSideInfoShell = self:getDescendantById("mdSideInfoShell") or self.mdSideInfoShell
+    self.mdSideInfoBody = self:getDescendantById("mdSideInfoBody") or self.mdSideInfoBody
     self.wcGlanceShell = self:getDescendantById("wcGlanceShell") or self.wcGlanceShell
     self.wcSubnavShell = self:getDescendantById("wcSubnavShell") or self.wcSubnavShell
     self.wcSubnavSelector = self:getDescendantById("wcSubnavSelector") or self.wcSubnavSelector
     self.wcSubnavDotBox = self:getDescendantById("wcSubnavDotBox") or self.wcSubnavDotBox
+    if self.mdCommodityList then
+        self.mdCommodityList.dataSource = self
+        self.mdCommodityList.delegate = self
+    end
     -- Dual-arrow FAIL-FIX: live page selector = title-chrome wcTitlePageSelector (not left twin).
     self.wcTitlePageShell = self:getDescendantById("wcTitlePageShell") or self.wcTitlePageShell
     self.wcTitlePageSelector = self:getDescendantById("wcTitlePageSelector") or self.wcTitlePageSelector
@@ -349,6 +368,9 @@ function RfPdaMenuPage:onGuiSetupFinished()
     self.rfSideMidSeparator = self:getDescendantById("rfSideMidSeparator") or self.rfSideMidSeparator
     self.rfModuleListShell = self:getDescendantById("rfModuleListShell") or self.rfModuleListShell
     self.wcPageShell = self:getDescendantById("wcPageShell") or self.wcPageShell
+    self.rfFrameworkGlanceShell = self:getDescendantById("rfFrameworkGlanceShell") or self.rfFrameworkGlanceShell
+    self.rfFwStatusBlock = self:getDescendantById("rfFwStatusBlock") or self.rfFwStatusBlock
+    self.rfFwTableBlock = self:getDescendantById("rfFwTableBlock") or self.rfFwTableBlock
     self.wcPageDashboard = self:getDescendantById("wcPageDashboard") or self.wcPageDashboard
     self.wcPageWages = self:getDescendantById("wcPageWages") or self.wcPageWages
     self.wcPageWorkers = self:getDescendantById("wcPageWorkers") or self.wcPageWorkers
@@ -475,11 +497,11 @@ function RfPdaMenuPage:initialize()
             end
         end
     }
-    -- Open full Market when MDM module is active. MENU_EXTRA_1, NOT MENU_ACTIVATE: the
-    -- commodity SmoothList consumes ACTIVATE/SPACE first so the footer callback never
-    -- fires (Ash+George r2 2026-08-07). Must exist in EVERY door carrier, because
-    -- whichever mod wins ensureDoor is the one whose footer the player actually gets
-    -- (Vera F1 2026-08-07).
+    -- Open full Market when MDM module is active (bottom strip twin).
+    -- MENU_EXTRA_1, NOT MENU_ACTIVATE: the commodity SmoothList consumes ACTIVATE/SPACE
+    -- first, so the footer callback never fired at all - zero MarketScreen.show lines in
+    -- the client log on click (Ash+George r2 2026-08-07). EXTRA_1 is free while MDM is
+    -- the active module, since Help / Rotation Planner / Field Detail are Soil-only footers.
     self.btnOpenMarket = {
         inputAction = InputAction.MENU_EXTRA_1,
         showWhenPaused = true,
@@ -548,7 +570,10 @@ function RfPdaMenuPage:initialize()
         end
     }
 
-    self.menuButtonInfo = { self.btnBack, self.btnHelp }
+    -- Back only. Help is Soil-only and _syncHostGuestChrome adds it when the Soil
+    -- module is the active one; seeding it here leaked Help onto every module's
+    -- footer for the window before the first sync ran.
+    self.menuButtonInfo = { self.btnBack }
     self:_applyChromeL10n()
     self:_bindHostListener()
 end
@@ -611,14 +636,16 @@ end
 
 function RfPdaMenuPage:draw(clipX1, clipY1, clipX2, clipY2)
     RfPdaMenuPage:superClass().draw(self, clipX1, clipY1, clipX2, clipY2)
-    -- Market Dynamics Esc glance graph (after chrome). Reuse MDMMarketScreenGraph.draw.
+    -- Market Dynamics Prices page graph (after chrome). Reuse MDMMarketScreenGraph.draw.
     do
         local host = self:_getHost()
         local active = host and host.getActivePanel and host:getActivePanel()
+        local pageIdx = tonumber(self.mdSubPageIndex) or 1
         if active ~= nil and active.id == "marketDynamics"
-                and self.mdGraphRegion ~= nil
+                and pageIdx == 1
+                and self.mdPricesBand ~= nil
                 and MDMMarketScreenGraph ~= nil and type(MDMMarketScreenGraph.draw) == "function" then
-            local area = self.mdGraphArea or self.mdGraphRegion
+            local area = self.mdGraphArea
             if area ~= nil and area.absPosition ~= nil and area.absSize ~= nil then
                 local ft = self.mdSelectedFillType
                 if ft == nil and MdRfPdaGuest ~= nil and type(MdRfPdaGuest.getSelectedFillType) == "function" then
@@ -661,6 +688,10 @@ function RfPdaMenuPage:update(dt)
 
     -- Market Dynamics: light text/graph refresh; never SmoothList thrash.
     if isMd then
+        local pageIdx = tonumber(self.mdSubPageIndex) or 1
+        if pageIdx == 1 and MDMMarketScreenGraph ~= nil and type(MDMMarketScreenGraph.update) == "function" then
+            pcall(MDMMarketScreenGraph.update, dt)
+        end
         self._mdLiveTimer = (self._mdLiveTimer or 0) + dt
         if self._mdLiveTimer >= REFRESH_INTERVAL then
             self._mdLiveTimer = 0
@@ -708,7 +739,7 @@ function RfPdaMenuPage:_getHost()
 end
 
 --- Shared MTO arrow ensure: enable + normalized ~36px hit (never setSize(36,36) literals)
---- then lime tint. Re-apply every call â€” profile can reset circle buttons to 42.
+--- then lime tint. Re-apply every call - profile can reset circle buttons to 42.
 function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
     if sel == nil then
         return
@@ -723,7 +754,7 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
         sel:setDisabled(false)
     end
 
-    -- Extract: GuiUtils.getNormalizedScreenValues(values, default) â€” values = "Wpx Hpx" or array; returns table.
+    -- Extract: GuiUtils.getNormalizedScreenValues(values, default) - values = "Wpx Hpx" or array; returns table.
     -- Never pass bare numbers (GuiUtils.lua #values throws on number).
     local tw, th = nil, nil
     if GuiUtils ~= nil and type(GuiUtils.getNormalizedScreenValues) == "function" then
@@ -739,7 +770,7 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
         if btn ~= nil then
             if btn.setVisible then btn:setVisible(true) end
             if btn.setDisabled then btn:setDisabled(false) end
-            -- Size THEN lime (George Plan A). Absolute target â€” do not ratio current size.
+            -- Size THEN lime (George Plan A). Absolute target - do not ratio current size.
             if type(btn.setSize) == "function" and tw ~= nil and th ~= nil then
                 btn:setSize(tw, th)
             end
@@ -1012,6 +1043,9 @@ end
 function RfPdaMenuPage:_refreshPageHeader(active)
     local isSoil = active == nil or active.id == "soilFertilizer"
     local isWc = active ~= nil and active.id == "workerCosts"
+    local activeId = active ~= nil and active.id or nil
+    local isFw = activeId == "income" or activeId == "tax" or activeId == "dairy"
+            or activeId == "npcFavor" or activeId == "fertilizerDepot"
     if self.rfPageTitle then
         if isSoil then
             self.rfPageTitle:setText(tr("rf_pda_panel_soil", "Soil Fertilizer"))
@@ -1020,11 +1054,23 @@ function RfPdaMenuPage:_refreshPageHeader(active)
         end
     end
     if self.rfPageBlurb then
-        if isSoil then
+        -- Framework overlap FAILFIX (George 2026-08-05): side About owns story; blank+hide blurb.
+        if isFw then
+            self.rfPageBlurb:setText("")
+            if type(self.rfPageBlurb.setVisible) == "function" then
+                self.rfPageBlurb:setVisible(false)
+            end
+        elseif isSoil then
+            if type(self.rfPageBlurb.setVisible) == "function" then
+                self.rfPageBlurb:setVisible(true)
+            end
             self.rfPageBlurb:setText(tr("rf_pda_menu_blurb",
                 "Monitor your fields' nutrient levels. Apply fertilizer to maintain optimal yields."))
         elseif isWc then
             -- Chrome FAIL-FIX: never leave Soil nutrient/treatment copy on Worker Costs.
+            if type(self.rfPageBlurb.setVisible) == "function" then
+                self.rfPageBlurb:setVisible(true)
+            end
             local rawBlurb = active and active.blurb
             local wcBlurb = "Wage mode, active workers, next settlement estimate. Open Worker Manager for hire and settings."
             if type(rawBlurb) == "string" and rawBlurb ~= "" then
@@ -1035,6 +1081,9 @@ function RfPdaMenuPage:_refreshPageHeader(active)
             end
             self.rfPageBlurb:setText(wcBlurb)
         elseif active ~= nil and type(active.blurb) == "string" and active.blurb ~= "" then
+            if type(self.rfPageBlurb.setVisible) == "function" then
+                self.rfPageBlurb:setVisible(true)
+            end
             local lower = active.blurb:lower()
             if not lower:find("^missing%s") and not lower:find("^missing_") then
                 self.rfPageBlurb:setText(active.blurb)
@@ -1043,6 +1092,9 @@ function RfPdaMenuPage:_refreshPageHeader(active)
                     "Quick look at this module. Open Farm Tablet for the full tools."))
             end
         else
+            if type(self.rfPageBlurb.setVisible) == "function" then
+                self.rfPageBlurb:setVisible(true)
+            end
             self.rfPageBlurb:setText(tr("rf_pda_host_blurb",
                 "Quick look at this module. Open Farm Tablet for the full tools."))
         end
@@ -1059,24 +1111,26 @@ function RfPdaMenuPage:_refreshSideInfo(activeId)
     local isCs = activeId == "seasonalCropStress"
     local isWc = activeId == "workerCosts"
     local isMd = activeId == "marketDynamics"
+    local isFw = activeId == "income" or activeId == "tax" or activeId == "dairy"
+            or activeId == "npcFavor" or activeId == "fertilizerDepot"
+    local isFwStatus = activeId == "tax"
+    local isFwTable = activeId == "income" or activeId == "dairy" or activeId == "npcFavor" or activeId == "fertilizerDepot"
     local function setVis(el, visible)
         if el ~= nil and type(el.setVisible) == "function" then
             el:setVisible(visible)
         end
     end
-    setVis(self.rfSideInfoShell, isSoil or isCs or isMd)
+    setVis(self.rfSideInfoShell, isSoil or isCs or isFw)
     setVis(self.wcSideInfoShell, isWc)
+    setVis(self.mdSideInfoShell, isMd)
     setVis(self.rfSuiteHint, false)
     if self.rfSideInfoBody and self.rfSideInfoBody.setText then
         if isSoil then
             self.rfSideInfoBody:setText(tr("rf_pda_side_info_soil",
-                "Soil Fertilizer\n\nThis table lists every field you own. One row = one field.\n\nColumns: Field #, Area, N/P/K (% of a healthy target), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).\n\nClick a row. Treatment (below) is the plan for that field:\n- PRODUCT = what to buy (first is preferred; \"or ...\" is an alternate)\n- RATE = amount per area / TOTAL = amount for this field\n- Selected names the field; Next (under it) says what to do first\n\nHow to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.\n\nStart with the weakest Status, open Treatment, follow Next, then the rest of the list."))
+                "Soil Fertilizer\n\nThis table lists every field you own. One row = one field.\n\nColumns: Field #, Area, N/P/K (% of a healthy target), pH (like the soil monitor - e.g. 6.2), Status (Good / Fair / Poor), Fertilizer need (short cue for what still looks short).\n\nClick a row. Treatment (below) is the plan for that field:\n- PRODUCT = what to buy (first is preferred; \"or ...\" is an alternate)\n- RATE = amount per area / TOTAL = amount for this field\n- Selected names the field; Next (under it) says what to do first\n\nHow to apply: dry goods (urea, MAP, potash, lime) go through a fertilizer spreader; liquids go in a sprayer tank. If pH and nutrients both show, fix lime or gypsum first so nutrients can work. Weed, pest, or disease lines mean spray (or weed mechanically) before you expect a full crop.\n\nStart with the weakest Status, open Treatment, follow Next, then the rest of the list."))
         elseif isCs then
             self.rfSideInfoBody:setText(tr("rf_pda_side_info_crop_stress",
                 "Crop Stress\n\nThis table lists every field you own. One row = one field.\n\nColumns: Field # / Crop, Moisture (how wet the soil is), Stress (how hard the crop is fighting dry spells), Irrigation (water help covering this field), Status (Healthy / Warning / Critical).\n\nClick a row. The strip below names the field, then Next says what to do first:\n- Critical or Warning Moisture → water that field (turn on irrigation if covered, or spray WATER / place coverage)\n- High Stress or a sensitive growth window → protect now; stress today cuts harvest later\n- Looking fine → recheck later; worse fields first\n\nIrrigation: Yes means a system can cover this field. The strip under the table shows this field's schedule, water rate, yield keep, and air dry-pull. Edit systems on Farm Tablet / Crop Consultant when you need to change them.\n\nIf Soil Fertilizer is also loaded, check nutrients there too. Dry soil drains faster when soil health is poor.\n\nStart with Critical Status, follow Next, then work up the list."))
-        elseif isMd then
-            self.rfSideInfoBody:setText(tr("rf_pda_side_info_market_dynamics",
-                "Market Dynamics\n\nThis is a pause market glance, not the full Market desk.\n\nGraph = price path for the crop you pick.\n\nMovers = biggest swings right now. Click one to change the graph.\n\nEvents = world events still driving prices. Empty means nothing active (normal).\n\nBottom strip = facts for the crop you selected.\n\nContracts line = open count only. Full contracts live deeper.\n\nOpen full Market when you need Prices / Events / Contracts admin."))
         else
             self.rfSideInfoBody:setText("")
         end
@@ -1090,6 +1144,10 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     local isCs = activeId == "seasonalCropStress"
     local isWc = activeId == "workerCosts"
     local isMd = activeId == "marketDynamics"
+    local isFw = activeId == "income" or activeId == "tax" or activeId == "dairy"
+            or activeId == "npcFavor" or activeId == "fertilizerDepot"
+    local isFwStatus = activeId == "tax"
+    local isFwTable = activeId == "income" or activeId == "dairy" or activeId == "npcFavor" or activeId == "fertilizerDepot"
     local function setVis(el, visible)
         if el ~= nil and type(el.setVisible) == "function" then
             el:setVisible(visible)
@@ -1098,25 +1156,44 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     setVis(self.rfHostTableRegion, isCs)
     setVis(self.csFieldOverviewList, isCs)
     setVis(self.csDetailStrip, isCs)
-    setVis(self.mdGraphRegion, isMd)
-    setVis(self.mdDetailStrip, isMd)
-    setVis(self.mdMoverSelector, isMd)
-    setVis(self.mdOpenMarketBtn, isMd)
+    -- MDM three-page chrome (TOP table + BOTTOM bands + secondary subnav).
+    setVis(self.mdTableRegion, isMd)
+    setVis(self.mdCommodityList, isMd)
+    setVis(self.mdPageBand, isMd)
+    setVis(self.mdGraphRegion, false)
+    setVis(self.mdDetailStrip, false)
+    setVis(self.mdMoverSelector, false)
     if self.mdMoverSelector ~= nil then
-        self.mdMoverSelector.disableButtonsOnSingleText = false
-        self.mdMoverSelector.hideLeftRightButtons = not isMd
+        self.mdMoverSelector.hideLeftRightButtons = true
         if type(self.mdMoverSelector.setDisabled) == "function" then
-            self.mdMoverSelector:setDisabled(not isMd)
+            self.mdMoverSelector:setDisabled(true)
         end
-        if isMd and type(self._ensureMtoArrowsVisible) == "function" then
-            self:_ensureMtoArrowsVisible(self.mdMoverSelector)
+    end
+    if isMd then
+        if self.mdTableRegion ~= nil and type(self.mdTableRegion.updateAbsolutePosition) == "function" then
+            self.mdTableRegion:updateAbsolutePosition()
         end
-        if isMd and self.mdGraphRegion ~= nil and type(self.mdGraphRegion.updateAbsolutePosition) == "function" then
-            self.mdGraphRegion:updateAbsolutePosition()
+        if self.mdPageBand ~= nil and type(self.mdPageBand.updateAbsolutePosition) == "function" then
+            self.mdPageBand:updateAbsolutePosition()
         end
-        if isMd and self.mdGraphArea ~= nil and type(self.mdGraphArea.updateAbsolutePosition) == "function" then
+        if self.mdGraphArea ~= nil and type(self.mdGraphArea.updateAbsolutePosition) == "function" then
             self.mdGraphArea:updateAbsolutePosition()
         end
+        if type(self._seedMdSubnavTexts) == "function" then
+            self:_seedMdSubnavTexts()
+        end
+        if type(self._syncMdSubPageVisibility) == "function" then
+            self:_syncMdSubPageVisibility()
+        end
+    else
+        setVis(self.mdPricesBand, false)
+        setVis(self.mdEventsBand, false)
+        setVis(self.mdContractsBand, false)
+        setVis(self.mdOpenMarketBtn, false)
+        local btnE = self:getDescendantById("mdOpenMarketBtnEvents")
+        local btnC = self:getDescendantById("mdOpenMarketBtnContracts")
+        setVis(btnE, false)
+        setVis(btnC, false)
     end
     if not isCs then
         setVis(self.csFieldsEmptyHint, false)
@@ -1125,6 +1202,40 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     setVis(self.wcSubnavShell, isWc)
     setVis(self.wcSubnavSelector, isWc)
     setVis(self.wcSubnavDotBox, isWc)
+    -- MDM subnav twin (Prices | Events | Contracts); exclusive with WC subnav.
+    setVis(self.mdSubnavShell, isMd)
+    setVis(self.mdSubnavSelector, isMd)
+    setVis(self.mdSubnavDotBox, isMd)
+    if self.mdSubnavSelector ~= nil then
+        if isMd then
+            self.mdSubnavSelector.disableButtonsOnSingleText = false
+            self.mdSubnavSelector.hideLeftRightButtons = false
+            if type(self.mdSubnavSelector.setDisabled) == "function" then
+                self.mdSubnavSelector:setDisabled(false)
+            end
+            if type(self.mdSubnavSelector.setCanChangeState) == "function" then
+                self.mdSubnavSelector:setCanChangeState(true)
+            end
+            if self.mdSubnavShell ~= nil and type(self.mdSubnavShell.updateAbsolutePosition) == "function" then
+                self.mdSubnavShell:updateAbsolutePosition()
+            end
+            if type(self.mdSubnavSelector.updateAbsolutePosition) == "function" then
+                self.mdSubnavSelector:updateAbsolutePosition()
+            end
+            if type(self._ensureMdSubnavArrowsVisible) == "function" then
+                self:_ensureMdSubnavArrowsVisible()
+            end
+        else
+            self.mdSubnavSelector.hideLeftRightButtons = true
+            if type(self.mdSubnavSelector.setDisabled) == "function" then
+                self.mdSubnavSelector:setDisabled(true)
+            end
+            if type(self.mdSubnavSelector.setCanChangeState) == "function" then
+                self.mdSubnavSelector:setCanChangeState(false)
+            end
+            self._mdSubnavSeeded = false
+        end
+    end
     if self.wcSubnavSelector ~= nil then
         if isWc then
             self.wcSubnavSelector.disableButtonsOnSingleText = false
@@ -1170,24 +1281,48 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     setVis(self.wcPageSelector, false)
     setVis(self.wcSideInfoShell, isWc)
     setVis(self.wcSideVersion, false)
-    setVis(self.rfSideInfoShell, isSoil or isCs or isMd)
+    setVis(self.mdSideInfoShell, isMd)
+    -- Keep framework (Income/Depot/etc) side shell; dots always visible per origin/development tip.
+    setVis(self.rfSideInfoShell, isSoil or isCs or isFw)
     -- Module page dots always visible (umbrella: dots = N, chrome geometry unchanged).
     setVis(self.rfPanelDotBox, true)
     setVis(self.rfDotLegend, false)
     setVis(self.rfSuiteHint, false)
     setVis(self.rfSideMidSeparator, false)
     setVis(self.wcPageShell, isWc)
+    setVis(self.rfFrameworkGlanceShell, isFw)
+    setVis(self.rfFwStatusBlock, isFw and isFwStatus)
+    setVis(self.rfFwTableBlock, isFw and isFwTable)
+    -- Duplex title kill: rfPageTitle owns module name (George 2026-08-05).
+    -- Income / Depot densify: rfFwTableTitle is the summary band; do not blank/hide for those panels.
+    local fwStatusTitle = self:getDescendantById("rfFwStatusTitle")
+    local fwTableTitle = self:getDescendantById("rfFwTableTitle")
+    setVis(fwStatusTitle, false)
+    if activeId ~= "income" and activeId ~= "fertilizerDepot" then
+        setVis(fwTableTitle, false)
+    end
+    if fwStatusTitle ~= nil and type(fwStatusTitle.setText) == "function" then
+        fwStatusTitle:setText("")
+    end
+    if activeId ~= "income" and activeId ~= "fertilizerDepot" and fwTableTitle ~= nil and type(fwTableTitle.setText) == "function" then
+        fwTableTitle:setText("")
+    end
+    -- Framework overlap FAILFIX: hide page blurb on fw doors (side About owns story).
+    setVis(self.rfPageBlurb, not isFw)
+    if isFw and self.rfPageBlurb ~= nil and type(self.rfPageBlurb.setText) == "function" then
+        self.rfPageBlurb:setText("")
+    end
     setVis(self.wcGlanceShell, false)
     self:_refreshSideInfo(activeId)
-    -- CS: hide host body so table+detail get room (not isWc alone — body was still on for CS).
-    setVis(self.rfHostBody, not isWc and not isCs and not isMd)
+    -- CS: hide host body so table+detail get room (not isWc alone - body was still on for CS).
+    setVis(self.rfHostBody, not isWc and not isCs and not isMd and not isFw)
     -- Keep right hero title/blurb; hide duplicate host title/blurb on WC, MDM and CS.
-    setVis(self.rfHostTitle, not isWc and not isMd and not isCs)
-    setVis(self.rfHostBlurb, not isWc and not isMd and not isCs)
-    if (isWc or isCs or isMd) and self.rfHostBody and self.rfHostBody.setText then
+    setVis(self.rfHostTitle, not isWc and not isMd and not isCs and not isFw)
+    setVis(self.rfHostBlurb, not isWc and not isMd and not isCs and not isFw)
+    if (isWc or isCs or isMd or isFw) and self.rfHostBody and self.rfHostBody.setText then
         self.rfHostBody:setText("")
     end
-    -- Bottom bar: SPACE opens the Worker Manager deep desk while WC is active.
+    -- Bottom bar: SPACE opens full Market while MDM is active.
     if isMd and self.btnOpenMarket ~= nil then
         self.menuButtonInfo = { self.btnBack, self.btnOpenMarket }
         local trFn = self._rfTr
@@ -1238,8 +1373,32 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
             shell:setVisible(true)
         end
     end
-    if isWc and self.wcPageShell ~= nil and self.wcPageShell.updateAbsolutePosition then
+    -- Rank 1 containment (George 2026-08-06): force abs after show so shell/gray rect match Texts.
+    if self.rfHostPlaceholder ~= nil and type(self.rfHostPlaceholder.updateAbsolutePosition) == "function" then
+        self.rfHostPlaceholder:updateAbsolutePosition()
+    end
+    if isFw then
+        if self.rfFrameworkGlanceShell ~= nil and type(self.rfFrameworkGlanceShell.updateAbsolutePosition) == "function" then
+            self.rfFrameworkGlanceShell:updateAbsolutePosition()
+        end
+        if isFwStatus and self.rfFwStatusBlock ~= nil and type(self.rfFwStatusBlock.updateAbsolutePosition) == "function" then
+            self.rfFwStatusBlock:updateAbsolutePosition()
+        end
+        if isFwTable and self.rfFwTableBlock ~= nil and type(self.rfFwTableBlock.updateAbsolutePosition) == "function" then
+            self.rfFwTableBlock:updateAbsolutePosition()
+        end
+    end
+    if isWc and self.wcPageShell ~= nil and type(self.wcPageShell.updateAbsolutePosition) == "function" then
         self.wcPageShell:updateAbsolutePosition()
+        for _, pid in ipairs({"wcPageDashboard", "wcPageWages", "wcPageWorkers"}) do
+            local pe = self[pid] or (self.getDescendantById and self:getDescendantById(pid))
+            if pe ~= nil and type(pe.updateAbsolutePosition) == "function" and pe.visible ~= false then
+                pe:updateAbsolutePosition()
+            end
+        end
+    end
+    if isCs and self.rfHostTableRegion ~= nil and type(self.rfHostTableRegion.updateAbsolutePosition) == "function" then
+        self.rfHostTableRegion:updateAbsolutePosition()
     end
     if not isWc then
         self._wcSubnavSeeded = false
@@ -1287,7 +1446,7 @@ function RfPdaMenuPage:_seedWcSubnavTexts()
     if idx < 1 then idx = 1 end
     if idx > 3 then idx = 3 end
     self.wcSubPageIndex = idx
-    -- George arrow-crash FAIL-FIX: forceEvent=false — setState(true) re-enters onClick.
+    -- George arrow-crash FAIL-FIX: forceEvent=false - setState(true) re-enters onClick.
     if sel.setState then
         sel:setState(idx, false)
     end
@@ -1411,7 +1570,179 @@ function RfPdaMenuPage:_syncWcSubPageVisibility()
     setVis(self.wcPageAbout, false)
 end
 
---- Sibling-shell page MTO. Page index only â€” never Brand / selectPanel.
+--- MDM page selector = sibling left shell under Brand (WC twin).
+function RfPdaMenuPage:_mdPageSel()
+    return self.mdSubnavSelector
+end
+
+function RfPdaMenuPage:_ensureMdSubnavArrowsVisible()
+    self:_ensureMtoArrowsVisible(self:_mdPageSel())
+end
+
+--- Host-seed MDM page labels once on MDM enter (never forceEvent).
+function RfPdaMenuPage:_seedMdSubnavTexts()
+    local sel = self:_mdPageSel()
+    if sel == nil then
+        return
+    end
+    if self._mdSubnavSeeded then
+        return
+    end
+    local trFn = self._rfTr
+    local function t(key, fb)
+        if type(trFn) == "function" then
+            return trFn(key, fb)
+        end
+        return fb
+    end
+    if sel.setVisible then
+        sel:setVisible(true)
+    end
+    sel.disableButtonsOnSingleText = false
+    sel.hideLeftRightButtons = false
+    if sel.setCanChangeState then
+        sel:setCanChangeState(true)
+    end
+    if sel.setDisabled then
+        sel:setDisabled(false)
+    end
+    local texts = {
+        t("md_rf_pda_page_prices", "Prices"),
+        t("md_rf_pda_page_events", "Events"),
+        t("md_rf_pda_page_contracts", "Contracts"),
+    }
+    self._mdSubnavSeeding = true
+    if sel.setTexts then
+        sel:setTexts(texts)
+    end
+    local idx = tonumber(self.mdSubPageIndex) or 1
+    if idx < 1 then idx = 1 end
+    if idx > 3 then idx = 3 end
+    self.mdSubPageIndex = idx
+    if sel.setState then
+        sel:setState(idx, false)
+    end
+    self._mdSubnavSeeding = false
+    self._mdSubnavSeeded = true
+    self:_ensureMdSubnavArrowsVisible()
+    self:_rebuildMdSubnavDots(3)
+    if self.mdSubnavShell ~= nil and self.mdSubnavShell.updateAbsolutePosition then
+        self.mdSubnavShell:updateAbsolutePosition()
+    end
+    if sel.updateAbsolutePosition then
+        sel:updateAbsolutePosition()
+    end
+end
+
+function RfPdaMenuPage:_rebuildMdSubnavDots(count)
+    local dotBox = self.mdSubnavDotBox
+    if dotBox == nil or dotBox.elements == nil or #dotBox.elements == 0 then
+        return
+    end
+    if type(dotBox.setVisible) == "function" then
+        dotBox:setVisible(true)
+    end
+    local elements = dotBox.elements
+    local expectedCount = math.max(1, count or 1)
+    while #elements < expectedCount do
+        local seed = elements[1]
+        if seed == nil or seed.clone == nil then
+            break
+        end
+        local ok, clone = pcall(function()
+            return seed:clone(dotBox)
+        end)
+        if not ok or clone == nil then
+            break
+        end
+        if FocusManager and FocusManager.loadElementFromCustomValues then
+            pcall(FocusManager.loadElementFromCustomValues, FocusManager, clone)
+        end
+        elements = dotBox.elements
+    end
+    while #elements > expectedCount do
+        local last = elements[#elements]
+        if last ~= nil and last.delete then
+            last:delete()
+        end
+        elements = dotBox.elements
+    end
+    for i, dot in ipairs(dotBox.elements) do
+        local index = i
+        function dot.getIsSelected()
+            local sel = self:_mdPageSel()
+            if sel == nil or sel.getState == nil then
+                return index == 1
+            end
+            return sel:getState() == index
+        end
+        if dot.setVisible then
+            dot:setVisible(true)
+        end
+    end
+    if dotBox.invalidateLayout then
+        dotBox:invalidateLayout()
+    end
+    if type(dotBox.updateAbsolutePosition) == "function" then
+        dotBox:updateAbsolutePosition()
+    end
+end
+
+--- Apply MDM secondary page visibility from self.mdSubPageIndex (1..3).
+--- TOP mdTableRegion stays visible; only BOTTOM bands swap.
+function RfPdaMenuPage:_syncMdSubPageVisibility()
+    local idx = tonumber(self.mdSubPageIndex) or 1
+    if idx < 1 then idx = 1 end
+    if idx > 3 then idx = 3 end
+    self.mdSubPageIndex = idx
+    local function setVis(el, visible)
+        if el ~= nil and type(el.setVisible) == "function" then
+            el:setVisible(visible)
+        end
+    end
+    setVis(self.mdPricesBand, idx == 1)
+    setVis(self.mdEventsBand, idx == 2)
+    setVis(self.mdContractsBand, idx == 3)
+    setVis(self.mdOpenMarketBtn, idx == 1)
+    local btnE = self:getDescendantById("mdOpenMarketBtnEvents")
+    local btnC = self:getDescendantById("mdOpenMarketBtnContracts")
+    setVis(btnE, idx == 2)
+    setVis(btnC, idx == 3)
+    if idx == 1 and self.mdGraphArea ~= nil and type(self.mdGraphArea.updateAbsolutePosition) == "function" then
+        self.mdGraphArea:updateAbsolutePosition()
+    end
+end
+
+--- Sibling-shell MDM page MTO. Page index only - never Brand / selectPanel.
+function RfPdaMenuPage:onClickMdSubnavSelector()
+    if self._mdSubnavSeeding then
+        return
+    end
+    local sel = self:_mdPageSel()
+    if sel == nil or sel.getState == nil then
+        return
+    end
+    if sel ~= self.mdSubnavSelector then
+        return
+    end
+    self:_ensureMdSubnavArrowsVisible()
+    local idx = sel:getState() or 1
+    if idx < 1 then idx = 1 end
+    if idx > 3 then idx = 3 end
+    self.mdSubPageIndex = idx
+    if sel.setState and sel:getState() ~= idx then
+        sel:setState(idx, false)
+    end
+    self:_syncMdSubPageVisibility()
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    if active ~= nil and active.id == "marketDynamics" and type(active.onShow) == "function" then
+        pcall(active.onShow, self.rfHostPlaceholder, true)
+    end
+end
+
+
+--- Sibling-shell page MTO. Page index only - never Brand / selectPanel.
 function RfPdaMenuPage:onClickWcSubnavSelector()
     if self._wcWageRefreshing or self._wcSubnavSeeding then
         return
@@ -1523,7 +1854,7 @@ function RfPdaMenuPage:refreshContent(rebuildLists)
         if panel == nil then
             if not self._rfSoilPanelMissingWarned then
                 self._rfSoilPanelMissingWarned = true
-                local msg = "[RfEsc] RfPdaSoilPanel missing — Soil table cannot rebuild (cross-mod env)"
+                local msg = "[RfEsc] RfPdaSoilPanel missing - Soil table cannot rebuild (cross-mod env)"
                 if Logging ~= nil and type(Logging.warning) == "function" then
                     Logging.warning("%s", msg)
                 else
@@ -1539,7 +1870,7 @@ function RfPdaMenuPage:refreshContent(rebuildLists)
                 end
                 panel.reloadFieldList(self)
             elseif self.fieldData == nil or #self.fieldData == 0 then
-                -- Safety: empty table after soft refresh — force one rebuild.
+                -- Safety: empty table after soft refresh - force one rebuild.
                 panel.rebuildFieldData(self)
                 if self.selectedFieldId == nil and self.fieldData[1] ~= nil then
                     self.selectedFieldId = self.fieldData[1].fieldId
@@ -1596,6 +1927,12 @@ function RfPdaMenuPage:refreshContent(rebuildLists)
                 self:_ensureWcWageArrowsVisible()
             end
         end
+        if active ~= nil and active.id == "marketDynamics" then
+            self:_seedMdSubnavTexts()
+            self:_syncMdSubPageVisibility()
+            self:_ensureMdSubnavArrowsVisible()
+            self:_ensureSelectorArrowsVisible()
+        end
         if active ~= nil and type(active.onShow) == "function" then
             if active.id == "seasonalCropStress" then
                 -- Full CS field list reload only on enter / rebuildLists (lightOnly otherwise).
@@ -1626,6 +1963,9 @@ function RfPdaMenuPage:getNumberOfItemsInSection(list, section)
     if list == self.csFieldOverviewList then
         return #(self.csFieldData or {})
     end
+    if list == self.mdCommodityList then
+        return #(self.mdCommodityData or {})
+    end
     if list == self.moduleList then
         return #self._panelCache
     end
@@ -1641,10 +1981,67 @@ function RfPdaMenuPage:populateCellForItemInSection(list, section, index, cell)
         end
     elseif list == self.csFieldOverviewList then
         self:_populateCsFieldRow(index, cell)
+    elseif list == self.mdCommodityList then
+        self:_populateMdCommodityRow(index, cell)
     elseif list == self.moduleList then
         self:_populateModuleRow(index, cell)
     end
 end
+
+function RfPdaMenuPage:_populateMdCommodityRow(index, cell)
+    local entry = (self.mdCommodityData or {})[index]
+    if entry == nil then return end
+    -- Deep Market twin: Bitmap cropIcon from fillType.hudOverlayFilename; hide if empty (no purple).
+    local iconEl = cell:getDescendantByName("cropIcon")
+    local nameEl = cell:getDescendantByName("mdCropRowName")
+    local priceEl = cell:getDescendantByName("mdCropRowPrice")
+    local changeEl = cell:getDescendantByName("mdCropRowChange")
+    if iconEl ~= nil then
+        local overlay = entry.hudOverlay
+        if type(overlay) == "string" and overlay ~= "" then
+            if type(iconEl.setImageFilename) == "function" then
+                iconEl:setImageFilename(overlay)
+            end
+            if type(iconEl.setVisible) == "function" then
+                iconEl:setVisible(true)
+            end
+        else
+            if type(iconEl.setVisible) == "function" then
+                iconEl:setVisible(false)
+            end
+        end
+    end
+    if nameEl then nameEl:setText(entry.title or "-") end
+    local priceText = "-"
+    if entry.price ~= nil then
+        if g_i18n and g_i18n.formatMoney then
+            priceText = g_i18n:formatMoney(entry.price, 0, true, true)
+        else
+            priceText = string.format("%.0f", entry.price)
+        end
+    end
+    if priceEl then priceEl:setText(priceText) end
+    local pct = tonumber(entry.changePct) or 0
+    local changeText
+    if pct > 0 then
+        changeText = string.format("+%.1f%%", pct)
+    else
+        changeText = string.format("%.1f%%", pct)
+    end
+    if changeEl then
+        changeEl:setText(changeText)
+        if type(changeEl.setTextColor) == "function" then
+            if pct > 0.5 then
+                changeEl:setTextColor(0.30, 0.80, 0.35, 1)
+            elseif pct < -0.5 then
+                changeEl:setTextColor(0.90, 0.25, 0.20, 1)
+            else
+                changeEl:setTextColor(0.70, 0.72, 0.75, 1)
+            end
+        end
+    end
+end
+
 
 function RfPdaMenuPage:_populateCsFieldRow(index, cell)
     local entry = (self.csFieldData or {})[index]
@@ -1722,6 +2119,10 @@ function RfPdaMenuPage:onListSelectionChanged(list, section, index)
             self.csSelectedIndex = index
             self.csSelectedFieldId = entry.fieldId
             self:_refreshGuestDetail()
+        end
+    elseif list == self.mdCommodityList and index ~= nil and index > 0 then
+        if MdRfPdaGuest ~= nil and type(MdRfPdaGuest.selectCommodityIndex) == "function" then
+            MdRfPdaGuest.selectCommodityIndex(index)
         end
     elseif list == self.moduleList then
         -- Highlight-only: SmoothList ↑↓ must NOT switch modules.
@@ -1833,16 +2234,22 @@ function RfPdaMenuPage.toggle()
 end
 
 
---- Empty bind stubs for frozen MDM chrome nodes under a non-MDM door (partial installs).
-function RfPdaMenuPage:onClickMdSubnavSelector()
-end
-
-function RfPdaMenuPage:onClickMdCommodityRow(element)
-end
-
 function RfPdaMenuPage:onClickMdMoverSelector()
-    if MdRfPdaGuest ~= nil and type(MdRfPdaGuest.onMoverChanged) == "function" then
-        MdRfPdaGuest.onMoverChanged(self.rfHostPlaceholder or self)
+    -- Retired movers MTO (kept for nil-safe onClick binding).
+    return
+end
+
+--- Mirror onClickCsFieldRow for MDM commodities: select row, refresh Prices bottom.
+function RfPdaMenuPage:onClickMdCommodityRow(element)
+    local index = resolveListRowIndex(element)
+    if index == nil or index < 1 then
+        return
+    end
+    if self.mdCommodityList and self.mdCommodityList.setSelectedIndex then
+        pcall(function() self.mdCommodityList:setSelectedIndex(index) end)
+    end
+    if MdRfPdaGuest ~= nil and type(MdRfPdaGuest.selectCommodityIndex) == "function" then
+        MdRfPdaGuest.selectCommodityIndex(index)
     end
 end
 
@@ -1853,3 +2260,4 @@ function RfPdaMenuPage:onClickMdOpenMarket()
         MDMMarketScreen.show()
     end
 end
+

--- a/tools/test/lua/scs039_delegation_test.lua
+++ b/tools/test/lua/scs039_delegation_test.lua
@@ -186,4 +186,54 @@ do
   T.near("set.survivesSettle", sys.fieldData[1].moisture, 0.80, 1e-9)
 end
 
+
+-- 9. MAP DRAINAGE: conserved by construction, and it runs downhill.
+--    Water must MOVE between places without the field total changing, and it
+--    must arrive at the hollow rather than the ridge.
+do
+  local drain = SoilMoistureSystem.computeDrainageAdditions
+
+  local function sum(t)
+    local s = 0
+    for i = 1, #t do s = s + t[i] end
+    return s
+  end
+
+  -- A slope with uniform water: relief alone decides the direction.
+  local h, m = {}, {}
+  for i = 1, 20 do h[i] = 100 + i * 1.0; m[i] = 0.50 end
+  local add = drain(h, m, 0.05)
+  T.near("drain.slopeConserves", sum(add), 0, 1e-9)
+  T.ok("drain.lowGroundGains", add[1] > 0)
+  T.ok("drain.highGroundGives", add[20] < 0)
+
+  -- A flat field with uneven water: the water term alone levels it, and still
+  -- conserves. This is the case that must match the cell store's behaviour.
+  local fh, fm = {}, {}
+  for i = 1, 20 do fh[i] = 88.0; fm[i] = 0.30 + (i % 4) * 0.1 end
+  local fadd = drain(fh, fm, 0.05)
+  T.near("drain.flatConserves", sum(fadd), 0, 1e-9)
+  local wettest, driest = 1, 1
+  for i = 2, 20 do
+    if fm[i] > fm[wettest] then wettest = i end
+    if fm[i] < fm[driest] then driest = i end
+  end
+  T.ok("drain.wettestGives", fadd[wettest] < 0)
+  T.ok("drain.driestGains", fadd[driest] > 0)
+
+  -- A hollow: one low block among many, the shape that must not leak.
+  local hh, hm = {}, {}
+  for i = 1, 30 do hh[i] = 120.0; hm[i] = 0.45 end
+  hh[15] = 112.0
+  local hadd = drain(hh, hm, 0.05)
+  T.near("drain.hollowConserves", sum(hadd), 0, 1e-9)
+  T.ok("drain.hollowGains", hadd[15] > 0)
+  T.ok("drain.surroundGives", hadd[1] < 0)
+
+  -- Degenerate inputs refuse rather than divide by zero.
+  T.eq("drain.singleBlockRefuses", drain({1}, {0.5}, 0.05), nil)
+  T.eq("drain.emptyRefuses", drain({}, {}, 0.05), nil)
+  T.eq("drain.mismatchedRefuses", drain({1, 2}, {0.5}, 0.05), nil)
+end
+
 T.summary()

--- a/tools/test/lua/scs039_delegation_test.lua
+++ b/tools/test/lua/scs039_delegation_test.lua
@@ -1,0 +1,189 @@
+-- scs039_delegation_test.lua
+-- SCS-039 / GRID-1: the delegate-when-present seam.
+--
+-- THE INVARIANT THIS EXISTS FOR: engine-absent must be TODAY, EXACTLY. Every
+-- branch SCS-039 adds is gated on mapActive(), and when that is false the
+-- shipped sparse-cell store must behave bit for bit as it did before the map
+-- was written. A regression here is invisible on any machine where the map
+-- works, which is most of them, so it gets its own bench.
+--
+-- The map-present half is driven through a stub value map: the engine calls
+-- themselves are not testable off a running game, but the DELEGATION (what gets
+-- called, with what, and what is skipped) is, and that is where the bugs live.
+--!load: src/maps/CropStressValueMap.lua, src/SoilMoistureSystem.lua
+
+-- A stub standing in for the engine-backed map. Records what it was asked to do.
+local function stubMap(grain)
+  local m = {
+    available = true,
+    grain     = grain or 2,
+    painted   = {},
+    writes    = {},
+    deltas    = {},
+    pixels    = {},          -- "x:z" -> value, so reads see prior writes
+    meanToReturn = nil,
+  }
+  function m:getGrainMetres() return self.grain end
+  function m:paintPolygon(_vx, _vz, _n, value)
+    self.painted[#self.painted + 1] = value
+    return true
+  end
+  function m:writeValueAtWorld(x, z, value, _r)
+    self.writes[#self.writes + 1] = { x = x, z = z, v = value }
+    self.pixels[string.format("%d:%d", math.floor(x), math.floor(z))] = value
+    return true
+  end
+  function m:readValueAtWorld(x, z)
+    return self.pixels[string.format("%d:%d", math.floor(x), math.floor(z))], self.grain
+  end
+  function m:applyDeltaToPolygon(_vx, _vz, _n, delta)
+    self.deltas[#self.deltas + 1] = delta
+    return delta            -- pretend the engine applied it in full
+  end
+  function m:readAverageOfPolygon(_vx, _vz, _n)
+    return self.meanToReturn, self.grain
+  end
+  return m
+end
+
+local function newSystem()
+  local sys = SoilMoistureSystem.new({ eventBus = nil })
+  sys.isInitialized = true
+  sys.fieldData[1] = {
+    fieldId = 1, moisture = 0.50, soilType = "loamy", irrigationGain = 0.0,
+    centerX = 0, centerZ = 0, cells = {}, cellSum = 0, cellCount = 0, reliefScan = false,
+  }
+  -- A square field polygon, pre-cached so no scene walk is needed.
+  sys._fieldVerts[1] = { vx = {0, 100, 100, 0}, vz = {0, 0, 100, 100}, n = 4 }
+  return sys
+end
+
+-- 1. NO MAP = NOT ACTIVE, and every new branch stays out of the way.
+do
+  local sys = newSystem()
+  T.eq("absent.mapNotActive", sys:mapActive(), false)
+  T.eq("absent.migrateRefuses", sys:migrateFieldToMap(1), false)
+
+  -- The positional getter falls back to the cell path and reports CELL grain.
+  local v, grain = sys:getMoisture(1, 10, 10)
+  T.near("absent.readsAggregate", v, 0.50, 1e-9)
+  T.eq("absent.reportsCellGrain", grain, sys:getCellSize())
+
+  -- Field-level read is unchanged and reports no grain.
+  local fv, fgrain = sys:getMoisture(1)
+  T.near("absent.fieldRead", fv, 0.50, 1e-9)
+  T.eq("absent.fieldGrainNil", fgrain, nil)
+end
+
+-- 2. ENGINE-ABSENT CELL BEHAVIOUR IS UNCHANGED: applyWaterAtCell still
+--    materialises a cell and still moves the aggregate, exactly as SCS-018.
+do
+  local sys = newSystem()
+  sys:applyWaterAtCell(1, 10, 10, 0.20)
+  local d = sys.fieldData[1]
+  T.eq("absent.cellMaterialised", d.cellCount, 1)
+  T.ok("absent.cellHoldsWater", d.cellSum > 0.5)
+  local v = sys:getMoisture(1, 10, 10)
+  T.near("absent.cellReadsBack", v, 0.70, 1e-6)
+end
+
+-- 3. MAP PRESENT: the getter delegates and reports MAP grain, not cell grain.
+do
+  local sys = newSystem()
+  sys.valueMap = stubMap(2)
+  T.eq("present.mapActive", sys:mapActive(), true)
+
+  sys:applyWaterAtCell(1, 10, 10, 0.20)
+  local d = sys.fieldData[1]
+  -- The cell store must NOT be touched once the map carries the truth,
+  -- or two stores drift apart and nobody knows which one is the ground.
+  T.eq("present.noCellMaterialised", d.cellCount, 0)
+  T.ok("present.mapWasWritten", #sys.valueMap.writes > 0)
+
+  local v, grain = sys:getMoisture(1, 10, 10)
+  T.near("present.readsMapValue", v, 0.70, 1e-6)
+  T.eq("present.reportsMapGrain", grain, 2)
+end
+
+-- 4. MIGRATION runs ONCE and paints the base coat before stamping cells.
+do
+  local sys = newSystem()
+  -- Give the field two materialised cells first (an old save being upgraded).
+  sys:applyWaterAtCell(1, 10, 10, 0.20)
+  sys:applyWaterAtCell(1, 50, 50, 0.10)
+  local before = sys:getMoisture(1)
+
+  sys.valueMap = stubMap(2)
+  T.eq("migrate.firstCallSeeds", sys:migrateFieldToMap(1), true)
+  T.eq("migrate.baseCoatPainted", #sys.valueMap.painted, 1)
+  T.near("migrate.baseCoatIsAggregate", sys.valueMap.painted[1], before, 1e-9)
+  T.eq("migrate.cellsStamped", #sys.valueMap.writes, 2)
+
+  -- Second call is a no-op: re-seeding would wipe live map data with stale cells.
+  local paintedBefore = #sys.valueMap.painted
+  T.eq("migrate.secondCallNoOp", sys:migrateFieldToMap(1), true)
+  T.eq("migrate.noReseed", #sys.valueMap.painted, paintedBefore)
+end
+
+-- 5. THE DAILY SETTLE RE-DERIVES the scalar from the map instead of trusting it.
+do
+  local sys = newSystem()
+  sys.valueMap = stubMap(2)
+  sys.fieldData[1].moisture = 0.50
+  sys.valueMap.meanToReturn = 0.42
+  sys:settleDaily(1)
+  T.near("settle.scalarReDerived", sys.fieldData[1].moisture, 0.42, 1e-9)
+
+  -- A map that cannot answer must leave the scalar alone rather than zero it.
+  sys.valueMap.meanToReturn = nil
+  sys:settleDaily(1)
+  T.near("settle.nilMeanLeavesScalar", sys.fieldData[1].moisture, 0.42, 1e-9)
+end
+
+-- 6. THE DAILY SETTLE ON THE FALLBACK still runs the conserving drainage and
+--    still conserves. Guards the branch split above from eating SCS-018.
+do
+  local sys = newSystem()
+  sys:applyWaterAtCell(1, 10, 10, 0.30)
+  sys:applyWaterAtCell(1, 50, 50, 0.00001)
+  local d = sys.fieldData[1]
+  local totalBefore = d.cellSum
+  sys:settleDaily(1)
+  T.near("fallback.drainageConserves", d.cellSum, totalBefore, 1e-6)
+  T.ok("fallback.stillHasCells", d.cellCount == 2)
+end
+
+-- 7. THE POLYGON CACHE remembers a refusal, so a field with no usable polygon
+--    does not re-walk the field list every single hour.
+do
+  local sys = newSystem()
+  sys._fieldVerts = {}
+  local vx = sys:_getFieldVerts(999)          -- no such field, no g_fieldManager
+  T.eq("cache.refusalReturnsNil", vx, nil)
+  T.ok("cache.refusalRemembered", sys._fieldVerts[999] ~= nil)
+  T.eq("cache.refusalIsZeroN", sys._fieldVerts[999].n, 0)
+  T.eq("cache.secondCallStillNil", (sys:_getFieldVerts(999)), nil)
+end
+
+
+-- 8. A FIELD-LEVEL SET REACHES THE MAP, or the daily re-derive silently
+--    reverts it. Regression guard for csSetMoisture and the sprayer path.
+do
+  local sys = newSystem()
+  sys.valueMap = stubMap(2)
+  sys.fieldData[1].mapPending = 0.002        -- stale sub-step carry
+
+  T.eq("set.accepted", sys:setMoisture(1, 0.80), true)
+  T.ok("set.mapPainted", #sys.valueMap.painted > 0)
+  T.near("set.paintedValue", sys.valueMap.painted[#sys.valueMap.painted], 0.80, 1e-9)
+  T.near("set.scalarFollows", sys.fieldData[1].moisture, 0.80, 1e-9)
+  -- The carried delta was accumulated against ground that no longer exists.
+  T.near("set.pendingCleared", sys.fieldData[1].mapPending, 0, 1e-12)
+
+  -- And it survives the daily re-derive, because the map now agrees.
+  sys.valueMap.meanToReturn = 0.80
+  sys:settleDaily(1)
+  T.near("set.survivesSettle", sys.fieldData[1].moisture, 0.80, 1e-9)
+end
+
+T.summary()

--- a/tools/test/lua/scs039_delivery_test.lua
+++ b/tools/test/lua/scs039_delivery_test.lua
@@ -1,0 +1,149 @@
+-- scs039_delivery_test.lua
+-- SCS-039 / GRID-1: MP row delivery, the release gate, the degrade path, and
+-- the SCS-037 composition seam.
+--
+-- The wire itself is not testable off a running game, but the PACKING is, and
+-- that is where a sync bug hides: a row that packs and unpacks to something
+-- other than what it was leaves a client's ground quietly wrong, with nothing
+-- in the log and no crash to notice.
+--!load: src/maps/CropStressValueMap.lua, src/ReleaseGate.lua, src/SoilMoistureSystem.lua
+
+local pack   = CropStressValueMap.packRow
+local unpack = CropStressValueMap.unpackRow
+
+local function sameRow(name, a, b, width)
+  if #a ~= #b then
+    T.ok(name .. ".length", false)
+    return
+  end
+  for i = 1, #a do
+    if a[i] ~= b[i] then
+      T.ok(name .. ".index" .. i, false)
+      return
+    end
+  end
+  T.ok(name, true)
+end
+
+-- 1. RUN-LENGTH ROUND TRIP is lossless on the shapes a moisture map actually has.
+do
+  -- The dominant real shape: a long off-field run at the raw-0 sentinel, one
+  -- field at a uniform level, then sentinel again.
+  local row = {}
+  for i = 1, 200 do row[i] = 0 end
+  for i = 80, 140 do row[i] = 128 end
+  sameRow("pack.fieldInSentinel", unpack(pack(row), 200), row, 200)
+
+  -- Fully uniform: the best case, and it must not lose the value.
+  local uni = {}
+  for i = 1, 100 do uni[i] = 77 end
+  sameRow("pack.uniform", unpack(pack(uni), 100), uni, 100)
+  T.eq("pack.uniformIsOneRun", #pack(uni), 2)
+
+  -- Fully noisy: the worst case. Still lossless, just not compressed.
+  local noisy = {}
+  for i = 1, 64 do noisy[i] = (i * 37) % 256 end
+  sameRow("pack.noisy", unpack(pack(noisy), 64), noisy, 64)
+
+  -- A single pixel.
+  sameRow("pack.single", unpack(pack({ 42 }), 1), { 42 }, 1)
+
+  -- Empty in, empty out, no crash.
+  T.eq("pack.emptyIsEmpty", #pack({}), 0)
+  T.eq("pack.unpackEmptyIsEmpty", #unpack({}, 10), 0)
+  T.eq("pack.unpackNilIsEmpty", #unpack(nil, 10), 0)
+end
+
+-- 2. UNPACK NEVER OVER-ALLOCATES. A malformed or hostile run table must not be
+--    able to make a client allocate past its own map width.
+do
+  local hostile = { 999999, 200 }          -- claims a run far wider than the map
+  local out = unpack(hostile, 64)
+  T.eq("pack.widthClamped", #out, 64)
+
+  local ragged = { 3, 10, 2 }              -- trailing length with no value
+  local r = unpack(ragged, 64)
+  T.ok("pack.raggedSurvives", #r >= 3)
+end
+
+-- 3. THE RELEASE GATE holds the map off for a player who has not opted in.
+--    SCS-039 ships LOCKED, so this is the default experience.
+do
+  T.ok("gate.rowExists", ReleaseGate.EXPERIMENTAL.cs_grid_concordance ~= nil)
+  T.eq("gate.lockedWithoutOptIn", ReleaseGate.isReleased("cs_grid_concordance", false), false)
+  T.eq("gate.liveWithOptIn", ReleaseGate.isReleased("cs_grid_concordance", true), true)
+  -- The shipped baseline is untouched by the new row.
+  T.eq("gate.baselineStillReleased", ReleaseGate.isReleased("something_shipped", false), true)
+end
+
+-- 4. THE DEGRADE PATH: a map that will not stand up leaves no half-built object
+--    behind, and does not retry the engine probe on every later call.
+do
+  local sys = SoilMoistureSystem.new({})
+  sys.isInitialized = true
+  -- No engine in the bench, so initialize() declines.
+  T.eq("degrade.initReturnsFalse", sys:initValueMap(nil), false)
+  T.eq("degrade.noHalfBuiltMap", sys.valueMap, nil)
+  T.eq("degrade.mapNotActive", sys:mapActive(), false)
+  T.eq("degrade.triedFlagSet", sys._valueMapTried, true)
+  -- Second call short-circuits rather than re-probing.
+  T.eq("degrade.secondCallStillFalse", sys:initValueMap(nil), false)
+end
+
+-- 5. SYNC REFUSES CLEANLY when there is no map, rather than queueing work that
+--    can never be delivered.
+do
+  local sys = SoilMoistureSystem.new({})
+  sys.isInitialized = true
+  T.eq("sync.queueRefusesWithoutMap", sys:queueMapSync({}), false)
+  T.eq("sync.updateIsZeroWhenIdle", sys:updateMapSync(), 0)
+end
+
+-- 6. THE INSTRUMENT answers even before anything has run, so csMapStats never
+--    errors on a fresh session.
+do
+  local sys = SoilMoistureSystem.new({})
+  sys.isInitialized = true
+  local s = sys:getMapStats()
+  T.eq("stats.inactive", s.active, false)
+  T.eq("stats.noRowsSent", s.syncRowsSent, 0)
+  T.eq("stats.noPending", s.syncPending, 0)
+  T.eq("stats.noSeededFields", s.seededFields, 0)
+end
+
+-- 7. THE SCS-037 SEAM: elapsed hours scale every per-hour term, and the default
+--    of 1 is arithmetically identical to what shipped.
+do
+  local weather = {
+    getHourlyEvapMultiplier = function() return 1.0 end,
+    getHourlyRainAmount     = function() return 0.0 end,
+  }
+
+  local function runWith(hours)
+    local sys = SoilMoistureSystem.new({})
+    sys.isInitialized = true
+    sys.fieldData[1] = {
+      fieldId = 1, moisture = 0.80, soilType = "loamy", irrigationGain = 0.0,
+      centerX = 0, centerZ = 0, cells = {}, cellSum = 0, cellCount = 0,
+    }
+    sys:hourlyUpdate(weather, hours)
+    return sys.fieldData[1].moisture
+  end
+
+  local oneHour   = runWith(1)
+  local defaulted = runWith(nil)
+  T.near("seam.defaultEqualsOneHour", defaulted, oneHour, 1e-12)
+
+  -- Three hours must dry three hours' worth, not one.
+  local threeHours = runWith(3)
+  local lossOne    = 0.80 - oneHour
+  local lossThree  = 0.80 - threeHours
+  T.ok("seam.threeHoursDriesMore", lossThree > lossOne)
+  T.near("seam.threeHoursIsThreeTimes", lossThree, lossOne * 3, 1e-9)
+
+  -- A garbage elapsed count cannot run time backwards.
+  T.near("seam.zeroFloorsToOne", runWith(0), oneHour, 1e-12)
+  T.near("seam.negativeFloorsToOne", runWith(-5), oneHour, 1e-12)
+end
+
+T.summary()

--- a/tools/test/lua/scs039_quantisation_floor_test.lua
+++ b/tools/test/lua/scs039_quantisation_floor_test.lua
@@ -1,0 +1,155 @@
+-- scs039_quantisation_floor_test.lua
+-- SCS-039 / GRID-1: the vendored moisture value map's correctness law.
+--
+-- THE BLOCKER THIS LOCKS: moisture spans 0..1 across 254 raw steps, so one raw
+-- step is ~0.0039 moisture. Hourly rain and evaporation deltas are routinely
+-- SMALLER than that. A naive per-hour write floors to zero every single time,
+-- so a full day of light rain moves the map by NOTHING and the ground silently
+-- stops responding to weather.
+--
+-- The moisture brief proved that shape on its own bench; this one locks the fix
+-- in the shipped code: sub-step deltas accumulate through quantiseDelta() and
+-- only whole raw steps are ever applied, with the remainder carried forward so
+-- nothing is lost and nothing is double counted.
+--!load: src/maps/CropStressValueMap.lua
+
+local DEF   = CropStressValueMap.LAYER_DEF
+local UPR   = CropStressValueMap._unitsPerRaw(DEF)      -- 1/254
+local quant = CropStressValueMap.quantiseDelta
+
+-- 1. The floor is where we think it is.
+do
+  T.near("upr.oneRawStep", UPR, 1 / 254, 1e-12)
+  T.ok("upr.subStepIsRealisticallyReachable", UPR > 0.003 and UPR < 0.005)
+end
+
+-- 2. THE NAIVE FAILURE, reproduced so the regression is visible if anyone
+--    removes the accumulator. A sub-step delta applied directly moves nothing.
+do
+  local hourlyRain = 0.001          -- well under one raw step
+  local base = 0.500
+  local rawBefore = CropStressValueMap._encode(base, DEF)
+  local rawAfter  = CropStressValueMap._encode(base + hourlyRain, DEF)
+  T.eq("naive.singleHourMovesNothing", rawAfter, rawBefore)
+
+  -- Twenty four of them, applied one at a time without accumulation, still
+  -- move nothing: each write re-reads the same unchanged value.
+  local v = base
+  for _ = 1, 24 do
+    local raw = CropStressValueMap._encode(v + hourlyRain, DEF)
+    v = CropStressValueMap._decode(raw, DEF)
+  end
+  T.near("naive.wholeDayMovesNothing", v, base, 1e-9)
+end
+
+-- 3. THE FIX: the same 24 hours through the accumulator DOES move the map,
+--    and lands within one raw step of the honest total.
+do
+  local hourlyRain = 0.001
+  local pending, applied = 0, 0
+  for _ = 1, 24 do
+    pending = pending + hourlyRain
+    local step, rest = quant(pending)
+    applied = applied + step
+    pending = rest
+  end
+  T.ok("accumulated.dayActuallyMoves", applied > 0)
+  T.near("accumulated.totalIsHonest", applied + pending, 24 * hourlyRain, 1e-12)
+  T.ok("accumulated.remainderUnderOneStep", math.abs(pending) < UPR)
+end
+
+-- 4. NOTHING IS LOST AND NOTHING IS INVENTED, over a long noisy run.
+--    applied + remaining must always equal everything fed in.
+do
+  local pending, applied, fed = 0, 0, 0
+  local seed = 12345
+  for i = 1, 500 do
+    -- deterministic pseudo-noise, both signs, mostly sub-step
+    seed = (seed * 1103515245 + 12345) % 2147483648
+    local d = ((seed / 2147483648) - 0.5) * 0.004
+    fed = fed + d
+    pending = pending + d
+    local step, rest = quant(pending)
+    applied = applied + step
+    pending = rest
+  end
+  T.near("conservation.nothingLost", applied + pending, fed, 1e-9)
+  T.ok("conservation.remainderBounded", math.abs(pending) < UPR)
+end
+
+-- 5. SIGN DISCIPLINE: truncation is toward zero in BOTH directions. A positive
+--    remainder must never produce a negative step, or a drying field would
+--    oscillate around a value it never reaches.
+do
+  local step, rest = quant(UPR * 0.9)
+  T.eq("sign.positiveSubStepApplies", step, 0)
+  T.near("sign.positiveSubStepCarries", rest, UPR * 0.9, 1e-12)
+
+  step, rest = quant(-UPR * 0.9)
+  T.eq("sign.negativeSubStepApplies", step, 0)
+  T.near("sign.negativeSubStepCarries", rest, -UPR * 0.9, 1e-12)
+
+  step, rest = quant(UPR * 2.5)
+  T.near("sign.positiveTakesWholeSteps", step, UPR * 2, 1e-12)
+  T.ok("sign.positiveRemainderStaysPositive", rest > 0)
+
+  step, rest = quant(-UPR * 2.5)
+  T.near("sign.negativeTakesWholeSteps", step, -UPR * 2, 1e-12)
+  T.ok("sign.negativeRemainderStaysNegative", rest < 0)
+end
+
+-- 6. EXACT STEP BOUNDARIES do not leak a phantom remainder.
+do
+  for n = 1, 6 do
+    local step, rest = quant(UPR * n)
+    T.near("boundary.applied." .. n, step, UPR * n, 1e-12)
+    T.near("boundary.remainder." .. n, rest, 0, 1e-12)
+  end
+end
+
+-- 7. ENCODE / DECODE round trip stays inside half a raw step across the range,
+--    and the no-data sentinel is never produced by a legal value.
+do
+  for i = 0, 20 do
+    local v = i / 20
+    local raw = CropStressValueMap._encode(v, DEF)
+    T.ok("encode.neverSentinel." .. i, raw >= 1 and raw <= 255)
+    local back = CropStressValueMap._decode(raw, DEF)
+    T.ok("encode.roundTrip." .. i, math.abs(back - v) <= UPR * 0.5 + 1e-9)
+  end
+  T.eq("decode.rawZeroIsNoData", CropStressValueMap._decode(0, DEF), nil)
+  T.eq("decode.rawNilIsNoData", CropStressValueMap._decode(nil, DEF), nil)
+end
+
+-- 8. CLAMPING: out-of-range moisture cannot wrap into the sentinel or past the top.
+do
+  T.eq("clamp.belowRange", CropStressValueMap._encode(-5.0, DEF), 1)
+  T.eq("clamp.aboveRange", CropStressValueMap._encode(5.0, DEF), 255)
+  T.eq("clamp.exactFloor", CropStressValueMap._encode(0.0, DEF), 1)
+  T.eq("clamp.exactCeiling", CropStressValueMap._encode(1.0, DEF), 255)
+end
+
+-- 9. ENGINE ABSENT IS INERT, NOT BROKEN. With no engine the map declines to
+--    initialize and every accessor stays quiet, so the cell-store fallback runs
+--    exactly as it does today.
+do
+  local m = CropStressValueMap.new()
+  T.eq("inert.notAvailableBeforeInit", m.available, false)
+  T.eq("inert.grainIsNil", m:getGrainMetres(), nil)
+  T.eq("inert.readIsNil", (m:readValueAtWorld(0, 0)), nil)
+  T.eq("inert.writeRefuses", m:writeValueAtWorld(0, 0, 0.5, 2), false)
+  T.eq("inert.deltaAppliesNothing", m:applyDeltaToPolygon(nil, nil, 0, 0.5), 0)
+  T.eq("inert.averageIsNil", (m:readAverageOfPolygon(nil, nil, 0)), nil)
+  T.eq("inert.saveRefuses", m:saveToSavegame("/nowhere"), false)
+end
+
+-- 10. THE QUANTISER IS PURE and needs no engine at all, which is what lets the
+--     accumulation law be proven off a running game.
+do
+  T.eq("pure.zeroIn", (quant(0)), 0)
+  T.eq("pure.nilIn", (quant(nil)), 0)
+  local _, rest = quant(nil)
+  T.eq("pure.nilCarriesZero", rest, 0)
+end
+
+T.summary()

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <!--
     RF Esc greenfield 2026-08-02 — vanilla InGameMenu chrome (Contracts/Animals).
     Left nest: fs25_subCategoryContainerBg + fs25_subCategoryContainer +
@@ -96,7 +96,7 @@
                 </GuiElement>
             </GuiElement>
 
-            <!-- RIGHT: suite content plane (RF_MainColShell flushes X≈406 to side-info right). -->
+            <!-- RIGHT: suite content plane (RF_MainColShell flushes X˜406 to side-info right). -->
             <GuiElement profile="RF_MainColShell" id="rfMainCol">
                 <GuiElement profile="fs25_menuHeaderPanel" position="0px 74px">
                     <Bitmap profile="fs25_menuHeaderIconBg">
@@ -104,7 +104,7 @@
                     </Bitmap>
                     <Text profile="fs25_menuHeaderTitle" id="rfPageTitle" text="Realistic Farming"/>
                 </GuiElement>
-                <Text profile="RF_PageTagline" id="rfPageBlurb" position="40px -24px" size="90% 28px"
+                <Text profile="RF_PageTagline" id="rfPageBlurb" position="40px -24px" size="90% 48px"
                       textMaxNumLines="2" text=""/>
 
                 <GuiElement id="wcTitlePageShell" visible="false">
@@ -167,9 +167,9 @@
 
                         <!-- Col 1: vertical target stack (F11 positions held; Selected field moved right) -->
                         <Text profile="RF_TreatTargetLine" id="treatTargetsHeading" position="10px -56px" size="250px 20px"/>
-                        <Text profile="RF_TreatTargetLine" id="treatTargetN" position="10px -78px" size="250px 20px"/>
-                        <Text profile="RF_TreatTargetLine" id="treatTargetP" position="10px -100px" size="250px 20px"/>
-                        <Text profile="RF_TreatTargetLine" id="treatTargetK" position="10px -122px" size="250px 20px"/>
+                        <Text profile="RF_TreatTargetLine" id="treatTargetN" position="10px -88px" size="250px 20px"/>
+                        <Text profile="RF_TreatTargetLine" id="treatTargetP" position="10px -120px" size="250px 20px"/>
+                        <Text profile="RF_TreatTargetLine" id="treatTargetK" position="10px -152px" size="250px 20px"/>
                         <!-- Legacy bind kept hidden (F5 replaces single multiline Text) -->
                         <Text profile="RF_HintText" id="treatTargetsLabel" position="10px -54px" size="1px 1px"
                               visible="false"/>
@@ -244,6 +244,18 @@
                             </GuiElement>
                         </GuiElement>
 
+                        <!-- Col 3: read-only crop rotation card (Wizard red square 2026-08-07,
+                             Samantha DESIGN ACK). Reuses RotationPlannerData copy so the words
+                             match the deep planner. Read-only: no SmoothList, no apply controls. -->
+                        <GuiElement profile="RF_ProductsShell" id="soilRotationCard" position="850px -88px" size="290px 248px">
+                            <Text profile="RF_ProductsTitle" id="soilRotationTitle" position="0px 0px" size="290px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationLast" position="0px -24px" size="290px 40px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCell" id="soilRotationStatus" position="0px -68px" size="290px 20px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationTip" position="0px -92px" size="290px 60px"
+                                  textMaxNumLines="3" textVerticalAlignment="top"/>
+                        </GuiElement>
+
                         <!-- Col 3: sampling — shifted right so widened PRODUCTS does not overlap -->
                         <GuiElement id="samplingInfoBox" position="850px -24px" width="180px" height="220px" visible="false">
                             <Bitmap profile="RF_InfoBoxBg"/>
@@ -271,14 +283,14 @@
                         <!-- Dashboard -->
                         <GuiElement profile="RF_WcPage" id="wcPageDashboard" visible="true">
                             <Text profile="RF_TreatTargetLine" id="wcDashStatus" position="0px 0px" size="1140px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashMode" position="0px -28px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashWage" position="580px -28px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashRate" position="0px -56px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashWorkers" position="580px -56px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashEstimate" position="0px -84px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashCountdown" position="580px -84px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="wcDashWorkerNames" position="0px -120px" size="1140px 360px"
-                                  textMaxNumLines="14" textVerticalAlignment="top" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashMode" position="0px -48px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashWage" position="580px -48px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashRate" position="0px -96px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashWorkers" position="580px -96px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashEstimate" position="0px -144px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashCountdown" position="580px -144px" size="560px 22px" text=""/>
+                            <Text profile="RF_HintText" id="wcDashWorkerNames" position="0px -200px" size="1140px 280px"
+                                  textMaxNumLines="12" textVerticalAlignment="top" text=""/>
                         </GuiElement>
 
                         <!-- Wages: tight label+option rows; summary/help/Reset UNDER stack (no 760 side column). -->
@@ -302,12 +314,12 @@
                             <MultiTextOption profile="RF_WcWageOption" id="wcOptMonthlySalary" position="220px -260px"
                                              disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
                             <!-- Summary band under last option (~-260); full width; not overlapping options. -->
-                            <Text profile="RF_SectionTitle" id="wcWageBigRate" position="0px -320px" size="1140px 36px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageRateLabel" position="0px -356px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcWagePayInterval" position="580px -356px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="wcWageHelpBody" position="0px -388px" size="1140px 120px"
-                                  textMaxNumLines="5" textVerticalAlignment="top" text=""/>
-                            <Button profile="buttonActivate" id="wcBtnWageReset" position="0px -520px" size="200px 36px"
+                            <Text profile="RF_SectionTitle" id="wcWageBigRate" position="0px -340px" size="1140px 36px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcWageRateLabel" position="0px -384px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcWagePayInterval" position="580px -384px" size="560px 22px" text=""/>
+                            <Text profile="RF_HintText" id="wcWageHelpBody" position="0px -420px" size="1140px 100px"
+                                  textMaxNumLines="4" textVerticalAlignment="top" text=""/>
+                            <Button profile="buttonActivate" id="wcBtnWageReset" position="0px -536px" size="200px 36px"
                                     text="Reset" onClick="onClickWcWageReset"/>
                         </GuiElement>
 
@@ -315,12 +327,12 @@
                         <GuiElement profile="RF_WcPage" id="wcPageWorkers" visible="false">
                             <Text profile="RF_TreatTargetLine" id="wcStatsMode" position="0px 0px" size="560px 22px" text=""/>
                             <Text profile="RF_TreatTargetLine" id="wcStatsWage" position="580px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsInterval" position="0px -28px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsCount" position="580px -28px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsCostPer" position="0px -56px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsTotal" position="580px -56px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="wcStatsWorkerList" position="0px -96px" size="1140px 380px"
-                                  textMaxNumLines="16" textVerticalAlignment="top" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcStatsInterval" position="0px -48px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcStatsCount" position="580px -48px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcStatsCostPer" position="0px -96px" size="560px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcStatsTotal" position="580px -96px" size="560px 22px" text=""/>
+                            <Text profile="RF_HintText" id="wcStatsWorkerList" position="0px -160px" size="1140px 320px"
+                                  textMaxNumLines="14" textVerticalAlignment="top" text=""/>
                         </GuiElement>
 
                         <!-- About page retired 2026-08-02: copy lives in wcSideInfoShell. Keep shell for nil-safe ids. -->
@@ -339,6 +351,70 @@
 
                     <!-- Legacy glance id kept as alias shell (hidden); guest prefers wcPageShell. -->
                     <GuiElement id="wcGlanceShell" position="16px -150px" size="1140px 1px" visible="false"/>
+
+
+                    <!-- Framework glance shell (Income/Tax/Depot Status + Dairy/NPC Favor Table).
+                         Text-only; no onClick. Visible only for framework module ids.
+                         George 2026-08-05: shell 0/-20 (X flush + B1 blurb-48 clearance); titles hidden; rows +36. -->
+                    <GuiElement profile="RF_WcPageShell" id="rfFrameworkGlanceShell" visible="false" position="0px 0px">
+                        <GuiElement id="rfFwStatusBlock" visible="true" position="0px 0px" size="1140px 580px">
+                            <Text profile="RF_SectionTitle" id="rfFwStatusTitle" position="0px 0px" size="1140px 24px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine1" position="0px 0px" size="1140px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine2" position="0px -48px" size="1140px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine3" position="0px -96px" size="1140px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine4" position="0px -144px" size="1140px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine5" position="0px -192px" size="1140px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine6" position="0px -240px" size="1140px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine7" position="0px -288px" size="1140px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine8" position="0px -336px" size="1140px 22px" text=""/>
+                            <Text profile="RF_HintText" id="rfFwHint" position="0px -384px" size="1140px 120px"
+                                  textMaxNumLines="4" textVerticalAlignment="top" text=""/>
+                        </GuiElement>
+                        <GuiElement id="rfFwTableBlock" visible="false" position="0px 0px" size="1140px 580px">
+                            <Text profile="RF_SectionTitle" id="rfFwTableTitle" position="0px 0px" size="1140px 24px" text="" visible="false"/>
+                            <Text profile="RF_ColHeader" id="rfFwColA" position="0px -32px" size="280px 22px" text=""/>
+                            <Text profile="RF_ColHeader" id="rfFwColB" position="300px -32px" size="280px 22px" text=""/>
+                            <Text profile="RF_ColHeader" id="rfFwColC" position="600px -32px" size="220px 22px" text=""/>
+                            <Text profile="RF_ColHeader" id="rfFwColD" position="840px -32px" size="280px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1A" position="0px -60px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1B" position="300px -60px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1C" position="600px -60px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1D" position="840px -60px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2A" position="0px -88px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2B" position="300px -88px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2C" position="600px -88px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2D" position="840px -88px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3A" position="0px -116px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3B" position="300px -116px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3C" position="600px -116px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3D" position="840px -116px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4A" position="0px -144px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4B" position="300px -144px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4C" position="600px -144px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4D" position="840px -144px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5A" position="0px -172px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5B" position="300px -172px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5C" position="600px -172px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5D" position="840px -172px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6A" position="0px -200px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6B" position="300px -200px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6C" position="600px -200px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6D" position="840px -200px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7A" position="0px -228px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7B" position="300px -228px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7C" position="600px -228px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7D" position="840px -228px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8A" position="0px -256px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8B" position="300px -256px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="600px -256px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="840px -256px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwMore" position="0px -292px" size="1140px 20px" text=""/>
+                            <Text profile="RF_HintText" id="rfFwEmptyHint" position="0px -60px" size="1140px 44px"
+                                  textMaxNumLines="2" visible="false" text=""/>
+                            <Text profile="RF_HintText" id="rfFwHintTable" position="0px -328px" size="1140px 80px"
+                                  textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                        </GuiElement>
+                    </GuiElement>
 
                     <!-- CS table: top-flush with 404 bottom reserve so the last rows clear the
                          FIELD DETAIL band title (CS FieldDetail fix, applied in the HOST page). -->
@@ -374,7 +450,7 @@
                         </GuiElement>
 
                         <Text profile="RF_EmptyHint" id="csFieldsEmptyHint" text=""
-                              position="0px 80px" size="100% 40px" visible="false"/>
+                              position="16px -80px" size="1100px 44px" visible="false"/>
                     </GuiElement>
 
                     <!-- CS bottom info band: twin Soil strip chrome, Text-only detail for the
@@ -422,7 +498,7 @@
                         </GuiElement>
 
                         <Text profile="RF_EmptyHint" id="mdCommoditiesEmptyHint" text=""
-                              position="0px 80px" size="100% 40px" visible="false"/>
+                              position="0px -80px" size="100% 40px" visible="false"/>
                     </GuiElement>
 
                     <!-- Legacy id alias (hidden): older draw paths may resolve mdGraphRegion. -->


### PR DESCRIPTION
> **Scope note:** this PR was opened on 2026-08-08 for the `getMoisture` positional-read fix alone. `development` is the trunk, so the SCS-039 build landed on top of it and this PR now carries **six commits**. Title and body updated to match what is actually here rather than what it was opened for.

## What is in this PR

| Commit | What |
|---|---|
| `330215f` | docs: SCS-018 positional read facade fix |
| `7620439` | fix(ui): unify Esc door chrome across all nine carriers |
| `b20f544` | **SCS-039** vendored value-map substrate + the quantisation law |
| `0ab019f` | **SCS-039** wire the value map behind engine detection |
| `172907f` | **SCS-039** conserved drainage on fresh height reads |
| `a97e217` | **SCS-039** MP delivery, release gate, degrade, instrument, seam |

**Suite: 325 assertions passed, 0 failed, across 12 files** (was 249/10 before SCS-039).

---

# SCS-039 / GRID-1: the ground gets one ruler

Moisture moves onto a 2 m value map, the same grain the rest of the soil suite measures by, instead of the shipped 10-40 m Lua cell store.

**Hosting is vendored per TysonK's ruling.** SCS carries its own machinery rather than registering a layer inside SoilFertilizer. Confirmed structurally while building: `SoilValueMaps.LAYER_DEFS` is a **static table with no registration API**, so there was never a door for SCS to register a seventh layer through. SF-hosted would have required SF to grow one first. SCS is sole writer; SF's six layers are never touched.

## Engine-absent is today, exactly

Every branch is gated on one `mapActive()` test. When it is false the shipped sparse-cell store is the whole system, bit for bit, including its relief pass, conserving drainage and packed persistence. **That invariant has its own bench**, because a regression in it is invisible on any machine where the map works, which is most of them.

## The quantisation floor is the law the build is shaped around

Moisture spans 0..1 across 254 raw steps, so **one raw step is ~0.0039 moisture** and an hourly weather delta is routinely smaller. A naive per-hour write floors to zero every time: **twenty four of them move the map by nothing** and the ground silently stops answering the weather.

Sub-step deltas accumulate through `quantiseDelta()` and only whole steps are spent, remainder carried, truncating toward zero in both directions so a drying field cannot oscillate. **The bench reproduces the broken behaviour first**, so anyone who later deletes the accumulator thinking it is an optimisation is told why it is not.

## Conserved drainage, on fresh height reads

Per the geometry audit's build law: terrain is deformable, so a cached relief picture drains water toward a hollow a player may have filled in weeks ago.

The maths is two terms and **each sums to zero on its own**, so conservation needs no correction pass to rescue it. An earlier draft used a sign-juggling relief bias plus a correction pass; it was replaced, because a conservation law you have to repair afterwards is one nobody can check by reading it.

## MP, gate, degrade, instrument

- **Delivery** is the six-layer precedent: eight rows per frame to a joining client, raw values run-length packed. Never one payload, since a 2048x2048 map is 4 MB.
- **`cs_grid_concordance` ships LOCKED and actually gates** — without the experimental opt-in the map never stands up.
- **The degrade is real**: a map that cannot load leaves no half-built object and does not re-probe; the per-field scalar rows carry the save.
- **`csMapStats`** reports the frame cost the brief left as its one open measurement.

## The SCS-037 seam

`hourlyUpdate` takes `elapsedHours`, defaulting to 1, arithmetically identical to what shipped. When SCS-037 replaces the edge detector with a real elapsed count it passes that count and nothing else changes.

## Two defects found and fixed in flight

1. **`readAverageOfPolygon` guarded on `getDensityMapModifierStats`, which has zero occurrences in the decompiled engine.** It would have returned nil forever and the field scalar would never have re-derived. Now guarded on the modifier, with `executeGet`'s real return order confirmed at the decompile: `(acc, numPixels, totalArea)`, and the divisor is `numPixels`.
2. **A field-level set did not reach the map**, so `csSetMoisture` and the sprayer path would have appeared to work then silently reverted on the next daily re-derive.

## Not verified in game

Nothing here has run in a live session. The maths, the delegation and the packing are proven on the bench; the engine plumbing is not. The system is release-gated off by default, which is the correct risk to carry at merge.
