### PR TITLE
SCS-037 the caught-up hour, and F154 the UsedPlus wear retirement

### DIFF
--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -109,6 +109,38 @@ CropStressManager.RWE_STRESS_MULTIPLIERS = {
     seed_growth_bonus   = 0.85,
 }
 
+-- SCS-037 THE CAUGHT-UP HOUR.
+-- The hourly tick is an EDGE DETECTOR: it fires once when the hour key changes,
+-- however many hours the key jumped. A player sleeping three days used to get ONE
+-- hour of evaporation, rain and irrigation, and the other 71 were discarded on the
+-- line that computed the key. The count is now carried as a parameter and every
+-- PER-HOUR term multiplies by it.
+--
+-- THE CAP is a deliberate ceiling on a single catch-up, not a tuning number: a
+-- week of unattended weather is already a total answer for a field, and an
+-- uncapped delta turns a corrupt or first-ever key into an unbounded simulation
+-- step. One in-game week.
+CropStressManager.MAX_CATCHUP_HOURS = 168
+
+--- Hours elapsed between two hour keys, as the hourly path should charge them.
+--- Pure and static so the bench can drive it without a mission.
+--- Returns 1 (today's behaviour exactly) for the first tick, for a key that did
+--- not advance, and for any key that moved backwards.
+---@param lastKey number|nil  the previously seen key, or -1/nil before the first
+---@param hourKey number      the key just observed
+---@return number hours       1 .. MAX_CATCHUP_HOURS
+function CropStressManager.elapsedHoursFrom(lastKey, hourKey)
+    local last = tonumber(lastKey)
+    local now  = tonumber(hourKey)
+    if last == nil or now == nil or last < 0 then return 1 end
+    local delta = now - last
+    if delta < 1 then return 1 end
+    if delta > CropStressManager.MAX_CATCHUP_HOURS then
+        return CropStressManager.MAX_CATCHUP_HOURS
+    end
+    return math.floor(delta)
+end
+
 
 function CropStressManager.new()
     local self = setmetatable({}, CropStressManager)
@@ -472,8 +504,11 @@ function CropStressManager:update(dt)
     local hourKey = day * 24 + hour
 
     if hourKey ~= self.lastHourKey then
+        -- SCS-037: the delta this detector already holds is the elapsed count.
+        -- Read it BEFORE the key is advanced, or it is gone.
+        local elapsedHours = CropStressManager.elapsedHoursFrom(self.lastHourKey, hourKey)
         self.lastHourKey = hourKey
-        self:onHourlyTick()
+        self:onHourlyTick(elapsedHours)
     end
 
     -- HUD frame update (handles auto-show, input response)
@@ -485,9 +520,24 @@ function CropStressManager:update(dt)
     end
 end
 
-function CropStressManager:onHourlyTick()
+--- SCS-037: `elapsedHours` is how many in-game hours this one tick stands for.
+--- It defaults to 1, which is arithmetically identical to what shipped, so every
+--- caller that does not care (the console heat simulator, any future direct call)
+--- keeps exactly today's behaviour.
+---
+--- WHAT MULTIPLIES AND WHAT DOES NOT. The three PER-HOUR consumers multiply:
+--- evaporation/rain/irrigation gain (SoilMoistureSystem), stress accrual
+--- (CropStressModifier) and irrigation running cost (FinanceIntegration).
+--- The DAILY DRAINAGE SETTLE DOES NOT: it rides its own day accrual and already
+--- honours `boundariesCrossed`, and the one-clock rule says a quantity is charged
+--- by exactly one clock. Weather is polled once and held: temperature and humidity
+--- are last-known sky across the whole span, which is the stated approximation.
+---@param elapsedHours number|nil  hours this tick covers (default 1)
+function CropStressManager:onHourlyTick(elapsedHours)
     -- Respect the player's master on/off toggle
     if not self.settings.enabled then return end
+
+    local hours = math.max(1, math.floor(tonumber(elapsedHours) or 1))
 
     -- Rebuild field map once per in-game day so newly bought/sold fields are tracked
     local env = g_currentMission and g_currentMission.environment
@@ -520,7 +570,10 @@ function CropStressManager:onHourlyTick()
         end
 
         -- 2c. Advance soil moisture simulation
-        self.soilSystem:hourlyUpdate(self.weatherIntegration)
+        -- SCS-037 round 2: when SoilFertilizer's Water Record is reachable, the
+        -- rain switch is reconstructed per skipped day rather than held at the
+        -- last-known sky. nil (the case today) means round-1 behaviour exactly.
+        self.soilSystem:hourlyUpdate(self.weatherIntegration, hours, self:getSkipRainHours(hours))
 
         -- 3. Apply RWE world-event stress multiplier (no-op when RWE not loaded)
         if self.rweManager then
@@ -529,9 +582,9 @@ function CropStressManager:onHourlyTick()
         end
 
         -- 4. Accumulate crop stress where moisture is critical
-        self.stressModifier:hourlyUpdate()
+        self.stressModifier:hourlyUpdate(hours)
 
-        self.financeIntegration:chargeHourlyCosts()
+        self.financeIntegration:chargeHourlyCosts(hours)
 
         -- Push updated moisture/stress to all connected clients. When the
         -- NetworkSync bridge is active the whole field map batches through its 1Hz
@@ -553,12 +606,70 @@ function CropStressManager:onHourlyTick()
         local seasonName = WeatherIntegration.SEASON_NAMES[self.weatherIntegration:getCurrentSeason()]
             or tostring(self.weatherIntegration:getCurrentSeason())
         csLog(string.format(
-            "Hourly tick complete. Season=%s Temp=%.1f Rain=%s",
+            "Hourly tick complete (%dh). Season=%s Temp=%.1f Rain=%s",
+            hours,
             seasonName,
             self.weatherIntegration:getCurrentTemp(),
             tostring(self.weatherIntegration.isRaining)
         ))
     end
+end
+
+-- ============================================================
+-- SCS-037 ROUND 2: THE RAIN SWITCH ACROSS A SKIP
+--
+-- Round 1 holds the sky at its last-known state for the whole span, so a skip
+-- that ends in rain charges the field rain for every skipped hour and a skip that
+-- ends dry charges none. SoilFertilizer's Water Record (SF-49) already freezes ONE
+-- VERDICT PER DAY — did water arrive, from any source — which is exactly the
+-- switch needed to reconstruct those hours instead of guessing them.
+--
+-- IT IS INERT TODAY, AND THE REASON IS THE CONTRACT, NOT THE FEATURE.
+-- `MaterialWetness:waterDaysInLast(days, throughDay)` exists and works, but it is
+-- NOT PUBLISHED: the only path to it from here is
+-- `g_currentMission.soilFertilityManager.soilSystem.materialWetness`, three
+-- internal field names deep. SoilFertilizer's own cross-boundary rule (its
+-- `getCellGrowthInfo` / `getFieldGrowthSummary` delegates, 2026-08-09) is that a
+-- consumer binds to a METHOD ON THE MANAGER and nothing else, precisely so a
+-- refactor there cannot rename this read out from under us. So we probe for the
+-- delegate and take round-1 behaviour until it exists.
+--
+-- THE ASK, stated so it can be built as one method: a manager-level
+-- `getWaterDaysInLast(days, throughDay)` on SoilFertilityManager returning
+-- (count, known), nil-safe in every direction, neutral when the Water Record is
+-- absent or the ground_material gate is closed.
+--
+-- Temperature and humidity stay last-known sky either way; only the rain switch
+-- is reconstructable, because only the rain switch is recorded.
+-- ============================================================
+
+--- Rain-bearing hours within a catch-up span, or nil when unknowable.
+--- nil is the normal answer and means "use `hours`", i.e. round-1 behaviour.
+---@param hours number  the elapsed span this tick covers
+---@return number|nil rainHours
+function CropStressManager:getSkipRainHours(hours)
+    -- A single hour has nothing to reconstruct: the sky IS current.
+    if hours == nil or hours <= 1 then return nil end
+
+    local sfm = g_currentMission ~= nil and g_currentMission.soilFertilityManager
+    if sfm == nil or type(sfm.getWaterDaysInLast) ~= "function" then return nil end
+
+    local env = g_currentMission.environment
+    local throughDay = env ~= nil and (env.currentMonotonicDay or env.currentDay) or nil
+    if throughDay == nil then return nil end
+
+    -- Ceil: a span of 30 hours touches two calendar days, both of which have a verdict.
+    local days = math.ceil(hours / 24)
+
+    local ok, wet, known = pcall(function() return sfm:getWaterDaysInLast(days, throughDay) end)
+    if not ok or type(wet) ~= "number" or type(known) ~= "number" or known <= 0 then
+        return nil
+    end
+
+    -- Scale the span by the fraction of KNOWN days that brought water. Days the
+    -- record does not reach back to are not counted as dry — they are not counted
+    -- at all, which is why the divisor is `known` and not `days`.
+    return hours * (wet / known)
 end
 
 -- ============================================================

--- a/src/CropStressModifier.lua
+++ b/src/CropStressModifier.lua
@@ -131,9 +131,15 @@ end
 -- HOURLY STRESS ACCUMULATION
 -- Called by CropStressManager:onHourlyTick()
 -- ============================================================
-function CropStressModifier:hourlyUpdate()
+--- SCS-037: `elapsedHours` is how many in-game hours this tick stands for. Stress
+--- is a PER-HOUR accrual, so a three-day skip must accrue three days of it rather
+--- than one hour. Defaults to 1, which is arithmetically identical to what shipped.
+---@param elapsedHours number|nil
+function CropStressModifier:hourlyUpdate(elapsedHours)
     if not self.isInitialized then return end
     if g_currentMission == nil or g_currentMission.fieldManager == nil then return end
+
+    local hours = math.max(1, math.floor(tonumber(elapsedHours) or 1))
 
     local soilSystem = self.manager.soilSystem
     if soilSystem == nil then return end
@@ -146,13 +152,14 @@ function CropStressModifier:hourlyUpdate()
     for fieldId, data in pairs(soilSystem.fieldData) do
         local field = fieldById[fieldId]
         if field ~= nil then
-            self:processFieldStress(field, fieldId, data.moisture)
+            self:processFieldStress(field, fieldId, data.moisture, hours)
         end
         -- If field not in map this tick, skip silently — map will be rebuilt on next lateInitialize
     end
 end
 
-function CropStressModifier:processFieldStress(field, fieldId, moisture)
+---@param elapsedHours number|nil  SCS-037: hours this accrual covers (default 1)
+function CropStressModifier:processFieldStress(field, fieldId, moisture, elapsedHours)
     -- FS25 confirmed API: field.fieldState.fruitTypeIndex / field.fieldState.growthState
     -- (field:getFieldState(), field:getGrowthState(), field.fruitType do NOT exist in FS25)
     local fieldState = field.fieldState
@@ -211,18 +218,21 @@ function CropStressModifier:processFieldStress(field, fieldId, moisture)
 
     -- Below critical moisture threshold → accumulate stress
     if moisture < window.criticalMoisture then
+        local hours        = math.max(1, math.floor(tonumber(elapsedHours) or 1))
         local deficit      = window.criticalMoisture - moisture
         local deficitRatio = deficit / window.criticalMoisture
         local rateMultiplier = (self.rateMultiplier or 1.0) * (self.rweMultiplier or 1.0)
-        local stressIncrease = window.stressRatePerHour * deficitRatio * rateMultiplier
+        -- stressRatePerHour is per hour by its own name, so the elapsed count is a
+        -- plain multiply. The min(1.0) cap below still bounds a long catch-up.
+        local stressIncrease = window.stressRatePerHour * deficitRatio * rateMultiplier * hours
 
         local prev = self.fieldStress[fieldId] or 0.0
         self.fieldStress[fieldId] = math.min(1.0, prev + stressIncrease)
 
         if self.manager ~= nil and self.manager.debugMode then
             csLog(string.format(
-                "Stress Field %d (%s stage %d): +%.4f → total %.3f (moisture %.1f%% < %.0f%%)",
-                fieldId, cropName, growthState, stressIncrease,
+                "Stress Field %d (%s stage %d): +%.4f over %dh → total %.3f (moisture %.1f%% < %.0f%%)",
+                fieldId, cropName, growthState, stressIncrease, hours,
                 self.fieldStress[fieldId], moisture * 100, window.criticalMoisture * 100
             ))
         end

--- a/src/FinanceIntegration.lua
+++ b/src/FinanceIntegration.lua
@@ -31,10 +31,20 @@ function FinanceIntegration:initialize()
     self.isInitialized = true
 end
 
-function FinanceIntegration:chargeHourlyCosts()
+--- SCS-037: `elapsedHours` is how many in-game hours this tick stands for. The
+--- pump ran for all of them, so the running cost is charged for all of them.
+--- Defaults to 1, which is arithmetically identical to what shipped.
+---
+--- THE WATER AND THE MONEY ARE NOW ON THE SAME CLOCK, which is the point: the
+--- moisture path already multiplied irrigation GAIN by the elapsed count, so
+--- leaving the charge at one hour would hand a player 72 hours of free water.
+---@param elapsedHours number|nil
+function FinanceIntegration:chargeHourlyCosts(elapsedHours)
     if not self.isInitialized then return end
     local irrMgr = self.manager.irrigationManager
     if irrMgr == nil then return end
+
+    local hours = math.max(1, math.floor(tonumber(elapsedHours) or 1))
 
     -- Respect the irrigation costs setting (costsEnabled == false means player disabled costs)
     -- nil means the flag was never set (default = costs enabled); only skip on explicit false.
@@ -45,7 +55,7 @@ function FinanceIntegration:chargeHourlyCosts()
             -- Deduct operational cost via vanilla FS25 fund system.
             -- UsedPlus public API (UsedPlusAPI) does not expose recordExpense() —
             -- confirmed against UsedPlusAPI wiki. Costs always go through vanilla updateFunds.
-            self:deductFundsVanilla(system.operationalCostPerHour)
+            self:deductFundsVanilla((system.operationalCostPerHour or 0) * hours)
 
             -- Update wear level from UsedPlus DNA (if UsedPlus active).
             -- Placeables typically have no DNA entry, so this usually returns 0.0.

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -358,10 +358,20 @@ end
 --- rather than 72 separate sub-step writes that would each floor to nothing.
 ---@param weather table
 ---@param elapsedHours number|nil  hours since the last tick (default 1)
-function SoilMoistureSystem:hourlyUpdate(weather, elapsedHours)
+---@param rainHours number|nil  SCS-037 round 2: how many of those hours brought
+---  rain, reconstructed from SoilFertilizer's Water Record. nil (the normal case)
+---  means the sky is held at its last-known state for the whole span, which is
+---  round-1 behaviour and identical to what shipped.
+function SoilMoistureSystem:hourlyUpdate(weather, elapsedHours, rainHours)
     if not self.isInitialized then return end
     if weather == nil then return end
     local hours = math.max(1, math.floor(elapsedHours or 1))
+    -- Clamped to the span: the record can never say it rained for more hours than
+    -- the skip actually lasted.
+    local wetHours = hours
+    if rainHours ~= nil then
+        wetHours = math.max(0, math.min(hours, rainHours))
+    end
 
     -- SCS-018 RW unwind: SeasonalCropStress owns its whole moisture simulation.
     -- RealisticWeather remains a read-only WEATHER source through WeatherIntegration
@@ -408,8 +418,9 @@ function SoilMoistureSystem:hourlyUpdate(weather, elapsedHours)
             * sfEvapMod
             * hours
 
-        -- Rain gain (modulated by soil absorption)
-        local rainGain  = rainAmount * soilParams.rainAbsorb * hours
+        -- Rain gain (modulated by soil absorption). Charged over `wetHours`, which
+        -- is the whole span unless the Water Record narrowed it (SCS-037 round 2).
+        local rainGain  = rainAmount * soilParams.rainAbsorb * wetHours
         local irrigGain = (self.irrigationGains[fieldId] or 0.0) * hours
 
         local prevMoisture = self:getFieldAggregate(data)

--- a/tools/test/lua/scs037_caught_up_hour_test.lua
+++ b/tools/test/lua/scs037_caught_up_hour_test.lua
@@ -1,0 +1,340 @@
+-- scs037_caught_up_hour_test.lua
+-- SCS-037 THE CAUGHT-UP HOUR. The hourly tick is an edge detector, so a time skip
+-- used to produce ONE tick and discard the rest of the span. The elapsed count is
+-- now carried as a parameter and every PER-HOUR consumer multiplies by it.
+--
+-- THE TWO ASSERTIONS THAT MATTER, and they pull against each other:
+--   1. A 72-hour skip charges 72x, in each of the three consumers.
+--   2. A NORMAL HOUR IS BIT-FOR-BIT TODAY'S BEHAVIOUR. Every default path is
+--      pinned against a hand-computed pre-SCS-037 value, not against itself.
+--!load: src/CropStressManager.lua, src/CropStressModifier.lua, src/FinanceIntegration.lua, src/SoilMoistureSystem.lua
+
+-- =========================================================
+-- 1. THE ELAPSED-COUNT CONTRACT (pure, no mission needed)
+-- =========================================================
+do
+  local f = CropStressManager.elapsedHoursFrom
+
+  T.eq("elapsed.normalHour", f(100, 101), 1)
+  T.eq("elapsed.threeDaySkip", f(100, 172), 72)
+
+  -- The first tick ever: lastHourKey is seeded to -1 in new(). Without this guard
+  -- a fresh save would open with a full capped catch-up of weather it never had.
+  T.eq("elapsed.firstTickIsOne", f(-1, 5000), 1)
+  T.eq("elapsed.nilLastIsOne", f(nil, 5000), 1)
+
+  -- The key cannot move backwards (currentMonotonicDay is monotonic), but a
+  -- reseed on savegame switch could make it look that way. Never charge negative.
+  T.eq("elapsed.backwardsIsOne", f(200, 100), 1)
+  T.eq("elapsed.sameKeyIsOne", f(200, 200), 1)
+
+  -- THE CAP is one in-game week, and it is a ceiling rather than a tuning number.
+  T.eq("elapsed.capAtWeek", f(0, 168), 168)
+  T.eq("elapsed.capHolds", f(0, 100000), CropStressManager.MAX_CATCHUP_HOURS)
+  T.eq("elapsed.capIsAWeek", CropStressManager.MAX_CATCHUP_HOURS, 168)
+
+  -- Always a whole number of hours: the consumers multiply raw amounts by it.
+  T.eq("elapsed.floors", f(0, 10.7), 10)
+end
+
+-- =========================================================
+-- 2. EVAPORATION / RAIN / IRRIGATION (SoilMoistureSystem)
+-- =========================================================
+local function newSoil()
+  local m = { eventBus = { subscribe = function() end, publish = function() end } }
+  local s = SoilMoistureSystem.new(m)
+  s._cellSize = 10
+  s.isInitialized = true
+  return s
+end
+
+-- A weather stub whose numbers are chosen so the arithmetic is checkable by hand.
+local function fakeWeather(evapMult, rain)
+  return {
+    getHourlyEvapMultiplier = function() return evapMult end,
+    getHourlyRainAmount     = function() return rain end,
+  }
+end
+
+-- Plain aggregate field (no cells, no value map): the simplest path through
+-- hourlyUpdate, and the one where the net is applied directly.
+local function seedPlainField(s, fieldId, moisture)
+  s.fieldData[fieldId] = { fieldId = fieldId, moisture = moisture, soilType = "loamy" }
+  return s.fieldData[fieldId]
+end
+
+local BASE = SoilMoistureSystem.BASE_EVAP_RATE
+local LOAM = SoilMoistureSystem.SOIL_PARAMS.loamy
+
+do
+  -- One hour, no rain: exactly one BASE_EVAP_RATE step. This is the pin against
+  -- pre-SCS-037 behaviour — the number is computed from the constants, not read
+  -- back out of the system under test.
+  local s = newSoil()
+  local d = seedPlainField(s, 1, 0.5)
+  s:hourlyUpdate(fakeWeather(1.0, 0.0))
+  T.near("soil.oneHourUnchanged", d.moisture, 0.5 - BASE * LOAM.evapMod, 1e-9)
+end
+
+do
+  -- 72 hours dries 72x as much as one hour, from the same start.
+  local one = newSoil()
+  local d1  = seedPlainField(one, 1, 0.9)
+  one:hourlyUpdate(fakeWeather(1.0, 0.0))
+  local oneHourLoss = 0.9 - d1.moisture
+
+  local many = newSoil()
+  local d72  = seedPlainField(many, 1, 0.9)
+  many:hourlyUpdate(fakeWeather(1.0, 0.0), 72)
+  local skipLoss = 0.9 - d72.moisture
+
+  T.near("soil.skipIs72x", skipLoss, oneHourLoss * 72, 1e-9)
+end
+
+do
+  -- Rain over a skip: gain scales with the span too.
+  local s = newSoil()
+  local d = seedPlainField(s, 1, 0.2)
+  s:hourlyUpdate(fakeWeather(0.0, 0.01), 24)
+  T.near("soil.rainScales", d.moisture, 0.2 + 0.01 * LOAM.rainAbsorb * 24, 1e-9)
+end
+
+do
+  -- Irrigation gain scales with the span. This is the half that was ALREADY
+  -- shipped by SCS-039; asserted here so the money assertion below has a partner.
+  local s = newSoil()
+  local d = seedPlainField(s, 1, 0.2)
+  s.irrigationGains[1] = 0.005
+  s:hourlyUpdate(fakeWeather(0.0, 0.0), 10)
+  T.near("soil.irrigationScales", d.moisture, 0.2 + 0.005 * 10, 1e-9)
+end
+
+do
+  -- Clamps still hold across a long catch-up: a week of drought cannot drive a
+  -- field below zero, and a week of rain cannot drive it above one.
+  local dry = newSoil()
+  local dd  = seedPlainField(dry, 1, 0.1)
+  dry:hourlyUpdate(fakeWeather(5.0, 0.0), 168)
+  T.ok("soil.floorHolds", dd.moisture >= 0.0, "moisture went negative: " .. tostring(dd.moisture))
+
+  local wet = newSoil()
+  local dw  = seedPlainField(wet, 1, 0.9)
+  wet:hourlyUpdate(fakeWeather(0.0, 0.05), 168)
+  T.ok("soil.ceilingHolds", dw.moisture <= 1.0, "moisture exceeded 1.0: " .. tostring(dw.moisture))
+end
+
+-- =========================================================
+-- 3. ROUND 2: THE RAIN SWITCH, AND IT IS INERT TODAY
+-- =========================================================
+do
+  -- rainHours narrows ONLY the rain term. Evaporation still runs the whole span,
+  -- because the record says nothing about temperature.
+  local s = newSoil()
+  local d = seedPlainField(s, 1, 0.2)
+  s:hourlyUpdate(fakeWeather(1.0, 0.01), 48, 12)
+  local expected = 0.2 - BASE * LOAM.evapMod * 48 + 0.01 * LOAM.rainAbsorb * 12
+  T.near("round2.rainHoursNarrowsRainOnly", d.moisture, expected, 1e-9)
+end
+
+do
+  -- nil rainHours is round-1 exactly: the two calls must agree bit for bit.
+  local a = newSoil(); local da = seedPlainField(a, 1, 0.4)
+  local b = newSoil(); local db = seedPlainField(b, 1, 0.4)
+  a:hourlyUpdate(fakeWeather(1.0, 0.01), 30)
+  b:hourlyUpdate(fakeWeather(1.0, 0.01), 30, nil)
+  T.near("round2.nilIsRound1", da.moisture, db.moisture, 0)
+end
+
+do
+  -- A record that claims more wet hours than the skip lasted is clamped to the
+  -- span, and a negative one to zero. Neither can invent or destroy water.
+  local hi = newSoil(); local dh = seedPlainField(hi, 1, 0.2)
+  hi:hourlyUpdate(fakeWeather(0.0, 0.01), 10, 999)
+  T.near("round2.clampsToSpan", dh.moisture, 0.2 + 0.01 * LOAM.rainAbsorb * 10, 1e-9)
+
+  local lo = newSoil(); local dl = seedPlainField(lo, 1, 0.2)
+  lo:hourlyUpdate(fakeWeather(0.0, 0.01), 10, -5)
+  T.near("round2.clampsToZero", dl.moisture, 0.2, 1e-9)
+end
+
+do
+  -- THE INERTNESS GUARD. SoilFertilizer publishes no manager-level Water Record
+  -- delegate today, so the reader must answer nil and round-1 must hold. This
+  -- assertion is the reason the feature is honest rather than half-wired: when
+  -- somebody publishes `getWaterDaysInLast`, this test is what changes.
+  local mgr = setmetatable({}, CropStressManager)
+
+  g_currentMission.soilFertilityManager = nil
+  T.eq("round2.absentSFIsNil", mgr:getSkipRainHours(72), nil)
+
+  -- Present but without the delegate: still nil. Reaching three internal field
+  -- names deep to `soilSystem.materialWetness` is exactly what we refuse to do.
+  g_currentMission.soilFertilityManager = { soilSystem = { materialWetness = { waterRecord = {} } } }
+  T.eq("round2.noDelegateIsNil", mgr:getSkipRainHours(72), nil)
+
+  -- A single hour has nothing to reconstruct.
+  g_currentMission.soilFertilityManager = {
+    getWaterDaysInLast = function() return 3, 3 end,
+  }
+  T.eq("round2.oneHourIsNil", mgr:getSkipRainHours(1), nil)
+
+  -- With the delegate present the span is scaled by the WET FRACTION OF KNOWN
+  -- DAYS. 72 hours, 2 of 3 recorded days wet → 48 rain-bearing hours.
+  g_currentMission.environment.currentMonotonicDay = 40
+  local askedDays, askedThrough
+  g_currentMission.soilFertilityManager = {
+    getWaterDaysInLast = function(_self, days, throughDay)
+      askedDays, askedThrough = days, throughDay
+      return 2, 3
+    end,
+  }
+  T.near("round2.scalesByWetFraction", mgr:getSkipRainHours(72), 48, 1e-9)
+  -- The window asked for covers the whole span: 72 hours is 3 calendar days.
+  T.eq("round2.asksWholeSpan", askedDays, 3)
+  T.eq("round2.asksThroughToday", askedThrough, 40)
+
+  -- A span that straddles a day boundary rounds UP, because both days have a
+  -- verdict and asking for one of them would silently drop the other.
+  T.eq("round2.partialDayRoundsUp", (function()
+    mgr:getSkipRainHours(30)
+    return askedDays
+  end)(), 2)
+
+  -- Fully wet and fully dry are both faithfully reported rather than clamped away.
+  g_currentMission.soilFertilityManager = {
+    getWaterDaysInLast = function() return 3, 3 end,
+  }
+  T.near("round2.allWetIsWholeSpan", mgr:getSkipRainHours(72), 72, 1e-9)
+  g_currentMission.soilFertilityManager = {
+    getWaterDaysInLast = function() return 0, 3 end,
+  }
+  T.near("round2.allDryIsZero", mgr:getSkipRainHours(72), 0, 1e-9)
+
+  -- known == 0 means the record does not reach back at all: nil, not zero rain.
+  -- Zero would be a claim ("it was dry"); nil is the truth ("we do not know").
+  g_currentMission.soilFertilityManager = {
+    getWaterDaysInLast = function() return 0, 0 end,
+  }
+  T.eq("round2.unknownIsNilNotZero", mgr:getSkipRainHours(72), nil)
+
+  -- A delegate that throws must not cross the mod boundary.
+  g_currentMission.soilFertilityManager = {
+    getWaterDaysInLast = function() error("boom") end,
+  }
+  T.eq("round2.throwingDelegateIsNil", mgr:getSkipRainHours(72), nil)
+
+  g_currentMission.soilFertilityManager = nil
+  g_currentMission.environment.currentMonotonicDay = nil
+end
+
+-- =========================================================
+-- 4. STRESS ACCUMULATION (CropStressModifier)
+-- =========================================================
+local function newModifier()
+  local m = { debugMode = false }
+  local mod = CropStressModifier.new(m)
+  mod.isInitialized = true
+  return mod
+end
+
+-- A field whose crop sits in a critical window, well below threshold.
+local function stressField(cropName, stage)
+  return { fieldState = { fruitTypeIndex = 7, growthState = stage } }
+end
+
+do
+  -- Drive processFieldStress directly: it is the arithmetic under test, and it
+  -- avoids standing up g_fruitTypeManager's whole surface for a multiply.
+  local wheat = CropStressModifier.CROP_WINDOWS.wheat
+  T.ok("stress.wheatWindowExists", wheat ~= nil, "CROP_WINDOWS.wheat missing")
+
+  g_fruitTypeManager = {
+    getFruitTypeByIndex = function(_self, _i) return { name = "WHEAT" } end,
+  }
+
+  local stage = wheat.stages[1]
+  local moisture = wheat.criticalMoisture * 0.5   -- half the threshold
+  local deficitRatio = (wheat.criticalMoisture - moisture) / wheat.criticalMoisture
+
+  local one = newModifier()
+  one:processFieldStress(stressField("wheat", stage), 1, moisture)
+  T.near("stress.oneHourUnchanged", one.fieldStress[1],
+         wheat.stressRatePerHour * deficitRatio, 1e-9)
+
+  -- Six hours accrue six times as much (chosen small enough not to hit the cap).
+  local six = newModifier()
+  six:processFieldStress(stressField("wheat", stage), 1, moisture, 6)
+  T.near("stress.sixHoursIs6x", six.fieldStress[1],
+         wheat.stressRatePerHour * deficitRatio * 6, 1e-9)
+
+  -- The 1.0 cap still bounds a full-week catch-up.
+  local week = newModifier()
+  week:processFieldStress(stressField("wheat", stage), 1, moisture, 168)
+  T.ok("stress.capHolds", week.fieldStress[1] <= 1.0,
+       "stress exceeded 1.0: " .. tostring(week.fieldStress[1]))
+
+  -- A field ABOVE its threshold accrues nothing, however long the skip.
+  local none = newModifier()
+  none:processFieldStress(stressField("wheat", stage), 1, 1.0, 168)
+  T.eq("stress.noDeficitNoStress", none.fieldStress[1], nil)
+
+  g_fruitTypeManager = nil
+end
+
+-- =========================================================
+-- 5. IRRIGATION RUNNING COST (FinanceIntegration)
+-- =========================================================
+local function newFinance(costPerHour, active)
+  local charged = { total = 0, calls = 0 }
+  local fi = FinanceIntegration.new({
+    irrigationManager = {
+      costsEnabled = true,
+      systems = { [1] = { isActive = active, operationalCostPerHour = costPerHour } },
+    },
+  })
+  fi.isInitialized = true
+  fi.deductFundsVanilla = function(_self, cost)
+    charged.total = charged.total + cost
+    charged.calls = charged.calls + 1
+  end
+  return fi, charged
+end
+
+do
+  local fi, c = newFinance(120, true)
+  fi:chargeHourlyCosts()
+  T.near("cost.oneHourUnchanged", c.total, 120, 1e-9)
+  T.eq("cost.oneCallPerSystem", c.calls, 1)
+end
+
+do
+  -- THE 72x CLAIM ON THE MONEY SIDE. The pump's water was already multiplied by
+  -- the span before SCS-037; without this the player got 72 hours of free water.
+  local fi, c = newFinance(120, true)
+  fi:chargeHourlyCosts(72)
+  T.near("cost.skipIs72x", c.total, 120 * 72, 1e-9)
+end
+
+do
+  -- An idle system is charged nothing, whatever the span.
+  local fi, c = newFinance(120, false)
+  fi:chargeHourlyCosts(168)
+  T.near("cost.inactiveIsFree", c.total, 0, 1e-9)
+end
+
+do
+  -- Costs disabled by the player stays free across a catch-up.
+  local fi, c = newFinance(120, true)
+  fi.manager.irrigationManager.costsEnabled = false
+  fi:chargeHourlyCosts(168)
+  T.near("cost.disabledIsFree", c.total, 0, 1e-9)
+end
+
+do
+  -- A garbage span never charges less than one hour and never charges NaN.
+  local fi, c = newFinance(120, true)
+  fi:chargeHourlyCosts("not a number")
+  T.near("cost.garbageSpanIsOneHour", c.total, 120, 1e-9)
+end
+
+T.summary()


### PR DESCRIPTION
> **THIS PR CARRIES TWO ITEMS.** `development` is the trunk, so F154 landed on top of SCS-037 and joined this PR after it was opened and approved. Retitled and rebodied rather than left describing half its contents, per the hazard Fred reported on 2026-08-09. **Sasha's first approval covered `c890007` only and she has re-reviewed for `adeccbb`.**
>
> - `c890007` **SCS-037**, the caught-up hour
> - `adeccbb` **F154**, retire the UsedPlus wear bridge

---

# 1. SCS-037 — the caught-up hour

**The hourly tick is an EDGE DETECTOR.** It fires once when the hour key changes, however many hours the key jumped. A player sleeping three days got **ONE hour** of evaporation, rain, irrigation and stress; the other 71 were discarded on the line that computed the key. That is `F159`.

The delta the detector already holds is now read **before** the key is advanced and carried as a parameter to `onHourlyTick`.

## What multiplies, and what deliberately does not

| Consumer | Quantity |
|---|---|
| `SoilMoistureSystem:hourlyUpdate` | evaporation, rain gain, irrigation gain (seam already opened by SCS-039) |
| `CropStressModifier:hourlyUpdate` | stress accrual |
| `FinanceIntegration:chargeHourlyCosts` | irrigation running cost |

**The daily drainage settle is UNTOUCHED.** It rides its own day accrual and already honours `boundariesCrossed`; the one-clock rule says a quantity is charged by exactly one clock.

**The money now shares the water's clock, and that is not a side effect.** The moisture path already scaled irrigation *gain* by the elapsed count, so leaving the charge at one hour was handing a player 72 hours of free pumping.

## The cap, and the three ways a span is refused

`MAX_CATCHUP_HOURS = 168`, one in-game week. A ceiling rather than a tuning number: a week of unattended weather is already a total answer for a field, and an uncapped delta turns a corrupt or first-ever key into an unbounded simulation step.

`elapsedHoursFrom` returns **exactly 1** for the first tick ever (`lastHourKey` seeds to `-1`, so without this guard a fresh save would open with a full capped catch-up of weather it never had), for a key that did not advance, and for a key that moved backwards. **Every parameter defaults to 1, arithmetically identical to what shipped.**

## Round 2 ships INERT, and the reason is the contract rather than the feature

The brief reconstructs the rain switch per skipped day from SoilFertilizer's Water Record (SF-49). **`MaterialWetness:waterDaysInLast` exists and works but is not published** — the only path is `soilFertilityManager.soilSystem.materialWetness`, three internal field names deep, which is exactly the coupling SoilFertilizer's own delegate rule forbids.

So `getSkipRainHours` **probes for a manager-level delegate and answers nil until one exists**, which is round-1 behaviour exactly and the brief's own stated fallback. **The ask is one method:** `SoilFertilityManager:getWaterDaysInLast(days, throughDay)` returning `(count, known)`, nil-safe, neutral when the record is absent or the `ground_material` gate is closed.

---

# 2. F154 — retire the UsedPlus wear bridge

**The bridge read equipment condition out of UsedPlus DNA to scale irrigation flow, and it never returned anything.** DNA tracks vehicles; irrigation systems are placeables and never have an entry, so the read was always `0.0` and `wearFactor = 1.0 - wearLevel * 0.3` was a permanent multiply by one. **Today by accident, after this by design.**

The bridge itself was correctly built — runtime-detected, read-only, neutral when absent. **That is exactly why nobody noticed: not-needed and not-working are indistinguishable from outside a defensive fallback.**

**Removed:** `FinanceIntegration`'s `getUPAPI` resolver, `usedPlusActive`, the wear call inside the charge loop, `getEquipmentWearLevel` and `enableUsedPlusMode`; `IrrigationManager`'s `wearLevel` field, `wearFactor` at **both** rate sites, and `updateSystemWearLevel`; the FinanceIntegration arm of the detection in `CropStressManager`.

**NO RATE MOVES.** That is invariant 1 and the acceptance test. The bench pins each rate against the **pre-removal expression written out in its old shape** with `wearLevel` at its provable `0`, rather than against the new code.

`updateSystemWearLevel` is **deleted rather than kept** as a public setter for a future wear source: its only caller was this bridge, so keeping it would have made it a built-and-uncalled mechanism the moment the bridge went. **Nothing is repointed at AdvancedDamageSystem** — that is a new bridge with its own design pass, and repointing a dead probe at a live mod without one is how a fallback chain becomes load-bearing with nobody deciding.

## One deliberate deviation from the fix doc

**The doc names `FinanceIntegration` as the detection site's only consumer. It is not.** `UsedEquipmentMarketplace` is a second one, and the doc does not otherwise scope it. Retiring a whole listings feature is a wider decision than retiring a dead wear probe, **so the detection survives with the marketplace arm only, commented with why, and the marketplace's fate is reported rather than taken here.** `csStatus` now reports the marketplace's flag, which is UsedPlus's only remaining consumer in this mod.

This means **verification checklist item 3 (zero UsedPlus hits mod-wide) is deliberately not satisfied.** Items 1, 2, 4 and 5 are.

**README corrected:** that row claimed irrigation costs were tracked in the UsedPlus finance manager and that wear degraded pump output. Neither was ever true — costs have always gone through vanilla `addMoney`. `modDesc.xml` already only claimed the marketplace and needed no change.

---

# Bench

**381/0 across 14 files**, 56 new assertions (42 for SCS-037, 14 for F154). Every default and every rate is pinned against a hand-computed pre-change value rather than against itself.

# Owed before release

**The SCS-037 skip test.** Sleep or fast-forward ~72 hours on a save with a dry field and an active pivot, then `csStatus`: moisture drop, stress and money should each be about 72× a single hour, and the debug log now prints `Hourly tick complete (72h)`.

**F154 needs no in-game pass beyond that** — its acceptance is that nothing changed, and the bench measures it. Ships LOCKED at merge for SCS-037; F154 rides no locked system.
